### PR TITLE
fix: account for library rename in plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,17 +38,19 @@ npm install @stripe/stripe-react-native
 If you're using Expo, add:
 
 ```json
-expo: {
-  ...
-  "plugins": [
-    [
-      "stripe-react-native",
-      {
-        "merchantIdentifier": string | string [],
-        "enableGooglePay": boolean
-      }
-    ]
-  ],
+{
+  "expo": {
+    ...
+    "plugins": [
+      [
+        "@stripe/stripe-react-native",
+        {
+          "merchantIdentifier": string | string [],
+          "enableGooglePay": boolean
+        }
+      ]
+    ],
+  }
 }
 ```
 

--- a/src/plugin/withStripe.ts
+++ b/src/plugin/withStripe.ts
@@ -12,7 +12,7 @@ const {
   removeMetaDataItemFromMainApplication,
 } = AndroidConfig.Manifest;
 
-const pkg = require('stripe-react-native/package.json');
+const pkg = require('@stripe/stripe-react-native/package.json');
 
 type StripePluginProps = {
   /**


### PR DESCRIPTION
renaming the library from `stripe-react-native` to `@stripe/stripe-react-native` broke the config plugin's behavior

tested these changes locally, and both `AndroidManifest.xml` and `.entitlements` files are updated when running `expo prebuild` with the new app.json configuration