### PR TITLE
fix: unify cancel handling

### DIFF
--- a/ios/StripeSdk.swift
+++ b/ios/StripeSdk.swift
@@ -600,10 +600,16 @@ class StripeSdk: RCTEventEmitter, STPApplePayContextDelegate, STPBankSelectionVi
         self.confirmPaymentClientSecret = nil
         switch (status) {
         case .failed:
-            confirmPaymentRejecter?(ConfirmPaymentErrorType.Failed.rawValue, error?.localizedDescription ?? "", nil)
+            confirmPaymentRejecter?(ConfirmPaymentErrorType.Failed.rawValue, paymentIntent?.lastPaymentError?.message ?? error?.localizedDescription ?? "", nil)
             break
         case .canceled:
-            confirmPaymentRejecter?(ConfirmPaymentErrorType.Canceled.rawValue, error?.localizedDescription ?? "", nil)
+            let statusCode: String
+            if (paymentIntent?.status == STPPaymentIntentStatus.requiresPaymentMethod) {
+                statusCode = ConfirmPaymentErrorType.Failed.rawValue
+            } else {
+                statusCode = ConfirmPaymentErrorType.Canceled.rawValue
+            }
+            confirmPaymentRejecter?(statusCode, paymentIntent?.lastPaymentError?.message ?? error?.localizedDescription ?? "", nil)
             break
         case .succeeded:
             if let paymentIntent = paymentIntent {


### PR DESCRIPTION
Fixes #205 

When someone cancels the 3DS authentication window, on Android we map the PI status `requires_payment_method` to status `Failed`. 

This does the same for iOS so that it's coherent