### PR TITLE
fix: make data param nullable for onActivityResult on android

### DIFF
--- a/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
+++ b/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
@@ -43,7 +43,7 @@ class StripeSdkModule(reactContext: ReactApplicationContext, cardFieldManager: S
   private var confirmPaymentClientSecret: String? = null
 
   private val mActivityEventListener = object : BaseActivityEventListener() {
-    override fun onActivityResult(activity: Activity, requestCode: Int, resultCode: Int, data: Intent) {
+    override fun onActivityResult(activity: Activity, requestCode: Int, resultCode: Int, data: Intent?) {
       stripe.onSetupResult(requestCode, data, object : ApiResultCallback<SetupIntentResult> {
         override fun onSuccess(result: SetupIntentResult) {
           val setupIntent = result.intent


### PR DESCRIPTION
It seems that the code using this param handled the possibility for `data` to be `null`, but it wasn't declared as a nullable type.

Encountered a crash while playing with another library which also spawned some activity which can return no data (ie `data = null`), but even so, it seemed that this param should've been declared with a nullable type.