### PR TITLE
Add example folder to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,3 +2,4 @@ lib/typescript/example
 **/__tests__
 **/__fixtures__
 **/__mocks__
+example/


### PR DESCRIPTION
Hey, 
Thanks for this awesome wrapping library for Stripe. And welcome to React Native world.
I just started using your lib and figure out that you publish to NPM also your `example` folder, means we ll get in when we do `npm install`, and It includes big `Pod` library.

So, I added to your `.npmignore` to ignore this unnecessary example folder.

Thanks,
Ran