### PR TITLE
add imperative cardField methods (focus, blur, clear)

### DIFF
--- a/android/src/main/java/com/reactnativestripesdk/StripeSdkCardView.kt
+++ b/android/src/main/java/com/reactnativestripesdk/StripeSdkCardView.kt
@@ -52,6 +52,28 @@ class StripeSdkCardView(private val context: ThemedReactContext) : FrameLayout(c
     }
   }
 
+  fun requestFocusFromJS() {
+    val binding = CardInputWidgetBinding.bind(mCardWidget)
+    binding.cardNumberEditText.requestFocus()
+    binding.cardNumberEditText.showSoftKeyboard()
+  }
+
+  fun requestBlurFromJS() {
+    val binding = CardInputWidgetBinding.bind(mCardWidget)
+    binding.cardNumberEditText.hideSoftKeyboard()
+    binding.cardNumberEditText.clearFocus()
+    binding.container.requestFocus()
+  }
+
+  fun requestClearFromJS() {
+    val binding = CardInputWidgetBinding.bind(mCardWidget)
+    binding.cardNumberEditText.setText("")
+    binding.cvcEditText.setText("")
+    binding.expiryDateEditText.setText("")
+    if (mCardWidget.postalCodeEnabled) {
+      binding.postalCodeEditText.setText("")
+    }
+  }
 
   fun setCardStyle(value: ReadableMap) {
     val binding = CardInputWidgetBinding.bind(mCardWidget)
@@ -242,6 +264,15 @@ fun View.showSoftKeyboard() {
     if (this.requestFocus()) {
       val imm = context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager?
       imm?.showSoftInput(this, InputMethodManager.SHOW_IMPLICIT)
+    }
+  }
+}
+
+fun View.hideSoftKeyboard() {
+  post {
+    if (this.requestFocus()) {
+      val imm = context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager?
+      imm?.hideSoftInputFromWindow(windowToken, 0)
     }
   }
 }

--- a/android/src/main/java/com/reactnativestripesdk/StripeSdkCardView.kt
+++ b/android/src/main/java/com/reactnativestripesdk/StripeSdkCardView.kt
@@ -23,256 +23,256 @@ import com.stripe.android.view.CardInputWidget
 
 
 class StripeSdkCardView(private val context: ThemedReactContext) : FrameLayout(context) {
-  private var mCardWidget: CardInputWidget
-  val cardDetails: MutableMap<String, Any?> = mutableMapOf("brand" to "", "last4" to "", "expiryMonth" to null, "expiryYear" to null, "postalCode" to "")
-  var cardParams: PaymentMethodCreateParams.Card? = null
-  private var mEventDispatcher: EventDispatcher?
-  private var dangerouslyGetFullCardDetails: Boolean = false
+    private var mCardWidget: CardInputWidget
+    val cardDetails: MutableMap<String, Any?> = mutableMapOf("brand" to "", "last4" to "", "expiryMonth" to null, "expiryYear" to null, "postalCode" to "")
+    var cardParams: PaymentMethodCreateParams.Card? = null
+    private var mEventDispatcher: EventDispatcher?
+    private var dangerouslyGetFullCardDetails: Boolean = false
 
-  init {
-    mCardWidget = CardInputWidget(context);
-    mEventDispatcher = context.getNativeModule(UIManagerModule::class.java)?.eventDispatcher
+    init {
+        mCardWidget = CardInputWidget(context);
+        mEventDispatcher = context.getNativeModule(UIManagerModule::class.java)?.eventDispatcher
 
-    val binding = CardInputWidgetBinding.bind(mCardWidget)
-    binding.container.isFocusable = true
-    binding.container.isFocusableInTouchMode = true
-    binding.container.requestFocus()
+        val binding = CardInputWidgetBinding.bind(mCardWidget)
+        binding.container.isFocusable = true
+        binding.container.isFocusableInTouchMode = true
+        binding.container.requestFocus()
 
-    addView(mCardWidget)
-    setListeners()
+        addView(mCardWidget)
+        setListeners()
 
-    viewTreeObserver.addOnGlobalLayoutListener { requestLayout() }
-  }
-
-  fun setAutofocus(value: Boolean) {
-    if (value) {
-      val binding = CardInputWidgetBinding.bind(mCardWidget)
-      binding.cardNumberEditText.requestFocus()
-      binding.cardNumberEditText.showSoftKeyboard()
-    }
-  }
-
-  fun requestFocusFromJS() {
-    val binding = CardInputWidgetBinding.bind(mCardWidget)
-    binding.cardNumberEditText.requestFocus()
-    binding.cardNumberEditText.showSoftKeyboard()
-  }
-
-  fun requestBlurFromJS() {
-    val binding = CardInputWidgetBinding.bind(mCardWidget)
-    binding.cardNumberEditText.hideSoftKeyboard()
-    binding.cardNumberEditText.clearFocus()
-    binding.container.requestFocus()
-  }
-
-  fun requestClearFromJS() {
-    val binding = CardInputWidgetBinding.bind(mCardWidget)
-    binding.cardNumberEditText.setText("")
-    binding.cvcEditText.setText("")
-    binding.expiryDateEditText.setText("")
-    if (mCardWidget.postalCodeEnabled) {
-      binding.postalCodeEditText.setText("")
-    }
-  }
-
-  fun setCardStyle(value: ReadableMap) {
-    val binding = CardInputWidgetBinding.bind(mCardWidget)
-    val borderWidth = getIntOrNull(value, "borderWidth")
-    val backgroundColor = getValOr(value, "backgroundColor", null)
-    val borderColor = getValOr(value, "borderColor", null)
-    val borderRadius = getIntOrNull(value, "borderRadius") ?: 0
-    val textColor = getValOr(value, "textColor", null)
-    val fontSize = getIntOrNull(value, "fontSize")
-    val fontFamily = getValOr(value, "fontFamily")
-    val placeholderColor = getValOr(value, "placeholderColor", null)
-    val textErrorColor = getValOr(value, "textErrorColor", null)
-
-    textColor?.let {
-      binding.cardNumberEditText.setTextColor(Color.parseColor(it))
-      binding.cvcEditText.setTextColor(Color.parseColor(it))
-      binding.expiryDateEditText.setTextColor(Color.parseColor(it))
-      binding.postalCodeEditText.setTextColor(Color.parseColor(it))
-    }
-    textErrorColor?.let {
-      binding.cardNumberEditText.setErrorColor(Color.parseColor(it))
-      binding.cvcEditText.setErrorColor(Color.parseColor(it))
-      binding.expiryDateEditText.setErrorColor(Color.parseColor(it))
-      binding.postalCodeEditText.setErrorColor(Color.parseColor(it))
-    }
-    placeholderColor?.let {
-      binding.cardNumberEditText.setHintTextColor(Color.parseColor(it))
-      binding.cvcEditText.setHintTextColor(Color.parseColor(it))
-      binding.expiryDateEditText.setHintTextColor(Color.parseColor(it))
-      binding.postalCodeEditText.setHintTextColor(Color.parseColor(it))
-    }
-    fontSize?.let {
-      binding.cardNumberEditText.textSize = it.toFloat()
-      binding.cvcEditText.textSize = it.toFloat()
-      binding.expiryDateEditText.textSize = it.toFloat()
-      binding.postalCodeEditText.textSize = it.toFloat()
-    }
-    fontFamily?.let {
-      binding.cardNumberEditText.typeface = Typeface.create(it, Typeface.NORMAL)
-      binding.cvcEditText.typeface = Typeface.create(it, Typeface.NORMAL)
-      binding.expiryDateEditText.typeface = Typeface.create(it, Typeface.NORMAL)
-      binding.postalCodeEditText.typeface = Typeface.create(it, Typeface.NORMAL)
+        viewTreeObserver.addOnGlobalLayoutListener { requestLayout() }
     }
 
-    mCardWidget.setPadding(40, 0, 40, 0)
-    mCardWidget.background = MaterialShapeDrawable(
-      ShapeAppearanceModel()
-        .toBuilder()
-        .setAllCorners(CornerFamily.ROUNDED, (borderRadius * 2).toFloat())
-        .build()
-    ).also { shape ->
-      shape.strokeWidth = 0.0f
-      shape.strokeColor = ColorStateList.valueOf(Color.parseColor("#000000"))
-      shape.fillColor = ColorStateList.valueOf(Color.parseColor("#FFFFFF"))
-      borderWidth?.let {
-        shape.strokeWidth = (it * 2).toFloat()
-      }
-      borderColor?.let {
-        shape.strokeColor = ColorStateList.valueOf(Color.parseColor(it))
-      }
-      backgroundColor?.let {
-        shape.fillColor = ColorStateList.valueOf(Color.parseColor(it))
-      }
-    }
-  }
-
-  fun setPlaceHolders(value: ReadableMap) {
-    val binding = CardInputWidgetBinding.bind(mCardWidget)
-    val numberPlaceholder = getValOr(value, "number", null)
-    val expirationPlaceholder = getValOr(value, "expiration", null)
-    val cvcPlaceholder = getValOr(value, "cvc", null)
-    val postalCodePlaceholder = getValOr(value, "postalCode", null)
-
-    numberPlaceholder?.let {
-      binding.cardNumberEditText.hint = it
-    }
-    expirationPlaceholder?.let {
-      binding.expiryDateEditText.hint = it
-    }
-    cvcPlaceholder?.let {
-      mCardWidget.setCvcLabel(it)
-    }
-    postalCodePlaceholder?.let {
-      binding.postalCodeEditText.hint = it
-    }
-  }
-
-  fun setDangerouslyGetFullCardDetails(isEnabled: Boolean) {
-    dangerouslyGetFullCardDetails = isEnabled
-  }
-
-  fun setPostalCodeEnabled(isEnabled: Boolean) {
-    mCardWidget.postalCodeEnabled = isEnabled
-  }
-
-  fun getValue(): MutableMap<String, Any?> {
-    return cardDetails
-  }
-
-  fun onCardChanged() {
-    mCardWidget.paymentMethodCard?.let { cardParams = it } ?: run {
-      cardParams = null
-    }
-    mCardWidget.cardParams?.let {
-      cardDetails["brand"] = mapCardBrand(it.brand)
-      cardDetails["last4"] = it.last4
-    } ?: run {
-      cardDetails["brand"] = null
-      cardDetails["last4"] = null
-    }
-    mEventDispatcher?.dispatchEvent(
-      CardChangedEvent(id, cardDetails, mCardWidget.postalCodeEnabled, cardParams != null, dangerouslyGetFullCardDetails))
-  }
-
-  private fun setListeners() {
-    mCardWidget.setCardInputListener(object : CardInputListener {
-      override fun onCardComplete() {}
-      override fun onExpirationComplete() {}
-      override fun onCvcComplete() {}
-
-      override fun onFocusChange(focusField: CardInputListener.FocusField) {
-        if (mEventDispatcher != null) {
-          mEventDispatcher?.dispatchEvent(
-            CardFocusEvent(id, focusField.name))
+    fun setAutofocus(value: Boolean) {
+        if (value) {
+            val binding = CardInputWidgetBinding.bind(mCardWidget)
+            binding.cardNumberEditText.requestFocus()
+            binding.cardNumberEditText.showSoftKeyboard()
         }
-      }
-    })
+    }
 
-    mCardWidget.setExpiryDateTextWatcher(object : TextWatcher {
-      override fun beforeTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {}
-      override fun afterTextChanged(p0: Editable?) {}
-      override fun onTextChanged(var1: CharSequence?, var2: Int, var3: Int, var4: Int) {
-        val splitted = var1.toString().split("/")
-        cardDetails["expiryMonth"] = splitted[0].toIntOrNull()
+    fun requestFocusFromJS() {
+        val binding = CardInputWidgetBinding.bind(mCardWidget)
+        binding.cardNumberEditText.requestFocus()
+        binding.cardNumberEditText.showSoftKeyboard()
+    }
 
-        if (splitted.size == 2) {
-          cardDetails["expiryYear"] = var1.toString().split("/")[1].toIntOrNull()
+    fun requestBlurFromJS() {
+        val binding = CardInputWidgetBinding.bind(mCardWidget)
+        binding.cardNumberEditText.hideSoftKeyboard()
+        binding.cardNumberEditText.clearFocus()
+        binding.container.requestFocus()
+    }
+
+    fun requestClearFromJS() {
+        val binding = CardInputWidgetBinding.bind(mCardWidget)
+        binding.cardNumberEditText.setText("")
+        binding.cvcEditText.setText("")
+        binding.expiryDateEditText.setText("")
+        if (mCardWidget.postalCodeEnabled) {
+            binding.postalCodeEditText.setText("")
+        }
+    }
+
+    fun setCardStyle(value: ReadableMap) {
+        val binding = CardInputWidgetBinding.bind(mCardWidget)
+        val borderWidth = getIntOrNull(value, "borderWidth")
+        val backgroundColor = getValOr(value, "backgroundColor", null)
+        val borderColor = getValOr(value, "borderColor", null)
+        val borderRadius = getIntOrNull(value, "borderRadius") ?: 0
+        val textColor = getValOr(value, "textColor", null)
+        val fontSize = getIntOrNull(value, "fontSize")
+        val fontFamily = getValOr(value, "fontFamily")
+        val placeholderColor = getValOr(value, "placeholderColor", null)
+        val textErrorColor = getValOr(value, "textErrorColor", null)
+
+        textColor?.let {
+            binding.cardNumberEditText.setTextColor(Color.parseColor(it))
+            binding.cvcEditText.setTextColor(Color.parseColor(it))
+            binding.expiryDateEditText.setTextColor(Color.parseColor(it))
+            binding.postalCodeEditText.setTextColor(Color.parseColor(it))
+        }
+        textErrorColor?.let {
+            binding.cardNumberEditText.setErrorColor(Color.parseColor(it))
+            binding.cvcEditText.setErrorColor(Color.parseColor(it))
+            binding.expiryDateEditText.setErrorColor(Color.parseColor(it))
+            binding.postalCodeEditText.setErrorColor(Color.parseColor(it))
+        }
+        placeholderColor?.let {
+            binding.cardNumberEditText.setHintTextColor(Color.parseColor(it))
+            binding.cvcEditText.setHintTextColor(Color.parseColor(it))
+            binding.expiryDateEditText.setHintTextColor(Color.parseColor(it))
+            binding.postalCodeEditText.setHintTextColor(Color.parseColor(it))
+        }
+        fontSize?.let {
+            binding.cardNumberEditText.textSize = it.toFloat()
+            binding.cvcEditText.textSize = it.toFloat()
+            binding.expiryDateEditText.textSize = it.toFloat()
+            binding.postalCodeEditText.textSize = it.toFloat()
+        }
+        fontFamily?.let {
+            binding.cardNumberEditText.typeface = Typeface.create(it, Typeface.NORMAL)
+            binding.cvcEditText.typeface = Typeface.create(it, Typeface.NORMAL)
+            binding.expiryDateEditText.typeface = Typeface.create(it, Typeface.NORMAL)
+            binding.postalCodeEditText.typeface = Typeface.create(it, Typeface.NORMAL)
         }
 
-        onCardChanged()
-      }
-    })
-
-    mCardWidget.setPostalCodeTextWatcher(object : TextWatcher {
-      override fun beforeTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {}
-      override fun afterTextChanged(p0: Editable?) {}
-      override fun onTextChanged(var1: CharSequence?, var2: Int, var3: Int, var4: Int) {
-        cardDetails["postalCode"] = var1.toString()
-        onCardChanged()
-      }
-    })
-
-    mCardWidget.setCardNumberTextWatcher(object : TextWatcher {
-      override fun beforeTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {}
-      override fun afterTextChanged(p0: Editable?) {}
-      override fun onTextChanged(var1: CharSequence?, var2: Int, var3: Int, var4: Int) {
-        if (dangerouslyGetFullCardDetails) {
-          cardDetails["number"] = var1.toString().replace(" ", "")
+        mCardWidget.setPadding(40, 0, 40, 0)
+        mCardWidget.background = MaterialShapeDrawable(
+                ShapeAppearanceModel()
+                        .toBuilder()
+                        .setAllCorners(CornerFamily.ROUNDED, (borderRadius * 2).toFloat())
+                        .build()
+        ).also { shape ->
+            shape.strokeWidth = 0.0f
+            shape.strokeColor = ColorStateList.valueOf(Color.parseColor("#000000"))
+            shape.fillColor = ColorStateList.valueOf(Color.parseColor("#FFFFFF"))
+            borderWidth?.let {
+                shape.strokeWidth = (it * 2).toFloat()
+            }
+            borderColor?.let {
+                shape.strokeColor = ColorStateList.valueOf(Color.parseColor(it))
+            }
+            backgroundColor?.let {
+                shape.fillColor = ColorStateList.valueOf(Color.parseColor(it))
+            }
         }
-        onCardChanged()
-      }
-    })
+    }
 
-    mCardWidget.setCvcNumberTextWatcher(object : TextWatcher {
-      override fun beforeTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {}
-      override fun afterTextChanged(p0: Editable?) {}
-      override fun onTextChanged(var1: CharSequence?, var2: Int, var3: Int, var4: Int) {
-        onCardChanged()
-      }
-    })
-  }
+    fun setPlaceHolders(value: ReadableMap) {
+        val binding = CardInputWidgetBinding.bind(mCardWidget)
+        val numberPlaceholder = getValOr(value, "number", null)
+        val expirationPlaceholder = getValOr(value, "expiration", null)
+        val cvcPlaceholder = getValOr(value, "cvc", null)
+        val postalCodePlaceholder = getValOr(value, "postalCode", null)
 
-  override fun requestLayout() {
-    super.requestLayout()
-    post(mLayoutRunnable)
-  }
+        numberPlaceholder?.let {
+            binding.cardNumberEditText.hint = it
+        }
+        expirationPlaceholder?.let {
+            binding.expiryDateEditText.hint = it
+        }
+        cvcPlaceholder?.let {
+            mCardWidget.setCvcLabel(it)
+        }
+        postalCodePlaceholder?.let {
+            binding.postalCodeEditText.hint = it
+        }
+    }
 
-  private val mLayoutRunnable = Runnable {
-    measure(
-      MeasureSpec.makeMeasureSpec(width, MeasureSpec.EXACTLY),
-      MeasureSpec.makeMeasureSpec(height, MeasureSpec.EXACTLY))
-    layout(left, top, right, bottom)
-  }
+    fun setDangerouslyGetFullCardDetails(isEnabled: Boolean) {
+        dangerouslyGetFullCardDetails = isEnabled
+    }
+
+    fun setPostalCodeEnabled(isEnabled: Boolean) {
+        mCardWidget.postalCodeEnabled = isEnabled
+    }
+
+    fun getValue(): MutableMap<String, Any?> {
+        return cardDetails
+    }
+
+    fun onCardChanged() {
+        mCardWidget.paymentMethodCard?.let { cardParams = it } ?: run {
+            cardParams = null
+        }
+        mCardWidget.cardParams?.let {
+            cardDetails["brand"] = mapCardBrand(it.brand)
+            cardDetails["last4"] = it.last4
+        } ?: run {
+            cardDetails["brand"] = null
+            cardDetails["last4"] = null
+        }
+        mEventDispatcher?.dispatchEvent(
+                CardChangedEvent(id, cardDetails, mCardWidget.postalCodeEnabled, cardParams != null, dangerouslyGetFullCardDetails))
+    }
+
+    private fun setListeners() {
+        mCardWidget.setCardInputListener(object : CardInputListener {
+            override fun onCardComplete() {}
+            override fun onExpirationComplete() {}
+            override fun onCvcComplete() {}
+
+            override fun onFocusChange(focusField: CardInputListener.FocusField) {
+                if (mEventDispatcher != null) {
+                    mEventDispatcher?.dispatchEvent(
+                            CardFocusEvent(id, focusField.name))
+                }
+            }
+        })
+
+        mCardWidget.setExpiryDateTextWatcher(object : TextWatcher {
+            override fun beforeTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {}
+            override fun afterTextChanged(p0: Editable?) {}
+            override fun onTextChanged(var1: CharSequence?, var2: Int, var3: Int, var4: Int) {
+                val splitted = var1.toString().split("/")
+                cardDetails["expiryMonth"] = splitted[0].toIntOrNull()
+
+                if (splitted.size == 2) {
+                    cardDetails["expiryYear"] = var1.toString().split("/")[1].toIntOrNull()
+                }
+
+                onCardChanged()
+            }
+        })
+
+        mCardWidget.setPostalCodeTextWatcher(object : TextWatcher {
+            override fun beforeTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {}
+            override fun afterTextChanged(p0: Editable?) {}
+            override fun onTextChanged(var1: CharSequence?, var2: Int, var3: Int, var4: Int) {
+                cardDetails["postalCode"] = var1.toString()
+                onCardChanged()
+            }
+        })
+
+        mCardWidget.setCardNumberTextWatcher(object : TextWatcher {
+            override fun beforeTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {}
+            override fun afterTextChanged(p0: Editable?) {}
+            override fun onTextChanged(var1: CharSequence?, var2: Int, var3: Int, var4: Int) {
+                if (dangerouslyGetFullCardDetails) {
+                    cardDetails["number"] = var1.toString().replace(" ", "")
+                }
+                onCardChanged()
+            }
+        })
+
+        mCardWidget.setCvcNumberTextWatcher(object : TextWatcher {
+            override fun beforeTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {}
+            override fun afterTextChanged(p0: Editable?) {}
+            override fun onTextChanged(var1: CharSequence?, var2: Int, var3: Int, var4: Int) {
+                onCardChanged()
+            }
+        })
+    }
+
+    override fun requestLayout() {
+        super.requestLayout()
+        post(mLayoutRunnable)
+    }
+
+    private val mLayoutRunnable = Runnable {
+        measure(
+                MeasureSpec.makeMeasureSpec(width, MeasureSpec.EXACTLY),
+                MeasureSpec.makeMeasureSpec(height, MeasureSpec.EXACTLY))
+        layout(left, top, right, bottom)
+    }
 }
 
 fun View.showSoftKeyboard() {
-  post {
-    if (this.requestFocus()) {
-      val imm = context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager?
-      imm?.showSoftInput(this, InputMethodManager.SHOW_IMPLICIT)
+    post {
+        if (this.requestFocus()) {
+            val imm = context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager?
+            imm?.showSoftInput(this, InputMethodManager.SHOW_IMPLICIT)
+        }
     }
-  }
 }
 
 fun View.hideSoftKeyboard() {
-  post {
-    if (this.requestFocus()) {
-      val imm = context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager?
-      imm?.hideSoftInputFromWindow(windowToken, 0)
+    post {
+        if (this.requestFocus()) {
+            val imm = context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager?
+            imm?.hideSoftInputFromWindow(windowToken, 0)
+        }
     }
-  }
 }

--- a/android/src/main/java/com/reactnativestripesdk/StripeSdkCardView.kt
+++ b/android/src/main/java/com/reactnativestripesdk/StripeSdkCardView.kt
@@ -23,256 +23,256 @@ import com.stripe.android.view.CardInputWidget
 
 
 class StripeSdkCardView(private val context: ThemedReactContext) : FrameLayout(context) {
-    private var mCardWidget: CardInputWidget
-    val cardDetails: MutableMap<String, Any?> = mutableMapOf("brand" to "", "last4" to "", "expiryMonth" to null, "expiryYear" to null, "postalCode" to "")
-    var cardParams: PaymentMethodCreateParams.Card? = null
-    private var mEventDispatcher: EventDispatcher?
-    private var dangerouslyGetFullCardDetails: Boolean = false
+  private var mCardWidget: CardInputWidget
+  val cardDetails: MutableMap<String, Any?> = mutableMapOf("brand" to "", "last4" to "", "expiryMonth" to null, "expiryYear" to null, "postalCode" to "")
+  var cardParams: PaymentMethodCreateParams.Card? = null
+  private var mEventDispatcher: EventDispatcher?
+  private var dangerouslyGetFullCardDetails: Boolean = false
 
-    init {
-        mCardWidget = CardInputWidget(context);
-        mEventDispatcher = context.getNativeModule(UIManagerModule::class.java)?.eventDispatcher
+  init {
+    mCardWidget = CardInputWidget(context);
+    mEventDispatcher = context.getNativeModule(UIManagerModule::class.java)?.eventDispatcher
 
-        val binding = CardInputWidgetBinding.bind(mCardWidget)
-        binding.container.isFocusable = true
-        binding.container.isFocusableInTouchMode = true
-        binding.container.requestFocus()
+    val binding = CardInputWidgetBinding.bind(mCardWidget)
+    binding.container.isFocusable = true
+    binding.container.isFocusableInTouchMode = true
+    binding.container.requestFocus()
 
-        addView(mCardWidget)
-        setListeners()
+    addView(mCardWidget)
+    setListeners()
 
-        viewTreeObserver.addOnGlobalLayoutListener { requestLayout() }
+    viewTreeObserver.addOnGlobalLayoutListener { requestLayout() }
+  }
+
+  fun setAutofocus(value: Boolean) {
+    if (value) {
+      val binding = CardInputWidgetBinding.bind(mCardWidget)
+      binding.cardNumberEditText.requestFocus()
+      binding.cardNumberEditText.showSoftKeyboard()
+    }
+  }
+
+  fun requestFocusFromJS() {
+    val binding = CardInputWidgetBinding.bind(mCardWidget)
+    binding.cardNumberEditText.requestFocus()
+    binding.cardNumberEditText.showSoftKeyboard()
+  }
+
+  fun requestBlurFromJS() {
+    val binding = CardInputWidgetBinding.bind(mCardWidget)
+    binding.cardNumberEditText.hideSoftKeyboard()
+    binding.cardNumberEditText.clearFocus()
+    binding.container.requestFocus()
+  }
+
+  fun requestClearFromJS() {
+    val binding = CardInputWidgetBinding.bind(mCardWidget)
+    binding.cardNumberEditText.setText("")
+    binding.cvcEditText.setText("")
+    binding.expiryDateEditText.setText("")
+    if (mCardWidget.postalCodeEnabled) {
+      binding.postalCodeEditText.setText("")
+    }
+  }
+
+  fun setCardStyle(value: ReadableMap) {
+    val binding = CardInputWidgetBinding.bind(mCardWidget)
+    val borderWidth = getIntOrNull(value, "borderWidth")
+    val backgroundColor = getValOr(value, "backgroundColor", null)
+    val borderColor = getValOr(value, "borderColor", null)
+    val borderRadius = getIntOrNull(value, "borderRadius") ?: 0
+    val textColor = getValOr(value, "textColor", null)
+    val fontSize = getIntOrNull(value, "fontSize")
+    val fontFamily = getValOr(value, "fontFamily")
+    val placeholderColor = getValOr(value, "placeholderColor", null)
+    val textErrorColor = getValOr(value, "textErrorColor", null)
+
+    textColor?.let {
+      binding.cardNumberEditText.setTextColor(Color.parseColor(it))
+      binding.cvcEditText.setTextColor(Color.parseColor(it))
+      binding.expiryDateEditText.setTextColor(Color.parseColor(it))
+      binding.postalCodeEditText.setTextColor(Color.parseColor(it))
+    }
+    textErrorColor?.let {
+      binding.cardNumberEditText.setErrorColor(Color.parseColor(it))
+      binding.cvcEditText.setErrorColor(Color.parseColor(it))
+      binding.expiryDateEditText.setErrorColor(Color.parseColor(it))
+      binding.postalCodeEditText.setErrorColor(Color.parseColor(it))
+    }
+    placeholderColor?.let {
+      binding.cardNumberEditText.setHintTextColor(Color.parseColor(it))
+      binding.cvcEditText.setHintTextColor(Color.parseColor(it))
+      binding.expiryDateEditText.setHintTextColor(Color.parseColor(it))
+      binding.postalCodeEditText.setHintTextColor(Color.parseColor(it))
+    }
+    fontSize?.let {
+      binding.cardNumberEditText.textSize = it.toFloat()
+      binding.cvcEditText.textSize = it.toFloat()
+      binding.expiryDateEditText.textSize = it.toFloat()
+      binding.postalCodeEditText.textSize = it.toFloat()
+    }
+    fontFamily?.let {
+      binding.cardNumberEditText.typeface = Typeface.create(it, Typeface.NORMAL)
+      binding.cvcEditText.typeface = Typeface.create(it, Typeface.NORMAL)
+      binding.expiryDateEditText.typeface = Typeface.create(it, Typeface.NORMAL)
+      binding.postalCodeEditText.typeface = Typeface.create(it, Typeface.NORMAL)
     }
 
-    fun setAutofocus(value: Boolean) {
-        if (value) {
-            val binding = CardInputWidgetBinding.bind(mCardWidget)
-            binding.cardNumberEditText.requestFocus()
-            binding.cardNumberEditText.showSoftKeyboard()
-        }
+    mCardWidget.setPadding(40, 0, 40, 0)
+    mCardWidget.background = MaterialShapeDrawable(
+      ShapeAppearanceModel()
+        .toBuilder()
+        .setAllCorners(CornerFamily.ROUNDED, (borderRadius * 2).toFloat())
+        .build()
+    ).also { shape ->
+      shape.strokeWidth = 0.0f
+      shape.strokeColor = ColorStateList.valueOf(Color.parseColor("#000000"))
+      shape.fillColor = ColorStateList.valueOf(Color.parseColor("#FFFFFF"))
+      borderWidth?.let {
+        shape.strokeWidth = (it * 2).toFloat()
+      }
+      borderColor?.let {
+        shape.strokeColor = ColorStateList.valueOf(Color.parseColor(it))
+      }
+      backgroundColor?.let {
+        shape.fillColor = ColorStateList.valueOf(Color.parseColor(it))
+      }
     }
+  }
 
-    fun requestFocusFromJS() {
-        val binding = CardInputWidgetBinding.bind(mCardWidget)
-        binding.cardNumberEditText.requestFocus()
-        binding.cardNumberEditText.showSoftKeyboard()
+  fun setPlaceHolders(value: ReadableMap) {
+    val binding = CardInputWidgetBinding.bind(mCardWidget)
+    val numberPlaceholder = getValOr(value, "number", null)
+    val expirationPlaceholder = getValOr(value, "expiration", null)
+    val cvcPlaceholder = getValOr(value, "cvc", null)
+    val postalCodePlaceholder = getValOr(value, "postalCode", null)
+
+    numberPlaceholder?.let {
+      binding.cardNumberEditText.hint = it
     }
-
-    fun requestBlurFromJS() {
-        val binding = CardInputWidgetBinding.bind(mCardWidget)
-        binding.cardNumberEditText.hideSoftKeyboard()
-        binding.cardNumberEditText.clearFocus()
-        binding.container.requestFocus()
+    expirationPlaceholder?.let {
+      binding.expiryDateEditText.hint = it
     }
-
-    fun requestClearFromJS() {
-        val binding = CardInputWidgetBinding.bind(mCardWidget)
-        binding.cardNumberEditText.setText("")
-        binding.cvcEditText.setText("")
-        binding.expiryDateEditText.setText("")
-        if (mCardWidget.postalCodeEnabled) {
-            binding.postalCodeEditText.setText("")
-        }
+    cvcPlaceholder?.let {
+      mCardWidget.setCvcLabel(it)
     }
-
-    fun setCardStyle(value: ReadableMap) {
-        val binding = CardInputWidgetBinding.bind(mCardWidget)
-        val borderWidth = getIntOrNull(value, "borderWidth")
-        val backgroundColor = getValOr(value, "backgroundColor", null)
-        val borderColor = getValOr(value, "borderColor", null)
-        val borderRadius = getIntOrNull(value, "borderRadius") ?: 0
-        val textColor = getValOr(value, "textColor", null)
-        val fontSize = getIntOrNull(value, "fontSize")
-        val fontFamily = getValOr(value, "fontFamily")
-        val placeholderColor = getValOr(value, "placeholderColor", null)
-        val textErrorColor = getValOr(value, "textErrorColor", null)
-
-        textColor?.let {
-            binding.cardNumberEditText.setTextColor(Color.parseColor(it))
-            binding.cvcEditText.setTextColor(Color.parseColor(it))
-            binding.expiryDateEditText.setTextColor(Color.parseColor(it))
-            binding.postalCodeEditText.setTextColor(Color.parseColor(it))
-        }
-        textErrorColor?.let {
-            binding.cardNumberEditText.setErrorColor(Color.parseColor(it))
-            binding.cvcEditText.setErrorColor(Color.parseColor(it))
-            binding.expiryDateEditText.setErrorColor(Color.parseColor(it))
-            binding.postalCodeEditText.setErrorColor(Color.parseColor(it))
-        }
-        placeholderColor?.let {
-            binding.cardNumberEditText.setHintTextColor(Color.parseColor(it))
-            binding.cvcEditText.setHintTextColor(Color.parseColor(it))
-            binding.expiryDateEditText.setHintTextColor(Color.parseColor(it))
-            binding.postalCodeEditText.setHintTextColor(Color.parseColor(it))
-        }
-        fontSize?.let {
-            binding.cardNumberEditText.textSize = it.toFloat()
-            binding.cvcEditText.textSize = it.toFloat()
-            binding.expiryDateEditText.textSize = it.toFloat()
-            binding.postalCodeEditText.textSize = it.toFloat()
-        }
-        fontFamily?.let {
-            binding.cardNumberEditText.typeface = Typeface.create(it, Typeface.NORMAL)
-            binding.cvcEditText.typeface = Typeface.create(it, Typeface.NORMAL)
-            binding.expiryDateEditText.typeface = Typeface.create(it, Typeface.NORMAL)
-            binding.postalCodeEditText.typeface = Typeface.create(it, Typeface.NORMAL)
-        }
-
-        mCardWidget.setPadding(40, 0, 40, 0)
-        mCardWidget.background = MaterialShapeDrawable(
-                ShapeAppearanceModel()
-                        .toBuilder()
-                        .setAllCorners(CornerFamily.ROUNDED, (borderRadius * 2).toFloat())
-                        .build()
-        ).also { shape ->
-            shape.strokeWidth = 0.0f
-            shape.strokeColor = ColorStateList.valueOf(Color.parseColor("#000000"))
-            shape.fillColor = ColorStateList.valueOf(Color.parseColor("#FFFFFF"))
-            borderWidth?.let {
-                shape.strokeWidth = (it * 2).toFloat()
-            }
-            borderColor?.let {
-                shape.strokeColor = ColorStateList.valueOf(Color.parseColor(it))
-            }
-            backgroundColor?.let {
-                shape.fillColor = ColorStateList.valueOf(Color.parseColor(it))
-            }
-        }
+    postalCodePlaceholder?.let {
+      binding.postalCodeEditText.hint = it
     }
+  }
 
-    fun setPlaceHolders(value: ReadableMap) {
-        val binding = CardInputWidgetBinding.bind(mCardWidget)
-        val numberPlaceholder = getValOr(value, "number", null)
-        val expirationPlaceholder = getValOr(value, "expiration", null)
-        val cvcPlaceholder = getValOr(value, "cvc", null)
-        val postalCodePlaceholder = getValOr(value, "postalCode", null)
+  fun setDangerouslyGetFullCardDetails(isEnabled: Boolean) {
+    dangerouslyGetFullCardDetails = isEnabled
+  }
 
-        numberPlaceholder?.let {
-            binding.cardNumberEditText.hint = it
+  fun setPostalCodeEnabled(isEnabled: Boolean) {
+    mCardWidget.postalCodeEnabled = isEnabled
+  }
+
+  fun getValue(): MutableMap<String, Any?> {
+    return cardDetails
+  }
+
+  fun onCardChanged() {
+    mCardWidget.paymentMethodCard?.let { cardParams = it } ?: run {
+      cardParams = null
+    }
+    mCardWidget.cardParams?.let {
+      cardDetails["brand"] = mapCardBrand(it.brand)
+      cardDetails["last4"] = it.last4
+    } ?: run {
+      cardDetails["brand"] = null
+      cardDetails["last4"] = null
+    }
+    mEventDispatcher?.dispatchEvent(
+      CardChangedEvent(id, cardDetails, mCardWidget.postalCodeEnabled, cardParams != null, dangerouslyGetFullCardDetails))
+  }
+
+  private fun setListeners() {
+    mCardWidget.setCardInputListener(object : CardInputListener {
+      override fun onCardComplete() {}
+      override fun onExpirationComplete() {}
+      override fun onCvcComplete() {}
+
+      override fun onFocusChange(focusField: CardInputListener.FocusField) {
+        if (mEventDispatcher != null) {
+          mEventDispatcher?.dispatchEvent(
+            CardFocusEvent(id, focusField.name))
         }
-        expirationPlaceholder?.let {
-            binding.expiryDateEditText.hint = it
+      }
+    })
+
+    mCardWidget.setExpiryDateTextWatcher(object : TextWatcher {
+      override fun beforeTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {}
+      override fun afterTextChanged(p0: Editable?) {}
+      override fun onTextChanged(var1: CharSequence?, var2: Int, var3: Int, var4: Int) {
+        val splitted = var1.toString().split("/")
+        cardDetails["expiryMonth"] = splitted[0].toIntOrNull()
+
+        if (splitted.size == 2) {
+          cardDetails["expiryYear"] = var1.toString().split("/")[1].toIntOrNull()
         }
-        cvcPlaceholder?.let {
-            mCardWidget.setCvcLabel(it)
+
+        onCardChanged()
+      }
+    })
+
+    mCardWidget.setPostalCodeTextWatcher(object : TextWatcher {
+      override fun beforeTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {}
+      override fun afterTextChanged(p0: Editable?) {}
+      override fun onTextChanged(var1: CharSequence?, var2: Int, var3: Int, var4: Int) {
+        cardDetails["postalCode"] = var1.toString()
+        onCardChanged()
+      }
+    })
+
+    mCardWidget.setCardNumberTextWatcher(object : TextWatcher {
+      override fun beforeTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {}
+      override fun afterTextChanged(p0: Editable?) {}
+      override fun onTextChanged(var1: CharSequence?, var2: Int, var3: Int, var4: Int) {
+        if (dangerouslyGetFullCardDetails) {
+          cardDetails["number"] = var1.toString().replace(" ", "")
         }
-        postalCodePlaceholder?.let {
-            binding.postalCodeEditText.hint = it
-        }
-    }
+        onCardChanged()
+      }
+    })
 
-    fun setDangerouslyGetFullCardDetails(isEnabled: Boolean) {
-        dangerouslyGetFullCardDetails = isEnabled
-    }
+    mCardWidget.setCvcNumberTextWatcher(object : TextWatcher {
+      override fun beforeTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {}
+      override fun afterTextChanged(p0: Editable?) {}
+      override fun onTextChanged(var1: CharSequence?, var2: Int, var3: Int, var4: Int) {
+        onCardChanged()
+      }
+    })
+  }
 
-    fun setPostalCodeEnabled(isEnabled: Boolean) {
-        mCardWidget.postalCodeEnabled = isEnabled
-    }
+  override fun requestLayout() {
+    super.requestLayout()
+    post(mLayoutRunnable)
+  }
 
-    fun getValue(): MutableMap<String, Any?> {
-        return cardDetails
-    }
-
-    fun onCardChanged() {
-        mCardWidget.paymentMethodCard?.let { cardParams = it } ?: run {
-            cardParams = null
-        }
-        mCardWidget.cardParams?.let {
-            cardDetails["brand"] = mapCardBrand(it.brand)
-            cardDetails["last4"] = it.last4
-        } ?: run {
-            cardDetails["brand"] = null
-            cardDetails["last4"] = null
-        }
-        mEventDispatcher?.dispatchEvent(
-                CardChangedEvent(id, cardDetails, mCardWidget.postalCodeEnabled, cardParams != null, dangerouslyGetFullCardDetails))
-    }
-
-    private fun setListeners() {
-        mCardWidget.setCardInputListener(object : CardInputListener {
-            override fun onCardComplete() {}
-            override fun onExpirationComplete() {}
-            override fun onCvcComplete() {}
-
-            override fun onFocusChange(focusField: CardInputListener.FocusField) {
-                if (mEventDispatcher != null) {
-                    mEventDispatcher?.dispatchEvent(
-                            CardFocusEvent(id, focusField.name))
-                }
-            }
-        })
-
-        mCardWidget.setExpiryDateTextWatcher(object : TextWatcher {
-            override fun beforeTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {}
-            override fun afterTextChanged(p0: Editable?) {}
-            override fun onTextChanged(var1: CharSequence?, var2: Int, var3: Int, var4: Int) {
-                val splitted = var1.toString().split("/")
-                cardDetails["expiryMonth"] = splitted[0].toIntOrNull()
-
-                if (splitted.size == 2) {
-                    cardDetails["expiryYear"] = var1.toString().split("/")[1].toIntOrNull()
-                }
-
-                onCardChanged()
-            }
-        })
-
-        mCardWidget.setPostalCodeTextWatcher(object : TextWatcher {
-            override fun beforeTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {}
-            override fun afterTextChanged(p0: Editable?) {}
-            override fun onTextChanged(var1: CharSequence?, var2: Int, var3: Int, var4: Int) {
-                cardDetails["postalCode"] = var1.toString()
-                onCardChanged()
-            }
-        })
-
-        mCardWidget.setCardNumberTextWatcher(object : TextWatcher {
-            override fun beforeTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {}
-            override fun afterTextChanged(p0: Editable?) {}
-            override fun onTextChanged(var1: CharSequence?, var2: Int, var3: Int, var4: Int) {
-                if (dangerouslyGetFullCardDetails) {
-                    cardDetails["number"] = var1.toString().replace(" ", "")
-                }
-                onCardChanged()
-            }
-        })
-
-        mCardWidget.setCvcNumberTextWatcher(object : TextWatcher {
-            override fun beforeTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {}
-            override fun afterTextChanged(p0: Editable?) {}
-            override fun onTextChanged(var1: CharSequence?, var2: Int, var3: Int, var4: Int) {
-                onCardChanged()
-            }
-        })
-    }
-
-    override fun requestLayout() {
-        super.requestLayout()
-        post(mLayoutRunnable)
-    }
-
-    private val mLayoutRunnable = Runnable {
-        measure(
-                MeasureSpec.makeMeasureSpec(width, MeasureSpec.EXACTLY),
-                MeasureSpec.makeMeasureSpec(height, MeasureSpec.EXACTLY))
-        layout(left, top, right, bottom)
-    }
+  private val mLayoutRunnable = Runnable {
+    measure(
+      MeasureSpec.makeMeasureSpec(width, MeasureSpec.EXACTLY),
+      MeasureSpec.makeMeasureSpec(height, MeasureSpec.EXACTLY))
+    layout(left, top, right, bottom)
+  }
 }
 
 fun View.showSoftKeyboard() {
-    post {
-        if (this.requestFocus()) {
-            val imm = context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager?
-            imm?.showSoftInput(this, InputMethodManager.SHOW_IMPLICIT)
-        }
+  post {
+    if (this.requestFocus()) {
+      val imm = context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager?
+      imm?.showSoftInput(this, InputMethodManager.SHOW_IMPLICIT)
     }
+  }
 }
 
 fun View.hideSoftKeyboard() {
-    post {
-        if (this.requestFocus()) {
-            val imm = context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager?
-            imm?.hideSoftInputFromWindow(windowToken, 0)
-        }
+  post {
+    if (this.requestFocus()) {
+      val imm = context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager?
+      imm?.hideSoftInputFromWindow(windowToken, 0)
     }
+  }
 }

--- a/android/src/main/java/com/reactnativestripesdk/StripeSdkCardViewManager.kt
+++ b/android/src/main/java/com/reactnativestripesdk/StripeSdkCardViewManager.kt
@@ -1,6 +1,7 @@
 package com.reactnativestripesdk
 
-import com.facebook.react.bridge.*
+import com.facebook.react.bridge.ReadableArray
+import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.common.MapBuilder
 import com.facebook.react.uimanager.SimpleViewManager
 import com.facebook.react.uimanager.ThemedReactContext
@@ -17,6 +18,14 @@ class StripeSdkCardViewManager : SimpleViewManager<StripeSdkCardView>() {
     return MapBuilder.of(
       CardFocusEvent.EVENT_NAME, MapBuilder.of("registrationName", "onFocusChange"),
       CardChangedEvent.EVENT_NAME, MapBuilder.of("registrationName", "onCardChange"))
+  }
+
+  override fun receiveCommand(root: StripeSdkCardView, commandId: String?, args: ReadableArray?) {
+    when (commandId) {
+      "focus" -> root.requestFocusFromJS()
+      "blur" -> root.requestBlurFromJS()
+      "clear" -> root.requestClearFromJS()
+    }
   }
 
   @ReactProp(name = "dangerouslyGetFullCardDetails")

--- a/android/src/main/java/com/reactnativestripesdk/StripeSdkCardViewManager.kt
+++ b/android/src/main/java/com/reactnativestripesdk/StripeSdkCardViewManager.kt
@@ -10,52 +10,52 @@ import com.facebook.react.uimanager.annotations.ReactProp
 const val CARD_FIELD_INSTANCE_NAME = "CardFieldInstance"
 
 class StripeSdkCardViewManager : SimpleViewManager<StripeSdkCardView>() {
-  override fun getName() = "CardField"
+    override fun getName() = "CardField"
 
-  private var cardViewInstanceMap: MutableMap<String, Any?> = mutableMapOf()
+    private var cardViewInstanceMap: MutableMap<String, Any?> = mutableMapOf()
 
-  override fun getExportedCustomDirectEventTypeConstants(): MutableMap<String, Any> {
-    return MapBuilder.of(
-      CardFocusEvent.EVENT_NAME, MapBuilder.of("registrationName", "onFocusChange"),
-      CardChangedEvent.EVENT_NAME, MapBuilder.of("registrationName", "onCardChange"))
-  }
-
-  override fun receiveCommand(root: StripeSdkCardView, commandId: String?, args: ReadableArray?) {
-    when (commandId) {
-      "focus" -> root.requestFocusFromJS()
-      "blur" -> root.requestBlurFromJS()
-      "clear" -> root.requestClearFromJS()
+    override fun getExportedCustomDirectEventTypeConstants(): MutableMap<String, Any> {
+        return MapBuilder.of(
+                CardFocusEvent.EVENT_NAME, MapBuilder.of("registrationName", "onFocusChange"),
+                CardChangedEvent.EVENT_NAME, MapBuilder.of("registrationName", "onCardChange"))
     }
-  }
 
-  @ReactProp(name = "dangerouslyGetFullCardDetails")
-  fun setDangerouslyGetFullCardDetails(view: StripeSdkCardView, dangerouslyGetFullCardDetails: Boolean = false) {
-    view.setDangerouslyGetFullCardDetails(dangerouslyGetFullCardDetails);
-  }
+    override fun receiveCommand(root: StripeSdkCardView, commandId: String?, args: ReadableArray?) {
+        when (commandId) {
+            "focus" -> root.requestFocusFromJS()
+            "blur" -> root.requestBlurFromJS()
+            "clear" -> root.requestClearFromJS()
+        }
+    }
 
-  @ReactProp(name = "postalCodeEnabled")
-  fun setPostalCodeEnabled(view: StripeSdkCardView, postalCodeEnabled: Boolean = true) {
-    view.setPostalCodeEnabled(postalCodeEnabled);
-  }
+    @ReactProp(name = "dangerouslyGetFullCardDetails")
+    fun setDangerouslyGetFullCardDetails(view: StripeSdkCardView, dangerouslyGetFullCardDetails: Boolean = false) {
+        view.setDangerouslyGetFullCardDetails(dangerouslyGetFullCardDetails);
+    }
 
-  @ReactProp(name = "autofocus")
-  fun setAutofocus(view: StripeSdkCardView, autofocus: Boolean = false) {
-    view.setAutofocus(autofocus);
-  }
+    @ReactProp(name = "postalCodeEnabled")
+    fun setPostalCodeEnabled(view: StripeSdkCardView, postalCodeEnabled: Boolean = true) {
+        view.setPostalCodeEnabled(postalCodeEnabled);
+    }
 
-  @ReactProp(name = "cardStyle")
-  fun setCardStyle(view: StripeSdkCardView, cardStyle: ReadableMap) {
-    view.setCardStyle(cardStyle);
-  }
+    @ReactProp(name = "autofocus")
+    fun setAutofocus(view: StripeSdkCardView, autofocus: Boolean = false) {
+        view.setAutofocus(autofocus);
+    }
 
-  @ReactProp(name = "placeholder")
-  fun setPlaceHolders(view: StripeSdkCardView, placeholder: ReadableMap) {
-    view.setPlaceHolders(placeholder);
-  }
+    @ReactProp(name = "cardStyle")
+    fun setCardStyle(view: StripeSdkCardView, cardStyle: ReadableMap) {
+        view.setCardStyle(cardStyle);
+    }
 
-  override fun createViewInstance(reactContext: ThemedReactContext): StripeSdkCardView {
-    // as it's reasonable we handle only one CardField component on the same screen
-    // TODO: temporary commented out due to android state persistence and improper behavior after app reload
+    @ReactProp(name = "placeholder")
+    fun setPlaceHolders(view: StripeSdkCardView, placeholder: ReadableMap) {
+        view.setPlaceHolders(placeholder);
+    }
+
+    override fun createViewInstance(reactContext: ThemedReactContext): StripeSdkCardView {
+        // as it's reasonable we handle only one CardField component on the same screen
+        // TODO: temporary commented out due to android state persistence and improper behavior after app reload
 //    if (cardViewInstanceMap[CARD_FIELD_INSTANCE_NAME] != null) {
 //      val exceptionManager = reactContext.getNativeModule(ExceptionsManagerModule::class.java)
 //      val error: WritableMap = WritableNativeMap()
@@ -63,20 +63,20 @@ class StripeSdkCardViewManager : SimpleViewManager<StripeSdkCardView>() {
 //      exceptionManager?.reportException(error)
 //    }
 
-    cardViewInstanceMap[CARD_FIELD_INSTANCE_NAME] = StripeSdkCardView(reactContext)
-    return cardViewInstanceMap[CARD_FIELD_INSTANCE_NAME] as StripeSdkCardView
-  }
-
-  override fun onDropViewInstance(view: StripeSdkCardView) {
-    super.onDropViewInstance(view)
-
-    this.cardViewInstanceMap[CARD_FIELD_INSTANCE_NAME] = null
-  }
-
-  fun getCardViewInstance(): StripeSdkCardView? {
-    if (cardViewInstanceMap[CARD_FIELD_INSTANCE_NAME] != null) {
-      return cardViewInstanceMap[CARD_FIELD_INSTANCE_NAME] as StripeSdkCardView
+        cardViewInstanceMap[CARD_FIELD_INSTANCE_NAME] = StripeSdkCardView(reactContext)
+        return cardViewInstanceMap[CARD_FIELD_INSTANCE_NAME] as StripeSdkCardView
     }
-    return null
-  }
+
+    override fun onDropViewInstance(view: StripeSdkCardView) {
+        super.onDropViewInstance(view)
+
+        this.cardViewInstanceMap[CARD_FIELD_INSTANCE_NAME] = null
+    }
+
+    fun getCardViewInstance(): StripeSdkCardView? {
+        if (cardViewInstanceMap[CARD_FIELD_INSTANCE_NAME] != null) {
+            return cardViewInstanceMap[CARD_FIELD_INSTANCE_NAME] as StripeSdkCardView
+        }
+        return null
+    }
 }

--- a/android/src/main/java/com/reactnativestripesdk/StripeSdkCardViewManager.kt
+++ b/android/src/main/java/com/reactnativestripesdk/StripeSdkCardViewManager.kt
@@ -10,52 +10,52 @@ import com.facebook.react.uimanager.annotations.ReactProp
 const val CARD_FIELD_INSTANCE_NAME = "CardFieldInstance"
 
 class StripeSdkCardViewManager : SimpleViewManager<StripeSdkCardView>() {
-    override fun getName() = "CardField"
+  override fun getName() = "CardField"
 
-    private var cardViewInstanceMap: MutableMap<String, Any?> = mutableMapOf()
+  private var cardViewInstanceMap: MutableMap<String, Any?> = mutableMapOf()
 
-    override fun getExportedCustomDirectEventTypeConstants(): MutableMap<String, Any> {
-        return MapBuilder.of(
-                CardFocusEvent.EVENT_NAME, MapBuilder.of("registrationName", "onFocusChange"),
-                CardChangedEvent.EVENT_NAME, MapBuilder.of("registrationName", "onCardChange"))
+  override fun getExportedCustomDirectEventTypeConstants(): MutableMap<String, Any> {
+    return MapBuilder.of(
+      CardFocusEvent.EVENT_NAME, MapBuilder.of("registrationName", "onFocusChange"),
+      CardChangedEvent.EVENT_NAME, MapBuilder.of("registrationName", "onCardChange"))
+  }
+
+  override fun receiveCommand(root: StripeSdkCardView, commandId: String?, args: ReadableArray?) {
+    when (commandId) {
+      "focus" -> root.requestFocusFromJS()
+      "blur" -> root.requestBlurFromJS()
+      "clear" -> root.requestClearFromJS()
     }
+  }
 
-    override fun receiveCommand(root: StripeSdkCardView, commandId: String?, args: ReadableArray?) {
-        when (commandId) {
-            "focus" -> root.requestFocusFromJS()
-            "blur" -> root.requestBlurFromJS()
-            "clear" -> root.requestClearFromJS()
-        }
-    }
+  @ReactProp(name = "dangerouslyGetFullCardDetails")
+  fun setDangerouslyGetFullCardDetails(view: StripeSdkCardView, dangerouslyGetFullCardDetails: Boolean = false) {
+    view.setDangerouslyGetFullCardDetails(dangerouslyGetFullCardDetails);
+  }
 
-    @ReactProp(name = "dangerouslyGetFullCardDetails")
-    fun setDangerouslyGetFullCardDetails(view: StripeSdkCardView, dangerouslyGetFullCardDetails: Boolean = false) {
-        view.setDangerouslyGetFullCardDetails(dangerouslyGetFullCardDetails);
-    }
+  @ReactProp(name = "postalCodeEnabled")
+  fun setPostalCodeEnabled(view: StripeSdkCardView, postalCodeEnabled: Boolean = true) {
+    view.setPostalCodeEnabled(postalCodeEnabled);
+  }
 
-    @ReactProp(name = "postalCodeEnabled")
-    fun setPostalCodeEnabled(view: StripeSdkCardView, postalCodeEnabled: Boolean = true) {
-        view.setPostalCodeEnabled(postalCodeEnabled);
-    }
+  @ReactProp(name = "autofocus")
+  fun setAutofocus(view: StripeSdkCardView, autofocus: Boolean = false) {
+    view.setAutofocus(autofocus);
+  }
 
-    @ReactProp(name = "autofocus")
-    fun setAutofocus(view: StripeSdkCardView, autofocus: Boolean = false) {
-        view.setAutofocus(autofocus);
-    }
+  @ReactProp(name = "cardStyle")
+  fun setCardStyle(view: StripeSdkCardView, cardStyle: ReadableMap) {
+    view.setCardStyle(cardStyle);
+  }
 
-    @ReactProp(name = "cardStyle")
-    fun setCardStyle(view: StripeSdkCardView, cardStyle: ReadableMap) {
-        view.setCardStyle(cardStyle);
-    }
+  @ReactProp(name = "placeholder")
+  fun setPlaceHolders(view: StripeSdkCardView, placeholder: ReadableMap) {
+    view.setPlaceHolders(placeholder);
+  }
 
-    @ReactProp(name = "placeholder")
-    fun setPlaceHolders(view: StripeSdkCardView, placeholder: ReadableMap) {
-        view.setPlaceHolders(placeholder);
-    }
-
-    override fun createViewInstance(reactContext: ThemedReactContext): StripeSdkCardView {
-        // as it's reasonable we handle only one CardField component on the same screen
-        // TODO: temporary commented out due to android state persistence and improper behavior after app reload
+  override fun createViewInstance(reactContext: ThemedReactContext): StripeSdkCardView {
+    // as it's reasonable we handle only one CardField component on the same screen
+    // TODO: temporary commented out due to android state persistence and improper behavior after app reload
 //    if (cardViewInstanceMap[CARD_FIELD_INSTANCE_NAME] != null) {
 //      val exceptionManager = reactContext.getNativeModule(ExceptionsManagerModule::class.java)
 //      val error: WritableMap = WritableNativeMap()
@@ -63,20 +63,20 @@ class StripeSdkCardViewManager : SimpleViewManager<StripeSdkCardView>() {
 //      exceptionManager?.reportException(error)
 //    }
 
-        cardViewInstanceMap[CARD_FIELD_INSTANCE_NAME] = StripeSdkCardView(reactContext)
-        return cardViewInstanceMap[CARD_FIELD_INSTANCE_NAME] as StripeSdkCardView
-    }
+    cardViewInstanceMap[CARD_FIELD_INSTANCE_NAME] = StripeSdkCardView(reactContext)
+    return cardViewInstanceMap[CARD_FIELD_INSTANCE_NAME] as StripeSdkCardView
+  }
 
-    override fun onDropViewInstance(view: StripeSdkCardView) {
-        super.onDropViewInstance(view)
+  override fun onDropViewInstance(view: StripeSdkCardView) {
+    super.onDropViewInstance(view)
 
-        this.cardViewInstanceMap[CARD_FIELD_INSTANCE_NAME] = null
-    }
+    this.cardViewInstanceMap[CARD_FIELD_INSTANCE_NAME] = null
+  }
 
-    fun getCardViewInstance(): StripeSdkCardView? {
-        if (cardViewInstanceMap[CARD_FIELD_INSTANCE_NAME] != null) {
-            return cardViewInstanceMap[CARD_FIELD_INSTANCE_NAME] as StripeSdkCardView
-        }
-        return null
+  fun getCardViewInstance(): StripeSdkCardView? {
+    if (cardViewInstanceMap[CARD_FIELD_INSTANCE_NAME] != null) {
+      return cardViewInstanceMap[CARD_FIELD_INSTANCE_NAME] as StripeSdkCardView
     }
+    return null
+  }
 }

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -263,7 +263,7 @@ PODS:
     - React-Core
   - Stripe (21.6.0):
     - Stripe/Stripe3DS2 (= 21.6.0)
-  - stripe-react-native (0.1.2):
+  - stripe-react-native (0.1.4):
     - React
     - Stripe (~> 21.6.0)
   - Stripe/Stripe3DS2 (21.6.0)
@@ -417,7 +417,7 @@ SPEC CHECKSUMS:
   RNReanimated: e03f7425cb7a38dcf1b644d680d1bfc91c3337ad
   RNScreens: 2ad555d4d9fa10b91bb765ca07fe9b29d59573f0
   Stripe: 6cc7bb348f4b1fad111129f6ee40eb6682deaefb
-  stripe-react-native: c0d6639ec0c1642655166d75d34881dca7a464b6
+  stripe-react-native: 86469904cad7d2a2e07f38f5d10c003048d5d6fc
   Yoga: 4bd86afe9883422a7c4028c00e34790f560923d6
 
 PODFILE CHECKSUM: 0f58dfe67906daa74ee6ff868f720d3c1014bac9

--- a/example/src/components/PaymentScreen.tsx
+++ b/example/src/components/PaymentScreen.tsx
@@ -34,7 +34,7 @@ const PaymentScreen: React.FC<Props> = ({ paymentMethod, children }) => {
     <ScrollView
       accessibilityLabel="payment-screen"
       style={styles.container}
-      keyboardShouldPersistTaps="never"
+      keyboardShouldPersistTaps="always"
     >
       {children}
       {/* eslint-disable-next-line react-native/no-inline-styles */}

--- a/example/src/components/PaymentScreen.tsx
+++ b/example/src/components/PaymentScreen.tsx
@@ -1,4 +1,4 @@
-import { initStripe, StripeContainer } from '@stripe/stripe-react-native';
+import { initStripe } from '@stripe/stripe-react-native';
 import React, { useEffect, useState } from 'react';
 import { ActivityIndicator, ScrollView, StyleSheet, Text } from 'react-native';
 import { colors } from '../colors';
@@ -31,17 +31,15 @@ const PaymentScreen: React.FC<Props> = ({ paymentMethod, children }) => {
   return loading ? (
     <ActivityIndicator size="large" style={StyleSheet.absoluteFill} />
   ) : (
-    <StripeContainer keyboardShouldPersistTaps={false}>
-      <ScrollView
-        accessibilityLabel="payment-screen"
-        style={styles.container}
-        keyboardShouldPersistTaps="handled"
-      >
-        {children}
-        {/* eslint-disable-next-line react-native/no-inline-styles */}
-        <Text style={{ opacity: 0 }}>appium fix</Text>
-      </ScrollView>
-    </StripeContainer>
+    <ScrollView
+      accessibilityLabel="payment-screen"
+      style={styles.container}
+      keyboardShouldPersistTaps="never"
+    >
+      {children}
+      {/* eslint-disable-next-line react-native/no-inline-styles */}
+      <Text style={{ opacity: 0 }}>appium fix</Text>
+    </ScrollView>
   );
 };
 

--- a/ios/CardFieldManager.m
+++ b/ios/CardFieldManager.m
@@ -10,4 +10,7 @@ RCT_EXPORT_VIEW_PROPERTY(cardStyle, NSDictionary)
 RCT_EXPORT_VIEW_PROPERTY(placeholder, NSDictionary)
 RCT_EXPORT_VIEW_PROPERTY(autofocus, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(dangerouslyGetFullCardDetails, BOOL)
+RCT_EXTERN_METHOD(focus:(nonnull NSNumber*) reactTag)
+RCT_EXTERN_METHOD(blur:(nonnull NSNumber*) reactTag)
+RCT_EXTERN_METHOD(clear:(nonnull NSNumber*) reactTag)
 @end

--- a/ios/CardFieldManager.swift
+++ b/ios/CardFieldManager.swift
@@ -2,51 +2,51 @@ import Foundation
 
 @objc(CardFieldManager)
 class CardFieldManager: RCTViewManager, CardFieldDelegate {
-  public let cardFieldMap: NSMutableDictionary = [:]
-  
-  func onDidCreateViewInstance(id: String, reference: Any?) -> Void {
-    cardFieldMap[id] = reference
-  }
-  
-  func onDidDestroyViewInstance(id: String) {
-    cardFieldMap[id] = nil
-  }
-  
-  public func getCardFieldReference(id: String) -> Any? {
-    return self.cardFieldMap[id]
-  }
-  
-  override func view() -> UIView! {
-    // as it's reasonable we handle only one CardField component on the same screen
-    if (cardFieldMap[CARD_FIELD_INSTANCE_ID] != nil) {
-      // TODO: throw an exception
+    public let cardFieldMap: NSMutableDictionary = [:]
+    
+    func onDidCreateViewInstance(id: String, reference: Any?) -> Void {
+        cardFieldMap[id] = reference
     }
-    return CardFieldView(delegate: self)
-  }
-  
-  
-  @objc func focus(_ reactTag: NSNumber) {
-    self.bridge!.uiManager.addUIBlock { (_: RCTUIManager?, viewRegistry: [NSNumber: UIView]?) in
-      let view: CardFieldView = (viewRegistry![reactTag] as? CardFieldView)!
-      view.focus()
+    
+    func onDidDestroyViewInstance(id: String) {
+        cardFieldMap[id] = nil
     }
-  }
-  
-  @objc func blur(_ reactTag: NSNumber) {
-    self.bridge!.uiManager.addUIBlock { (_: RCTUIManager?, viewRegistry: [NSNumber: UIView]?) in
-      let view: CardFieldView = (viewRegistry![reactTag] as? CardFieldView)!
-      view.blur()
+    
+    public func getCardFieldReference(id: String) -> Any? {
+        return self.cardFieldMap[id]
     }
-  }
-  
-  @objc func clear(_ reactTag: NSNumber) {
-    self.bridge!.uiManager.addUIBlock { (_: RCTUIManager?, viewRegistry: [NSNumber: UIView]?) in
-      let view: CardFieldView = (viewRegistry![reactTag] as? CardFieldView)!
-      view.clear()
+    
+    override func view() -> UIView! {
+        // as it's reasonable we handle only one CardField component on the same screen
+        if (cardFieldMap[CARD_FIELD_INSTANCE_ID] != nil) {
+            // TODO: throw an exception
+        }
+        return CardFieldView(delegate: self)
     }
-  }
-  
-  override class func requiresMainQueueSetup() -> Bool {
-    return false
-  }
+    
+    
+    @objc func focus(_ reactTag: NSNumber) {
+        self.bridge!.uiManager.addUIBlock { (_: RCTUIManager?, viewRegistry: [NSNumber: UIView]?) in
+            let view: CardFieldView = (viewRegistry![reactTag] as? CardFieldView)!
+            view.focus()
+        }
+    }
+    
+    @objc func blur(_ reactTag: NSNumber) {
+        self.bridge!.uiManager.addUIBlock { (_: RCTUIManager?, viewRegistry: [NSNumber: UIView]?) in
+            let view: CardFieldView = (viewRegistry![reactTag] as? CardFieldView)!
+            view.blur()
+        }
+    }
+    
+    @objc func clear(_ reactTag: NSNumber) {
+        self.bridge!.uiManager.addUIBlock { (_: RCTUIManager?, viewRegistry: [NSNumber: UIView]?) in
+            let view: CardFieldView = (viewRegistry![reactTag] as? CardFieldView)!
+            view.clear()
+        }
+    }
+    
+    override class func requiresMainQueueSetup() -> Bool {
+        return false
+    }
 }

--- a/ios/CardFieldManager.swift
+++ b/ios/CardFieldManager.swift
@@ -2,29 +2,51 @@ import Foundation
 
 @objc(CardFieldManager)
 class CardFieldManager: RCTViewManager, CardFieldDelegate {
-    public let cardFieldMap: NSMutableDictionary = [:]
-
-    func onDidCreateViewInstance(id: String, reference: Any?) -> Void {
-        cardFieldMap[id] = reference
+  public let cardFieldMap: NSMutableDictionary = [:]
+  
+  func onDidCreateViewInstance(id: String, reference: Any?) -> Void {
+    cardFieldMap[id] = reference
+  }
+  
+  func onDidDestroyViewInstance(id: String) {
+    cardFieldMap[id] = nil
+  }
+  
+  public func getCardFieldReference(id: String) -> Any? {
+    return self.cardFieldMap[id]
+  }
+  
+  override func view() -> UIView! {
+    // as it's reasonable we handle only one CardField component on the same screen
+    if (cardFieldMap[CARD_FIELD_INSTANCE_ID] != nil) {
+      // TODO: throw an exception
     }
-    
-    func onDidDestroyViewInstance(id: String) {
-        cardFieldMap[id] = nil
+    return CardFieldView(delegate: self)
+  }
+  
+  
+  @objc func focus(_ reactTag: NSNumber) {
+    self.bridge!.uiManager.addUIBlock { (_: RCTUIManager?, viewRegistry: [NSNumber: UIView]?) in
+      let view: CardFieldView = (viewRegistry![reactTag] as? CardFieldView)!
+      view.focus()
     }
-        
-    public func getCardFieldReference(id: String) -> Any? {
-        return self.cardFieldMap[id]
+  }
+  
+  @objc func blur(_ reactTag: NSNumber) {
+    self.bridge!.uiManager.addUIBlock { (_: RCTUIManager?, viewRegistry: [NSNumber: UIView]?) in
+      let view: CardFieldView = (viewRegistry![reactTag] as? CardFieldView)!
+      view.blur()
     }
-    
-    override func view() -> UIView! {
-        // as it's reasonable we handle only one CardField component on the same screen
-        if (cardFieldMap[CARD_FIELD_INSTANCE_ID] != nil) {
-         // TODO: throw an exception
-        }
-        return CardFieldView(delegate: self)
+  }
+  
+  @objc func clear(_ reactTag: NSNumber) {
+    self.bridge!.uiManager.addUIBlock { (_: RCTUIManager?, viewRegistry: [NSNumber: UIView]?) in
+      let view: CardFieldView = (viewRegistry![reactTag] as? CardFieldView)!
+      view.clear()
     }
-        
-    override class func requiresMainQueueSetup() -> Bool {
-        return false
-    }
+  }
+  
+  override class func requiresMainQueueSetup() -> Bool {
+    return false
+  }
 }

--- a/ios/CardFieldView.swift
+++ b/ios/CardFieldView.swift
@@ -5,186 +5,186 @@ import Stripe
 let CARD_FIELD_INSTANCE_ID = "CardFieldInstance"
 
 class CardFieldView: UIView, STPPaymentCardTextFieldDelegate {
-  @objc var onCardChange: RCTDirectEventBlock?
-  @objc var onFocusChange: RCTDirectEventBlock?
-  @objc var dangerouslyGetFullCardDetails: Bool = false
-  
-  private var cardField = STPPaymentCardTextField()
-  
-  public var cardParams: STPPaymentMethodCardParams? = nil
-  
-  public var delegate: CardFieldDelegate?
-  
-  @objc var postalCodeEnabled: Bool = true {
-    didSet {
-      cardField.postalCodeEntryEnabled = postalCodeEnabled
-    }
-  }
-  
-  @objc var placeholder: NSDictionary = NSDictionary() {
-    didSet {
-      if let numberPlaceholder = placeholder["number"] as? String {
-        cardField.numberPlaceholder = numberPlaceholder
-      } else {
-        cardField.numberPlaceholder = "1234123412341234"
-      }
-      if let expirationPlaceholder = placeholder["expiration"] as? String {
-        cardField.expirationPlaceholder = expirationPlaceholder
-      }
-      if let cvcPlaceholder = placeholder["cvc"] as? String {
-        cardField.cvcPlaceholder = cvcPlaceholder
-      }
-      if let postalCodePlaceholder = placeholder["postalCode"] as? String {
-        cardField.postalCodePlaceholder = postalCodePlaceholder
-      }
-    }
-  }
-  
-  @objc var autofocus: Bool = false {
-    didSet {
-      if autofocus == true {
-        cardField.reactFocus()
-      }
-    }
-  }
-  
-  @objc var cardStyle: NSDictionary = NSDictionary() {
-    didSet {
-      if let borderWidth = cardStyle["borderWidth"] as? Int {
-        cardField.borderWidth = CGFloat(borderWidth)
-      } else {
-        cardField.borderWidth = CGFloat(0)
-      }
-      if let backgroundColor = cardStyle["backgroundColor"] as? String {
-        cardField.backgroundColor = UIColor(hexString: backgroundColor)
-      }
-      if let borderColor = cardStyle["borderColor"] as? String {
-        cardField.borderColor = UIColor(hexString: borderColor)
-      }
-      if let borderRadius = cardStyle["borderRadius"] as? Int {
-        cardField.cornerRadius = CGFloat(borderRadius)
-      }
-      if let cursorColor = cardStyle["cursorColor"] as? String {
-        cardField.cursorColor = UIColor(hexString: cursorColor)
-      }
-      if let textColor = cardStyle["textColor"] as? String {
-        cardField.textColor = UIColor(hexString: textColor)
-      }
-      if let textErrorColor = cardStyle["textErrorColor"] as? String {
-        cardField.textErrorColor = UIColor(hexString: textErrorColor)
-      }
-      let fontSize = cardStyle["fontSize"] as? Int ?? 14
-      
-      if let fontFamily = cardStyle["fontFamily"] as? String {
-        cardField.font = UIFont(name: fontFamily, size: CGFloat(fontSize)) ?? UIFont.systemFont(ofSize: CGFloat(fontSize))
-      } else {
-        if let fontSize = cardStyle["fontSize"] as? Int {
-          cardField.font = UIFont.systemFont(ofSize: CGFloat(fontSize))
+    @objc var onCardChange: RCTDirectEventBlock?
+    @objc var onFocusChange: RCTDirectEventBlock?
+    @objc var dangerouslyGetFullCardDetails: Bool = false
+    
+    private var cardField = STPPaymentCardTextField()
+    
+    public var cardParams: STPPaymentMethodCardParams? = nil
+    
+    public var delegate: CardFieldDelegate?
+    
+    @objc var postalCodeEnabled: Bool = true {
+        didSet {
+            cardField.postalCodeEntryEnabled = postalCodeEnabled
         }
-      }
-      if let placeholderColor = cardStyle["placeholderColor"] as? String {
-        cardField.placeholderColor = UIColor(hexString: placeholderColor)
-      }
     }
-  }
-  
-  override init(frame: CGRect) {
-    super.init(frame: frame)
-    cardField.delegate = self
     
-    self.addSubview(cardField)
-  }
-  
-  convenience init(delegate: CardFieldDelegate) {
-    self.init(frame: CGRect.zero)
-    self.delegate = delegate
+    @objc var placeholder: NSDictionary = NSDictionary() {
+        didSet {
+            if let numberPlaceholder = placeholder["number"] as? String {
+                cardField.numberPlaceholder = numberPlaceholder
+            } else {
+                cardField.numberPlaceholder = "1234123412341234"
+            }
+            if let expirationPlaceholder = placeholder["expiration"] as? String {
+                cardField.expirationPlaceholder = expirationPlaceholder
+            }
+            if let cvcPlaceholder = placeholder["cvc"] as? String {
+                cardField.cvcPlaceholder = cvcPlaceholder
+            }
+            if let postalCodePlaceholder = placeholder["postalCode"] as? String {
+                cardField.postalCodePlaceholder = postalCodePlaceholder
+            }
+        }
+    }
     
-    self.delegate?.onDidCreateViewInstance(id: CARD_FIELD_INSTANCE_ID, reference: self)
-  }
-
-  func focus() {
-    cardField.becomeFirstResponder()
-  }
-  
-  func blur() {
-    cardField.resignFirstResponder()
-  }
-  
-  func clear() {
-    cardField.clear()
-  }
-  
-  override func removeFromSuperview() {
-    self.delegate?.onDidDestroyViewInstance(id: CARD_FIELD_INSTANCE_ID)
-  }
-  
-  func paymentCardTextFieldDidEndEditing(_ textField: STPPaymentCardTextField) {
-    onFocusChange?(["focusedField": NSNull()])
-  }
-  
-  func paymentCardTextFieldDidBeginEditingNumber(_ textField: STPPaymentCardTextField) {
-    onFocusChange?(["focusedField": "CardNumber"])
-  }
-  
-  func paymentCardTextFieldDidBeginEditingCVC(_ textField: STPPaymentCardTextField) {
-    onFocusChange?(["focusedField": "Cvc"])
-  }
-  
-  func paymentCardTextFieldDidBeginEditingExpiration(_ textField: STPPaymentCardTextField) {
-    onFocusChange?(["focusedField": "ExpiryDate"])
-  }
-  
-  func paymentCardTextFieldDidBeginEditingPostalCode(_ textField: STPPaymentCardTextField) {
-    onFocusChange?(["focusedField": "PostalCode"])
-  }
-  
-  func paymentCardTextFieldDidChange(_ textField: STPPaymentCardTextField) {
-    if onCardChange != nil {
-      let brand = STPCardValidator.brand(forNumber: textField.cardParams.number ?? "")
-      var cardData: [String: Any?] = [
-        "expiryMonth": textField.cardParams.expMonth ?? NSNull(),
-        "expiryYear": textField.cardParams.expYear ?? NSNull(),
-        "complete": textField.isValid,
-        "brand": Mappers.mapCardBrand(brand) ?? NSNull(),
-        "last4": textField.cardParams.last4 ?? ""
-      ]
-      if (cardField.postalCodeEntryEnabled) {
-        cardData["postalCode"] = textField.postalCode ?? ""
-      }
-      if (dangerouslyGetFullCardDetails) {
-        cardData["number"] = textField.cardParams.number ?? ""
-      }
-      onCardChange!(cardData as [AnyHashable : Any])
+    @objc var autofocus: Bool = false {
+        didSet {
+            if autofocus == true {
+                cardField.reactFocus()
+            }
+        }
     }
-    if (textField.isValid) {
-      self.cardParams = textField.cardParams
-    } else {
-      self.cardParams = nil
+    
+    @objc var cardStyle: NSDictionary = NSDictionary() {
+        didSet {
+            if let borderWidth = cardStyle["borderWidth"] as? Int {
+                cardField.borderWidth = CGFloat(borderWidth)
+            } else {
+                cardField.borderWidth = CGFloat(0)
+            }
+            if let backgroundColor = cardStyle["backgroundColor"] as? String {
+                cardField.backgroundColor = UIColor(hexString: backgroundColor)
+            }
+            if let borderColor = cardStyle["borderColor"] as? String {
+                cardField.borderColor = UIColor(hexString: borderColor)
+            }
+            if let borderRadius = cardStyle["borderRadius"] as? Int {
+                cardField.cornerRadius = CGFloat(borderRadius)
+            }
+            if let cursorColor = cardStyle["cursorColor"] as? String {
+                cardField.cursorColor = UIColor(hexString: cursorColor)
+            }
+            if let textColor = cardStyle["textColor"] as? String {
+                cardField.textColor = UIColor(hexString: textColor)
+            }
+            if let textErrorColor = cardStyle["textErrorColor"] as? String {
+                cardField.textErrorColor = UIColor(hexString: textErrorColor)
+            }
+            let fontSize = cardStyle["fontSize"] as? Int ?? 14
+            
+            if let fontFamily = cardStyle["fontFamily"] as? String {
+                cardField.font = UIFont(name: fontFamily, size: CGFloat(fontSize)) ?? UIFont.systemFont(ofSize: CGFloat(fontSize))
+            } else {
+                if let fontSize = cardStyle["fontSize"] as? Int {
+                    cardField.font = UIFont.systemFont(ofSize: CGFloat(fontSize))
+                }
+            }
+            if let placeholderColor = cardStyle["placeholderColor"] as? String {
+                cardField.placeholderColor = UIColor(hexString: placeholderColor)
+            }
+        }
     }
-  }
-  
-  override func layoutSubviews() {
-    cardField.frame = self.bounds
-  }
-  
-  required init?(coder: NSCoder) {
-    fatalError("init(coder:) has not been implemented")
-  }
-  
-  func paymentContext(_ paymentContext: STPPaymentContext, didFailToLoadWithError error: Error) {
-    //
-  }
-  
-  func paymentContextDidChange(_ paymentContext: STPPaymentContext) {
-    //
-  }
-  
-  func paymentContext(_ paymentContext: STPPaymentContext, didCreatePaymentResult paymentResult: STPPaymentResult, completion: @escaping STPPaymentStatusBlock) {
-    //
-  }
-  
-  func paymentContext(_ paymentContext: STPPaymentContext, didFinishWith status: STPPaymentStatus, error: Error?) {
-    //
-  }
-  
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        cardField.delegate = self
+        
+        self.addSubview(cardField)
+    }
+    
+    convenience init(delegate: CardFieldDelegate) {
+        self.init(frame: CGRect.zero)
+        self.delegate = delegate
+        
+        self.delegate?.onDidCreateViewInstance(id: CARD_FIELD_INSTANCE_ID, reference: self)
+    }
+    
+    func focus() {
+        cardField.becomeFirstResponder()
+    }
+    
+    func blur() {
+        cardField.resignFirstResponder()
+    }
+    
+    func clear() {
+        cardField.clear()
+    }
+    
+    override func removeFromSuperview() {
+        self.delegate?.onDidDestroyViewInstance(id: CARD_FIELD_INSTANCE_ID)
+    }
+    
+    func paymentCardTextFieldDidEndEditing(_ textField: STPPaymentCardTextField) {
+        onFocusChange?(["focusedField": NSNull()])
+    }
+    
+    func paymentCardTextFieldDidBeginEditingNumber(_ textField: STPPaymentCardTextField) {
+        onFocusChange?(["focusedField": "CardNumber"])
+    }
+    
+    func paymentCardTextFieldDidBeginEditingCVC(_ textField: STPPaymentCardTextField) {
+        onFocusChange?(["focusedField": "Cvc"])
+    }
+    
+    func paymentCardTextFieldDidBeginEditingExpiration(_ textField: STPPaymentCardTextField) {
+        onFocusChange?(["focusedField": "ExpiryDate"])
+    }
+    
+    func paymentCardTextFieldDidBeginEditingPostalCode(_ textField: STPPaymentCardTextField) {
+        onFocusChange?(["focusedField": "PostalCode"])
+    }
+    
+    func paymentCardTextFieldDidChange(_ textField: STPPaymentCardTextField) {
+        if onCardChange != nil {
+            let brand = STPCardValidator.brand(forNumber: textField.cardParams.number ?? "")
+            var cardData: [String: Any?] = [
+                "expiryMonth": textField.cardParams.expMonth ?? NSNull(),
+                "expiryYear": textField.cardParams.expYear ?? NSNull(),
+                "complete": textField.isValid,
+                "brand": Mappers.mapCardBrand(brand) ?? NSNull(),
+                "last4": textField.cardParams.last4 ?? ""
+            ]
+            if (cardField.postalCodeEntryEnabled) {
+                cardData["postalCode"] = textField.postalCode ?? ""
+            }
+            if (dangerouslyGetFullCardDetails) {
+                cardData["number"] = textField.cardParams.number ?? ""
+            }
+            onCardChange!(cardData as [AnyHashable : Any])
+        }
+        if (textField.isValid) {
+            self.cardParams = textField.cardParams
+        } else {
+            self.cardParams = nil
+        }
+    }
+    
+    override func layoutSubviews() {
+        cardField.frame = self.bounds
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    func paymentContext(_ paymentContext: STPPaymentContext, didFailToLoadWithError error: Error) {
+        //
+    }
+    
+    func paymentContextDidChange(_ paymentContext: STPPaymentContext) {
+        //
+    }
+    
+    func paymentContext(_ paymentContext: STPPaymentContext, didCreatePaymentResult paymentResult: STPPaymentResult, completion: @escaping STPPaymentStatusBlock) {
+        //
+    }
+    
+    func paymentContext(_ paymentContext: STPPaymentContext, didFinishWith status: STPPaymentStatus, error: Error?) {
+        //
+    }
+    
 }

--- a/ios/CardFieldView.swift
+++ b/ios/CardFieldView.swift
@@ -5,170 +5,186 @@ import Stripe
 let CARD_FIELD_INSTANCE_ID = "CardFieldInstance"
 
 class CardFieldView: UIView, STPPaymentCardTextFieldDelegate {
-    @objc var onCardChange: RCTDirectEventBlock?
-    @objc var onFocusChange: RCTDirectEventBlock?
-    @objc var dangerouslyGetFullCardDetails: Bool = false
-    
-    private var cardField = STPPaymentCardTextField()
-    
-    public var cardParams: STPPaymentMethodCardParams? = nil
-    
-    public var delegate: CardFieldDelegate?
-    
-    @objc var postalCodeEnabled: Bool = true {
-        didSet {
-            cardField.postalCodeEntryEnabled = postalCodeEnabled
-        }
+  @objc var onCardChange: RCTDirectEventBlock?
+  @objc var onFocusChange: RCTDirectEventBlock?
+  @objc var dangerouslyGetFullCardDetails: Bool = false
+  
+  private var cardField = STPPaymentCardTextField()
+  
+  public var cardParams: STPPaymentMethodCardParams? = nil
+  
+  public var delegate: CardFieldDelegate?
+  
+  @objc var postalCodeEnabled: Bool = true {
+    didSet {
+      cardField.postalCodeEntryEnabled = postalCodeEnabled
     }
+  }
+  
+  @objc var placeholder: NSDictionary = NSDictionary() {
+    didSet {
+      if let numberPlaceholder = placeholder["number"] as? String {
+        cardField.numberPlaceholder = numberPlaceholder
+      } else {
+        cardField.numberPlaceholder = "1234123412341234"
+      }
+      if let expirationPlaceholder = placeholder["expiration"] as? String {
+        cardField.expirationPlaceholder = expirationPlaceholder
+      }
+      if let cvcPlaceholder = placeholder["cvc"] as? String {
+        cardField.cvcPlaceholder = cvcPlaceholder
+      }
+      if let postalCodePlaceholder = placeholder["postalCode"] as? String {
+        cardField.postalCodePlaceholder = postalCodePlaceholder
+      }
+    }
+  }
+  
+  @objc var autofocus: Bool = false {
+    didSet {
+      if autofocus == true {
+        cardField.reactFocus()
+      }
+    }
+  }
+  
+  @objc var cardStyle: NSDictionary = NSDictionary() {
+    didSet {
+      if let borderWidth = cardStyle["borderWidth"] as? Int {
+        cardField.borderWidth = CGFloat(borderWidth)
+      } else {
+        cardField.borderWidth = CGFloat(0)
+      }
+      if let backgroundColor = cardStyle["backgroundColor"] as? String {
+        cardField.backgroundColor = UIColor(hexString: backgroundColor)
+      }
+      if let borderColor = cardStyle["borderColor"] as? String {
+        cardField.borderColor = UIColor(hexString: borderColor)
+      }
+      if let borderRadius = cardStyle["borderRadius"] as? Int {
+        cardField.cornerRadius = CGFloat(borderRadius)
+      }
+      if let cursorColor = cardStyle["cursorColor"] as? String {
+        cardField.cursorColor = UIColor(hexString: cursorColor)
+      }
+      if let textColor = cardStyle["textColor"] as? String {
+        cardField.textColor = UIColor(hexString: textColor)
+      }
+      if let textErrorColor = cardStyle["textErrorColor"] as? String {
+        cardField.textErrorColor = UIColor(hexString: textErrorColor)
+      }
+      let fontSize = cardStyle["fontSize"] as? Int ?? 14
+      
+      if let fontFamily = cardStyle["fontFamily"] as? String {
+        cardField.font = UIFont(name: fontFamily, size: CGFloat(fontSize)) ?? UIFont.systemFont(ofSize: CGFloat(fontSize))
+      } else {
+        if let fontSize = cardStyle["fontSize"] as? Int {
+          cardField.font = UIFont.systemFont(ofSize: CGFloat(fontSize))
+        }
+      }
+      if let placeholderColor = cardStyle["placeholderColor"] as? String {
+        cardField.placeholderColor = UIColor(hexString: placeholderColor)
+      }
+    }
+  }
+  
+  override init(frame: CGRect) {
+    super.init(frame: frame)
+    cardField.delegate = self
+    
+    self.addSubview(cardField)
+  }
+  
+  convenience init(delegate: CardFieldDelegate) {
+    self.init(frame: CGRect.zero)
+    self.delegate = delegate
+    
+    self.delegate?.onDidCreateViewInstance(id: CARD_FIELD_INSTANCE_ID, reference: self)
+  }
 
-    @objc var placeholder: NSDictionary = NSDictionary() {
-        didSet {
-            if let numberPlaceholder = placeholder["number"] as? String {
-                cardField.numberPlaceholder = numberPlaceholder
-            } else {
-                cardField.numberPlaceholder = "1234123412341234"
-            }
-            if let expirationPlaceholder = placeholder["expiration"] as? String {
-                cardField.expirationPlaceholder = expirationPlaceholder
-            }
-            if let cvcPlaceholder = placeholder["cvc"] as? String {
-                cardField.cvcPlaceholder = cvcPlaceholder
-            }
-            if let postalCodePlaceholder = placeholder["postalCode"] as? String {
-                cardField.postalCodePlaceholder = postalCodePlaceholder
-            }
-        }
+  func focus() {
+    cardField.becomeFirstResponder()
+  }
+  
+  func blur() {
+    cardField.resignFirstResponder()
+  }
+  
+  func clear() {
+    cardField.clear()
+  }
+  
+  override func removeFromSuperview() {
+    self.delegate?.onDidDestroyViewInstance(id: CARD_FIELD_INSTANCE_ID)
+  }
+  
+  func paymentCardTextFieldDidEndEditing(_ textField: STPPaymentCardTextField) {
+    onFocusChange?(["focusedField": NSNull()])
+  }
+  
+  func paymentCardTextFieldDidBeginEditingNumber(_ textField: STPPaymentCardTextField) {
+    onFocusChange?(["focusedField": "CardNumber"])
+  }
+  
+  func paymentCardTextFieldDidBeginEditingCVC(_ textField: STPPaymentCardTextField) {
+    onFocusChange?(["focusedField": "Cvc"])
+  }
+  
+  func paymentCardTextFieldDidBeginEditingExpiration(_ textField: STPPaymentCardTextField) {
+    onFocusChange?(["focusedField": "ExpiryDate"])
+  }
+  
+  func paymentCardTextFieldDidBeginEditingPostalCode(_ textField: STPPaymentCardTextField) {
+    onFocusChange?(["focusedField": "PostalCode"])
+  }
+  
+  func paymentCardTextFieldDidChange(_ textField: STPPaymentCardTextField) {
+    if onCardChange != nil {
+      let brand = STPCardValidator.brand(forNumber: textField.cardParams.number ?? "")
+      var cardData: [String: Any?] = [
+        "expiryMonth": textField.cardParams.expMonth ?? NSNull(),
+        "expiryYear": textField.cardParams.expYear ?? NSNull(),
+        "complete": textField.isValid,
+        "brand": Mappers.mapCardBrand(brand) ?? NSNull(),
+        "last4": textField.cardParams.last4 ?? ""
+      ]
+      if (cardField.postalCodeEntryEnabled) {
+        cardData["postalCode"] = textField.postalCode ?? ""
+      }
+      if (dangerouslyGetFullCardDetails) {
+        cardData["number"] = textField.cardParams.number ?? ""
+      }
+      onCardChange!(cardData as [AnyHashable : Any])
     }
-    
-    @objc var autofocus: Bool = false {
-        didSet {
-            if autofocus == true {
-                cardField.reactFocus()
-            }
-        }
+    if (textField.isValid) {
+      self.cardParams = textField.cardParams
+    } else {
+      self.cardParams = nil
     }
-    
-    @objc var cardStyle: NSDictionary = NSDictionary() {
-        didSet {
-            if let borderWidth = cardStyle["borderWidth"] as? Int {
-                cardField.borderWidth = CGFloat(borderWidth)
-            } else {
-                cardField.borderWidth = CGFloat(0)
-            }
-            if let backgroundColor = cardStyle["backgroundColor"] as? String {
-                cardField.backgroundColor = UIColor(hexString: backgroundColor)
-            }
-            if let borderColor = cardStyle["borderColor"] as? String {
-                cardField.borderColor = UIColor(hexString: borderColor)
-            }
-            if let borderRadius = cardStyle["borderRadius"] as? Int {
-                cardField.cornerRadius = CGFloat(borderRadius)
-            }
-            if let cursorColor = cardStyle["cursorColor"] as? String {
-                cardField.cursorColor = UIColor(hexString: cursorColor)
-            }
-            if let textColor = cardStyle["textColor"] as? String {
-                cardField.textColor = UIColor(hexString: textColor)
-            }
-            if let textErrorColor = cardStyle["textErrorColor"] as? String {
-                cardField.textErrorColor = UIColor(hexString: textErrorColor)
-            }
-            let fontSize = cardStyle["fontSize"] as? Int ?? 14
-
-            if let fontFamily = cardStyle["fontFamily"] as? String {
-                cardField.font = UIFont(name: fontFamily, size: CGFloat(fontSize)) ?? UIFont.systemFont(ofSize: CGFloat(fontSize))
-            } else {
-                if let fontSize = cardStyle["fontSize"] as? Int {
-                    cardField.font = UIFont.systemFont(ofSize: CGFloat(fontSize))
-                }
-            }
-            if let placeholderColor = cardStyle["placeholderColor"] as? String {
-                cardField.placeholderColor = UIColor(hexString: placeholderColor)
-            }
-        }
-    }
-    
-    override init(frame: CGRect) {
-        super.init(frame: frame)
-        cardField.delegate = self
-
-        self.addSubview(cardField)
-    }
-    
-    convenience init(delegate: CardFieldDelegate) {
-        self.init(frame: CGRect.zero)
-        self.delegate = delegate
-        
-        self.delegate?.onDidCreateViewInstance(id: CARD_FIELD_INSTANCE_ID, reference: self)
-    }
-    
-    override func removeFromSuperview() {
-        self.delegate?.onDidDestroyViewInstance(id: CARD_FIELD_INSTANCE_ID)
-    }
-    
-    func paymentCardTextFieldDidBeginEditingNumber(_ textField: STPPaymentCardTextField) {
-        onFocusChange?(["focusedField": "CardNumber"])
-    }
-    
-    func paymentCardTextFieldDidBeginEditingCVC(_ textField: STPPaymentCardTextField) {
-        onFocusChange?(["focusedField": "Cvc"])
-    }
-    
-    func paymentCardTextFieldDidBeginEditingExpiration(_ textField: STPPaymentCardTextField) {
-        onFocusChange?(["focusedField": "ExpiryDate"])
-    }
-    
-    func paymentCardTextFieldDidBeginEditingPostalCode(_ textField: STPPaymentCardTextField) {
-        onFocusChange?(["focusedField": "PostalCode"])
-    }
-    
-    func paymentCardTextFieldDidChange(_ textField: STPPaymentCardTextField) {
-        if onCardChange != nil {
-            let brand = STPCardValidator.brand(forNumber: textField.cardParams.number ?? "")
-            var cardData: [String: Any?] = [
-                "expiryMonth": textField.cardParams.expMonth ?? NSNull(),
-                "expiryYear": textField.cardParams.expYear ?? NSNull(),
-                "complete": textField.isValid,
-                "brand": Mappers.mapCardBrand(brand) ?? NSNull(),
-                "last4": textField.cardParams.last4 ?? ""
-            ]
-            if (cardField.postalCodeEntryEnabled) {
-                cardData["postalCode"] = textField.postalCode ?? ""
-            }
-            if (dangerouslyGetFullCardDetails) {
-                cardData["number"] = textField.cardParams.number ?? ""
-            }
-            onCardChange!(cardData as [AnyHashable : Any])
-        }
-        if (textField.isValid) {
-            self.cardParams = textField.cardParams
-        } else {
-            self.cardParams = nil
-        }
-    }
-    
-    override func layoutSubviews() {
-        cardField.frame = self.bounds
-    }
-    
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-    
-    func paymentContext(_ paymentContext: STPPaymentContext, didFailToLoadWithError error: Error) {
-        //
-    }
-    
-    func paymentContextDidChange(_ paymentContext: STPPaymentContext) {
-        //
-    }
-    
-    func paymentContext(_ paymentContext: STPPaymentContext, didCreatePaymentResult paymentResult: STPPaymentResult, completion: @escaping STPPaymentStatusBlock) {
-        //
-    }
-    
-    func paymentContext(_ paymentContext: STPPaymentContext, didFinishWith status: STPPaymentStatus, error: Error?) {
-        //
-    }
-    
+  }
+  
+  override func layoutSubviews() {
+    cardField.frame = self.bounds
+  }
+  
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  func paymentContext(_ paymentContext: STPPaymentContext, didFailToLoadWithError error: Error) {
+    //
+  }
+  
+  func paymentContextDidChange(_ paymentContext: STPPaymentContext) {
+    //
+  }
+  
+  func paymentContext(_ paymentContext: STPPaymentContext, didCreatePaymentResult paymentResult: STPPaymentResult, completion: @escaping STPPaymentStatusBlock) {
+    //
+  }
+  
+  func paymentContext(_ paymentContext: STPPaymentContext, didFinishWith status: STPPaymentStatus, error: Error?) {
+    //
+  }
+  
 }

--- a/ios/StripeSdk.swift
+++ b/ios/StripeSdk.swift
@@ -599,6 +599,7 @@ class StripeSdk: RCTEventEmitter, STPApplePayContextDelegate, STPBankSelectionVi
                 paymentMethodOptions = try factory.createOptions(paymentMethodType: paymentMethodType)
             } catch  {
                 resolve(Errors.createError(ConfirmPaymentErrorType.Failed.rawValue, error.localizedDescription))
+                return
             }
             guard paymentMethodParams != nil else {
                 resolve(Errors.createError(ConfirmPaymentErrorType.Unknown.rawValue, "Unhandled error occured"))

--- a/src/types/components/CardFieldInput.ts
+++ b/src/types/components/CardFieldInput.ts
@@ -54,4 +54,10 @@ export namespace CardFieldInput {
     cardStyle?: Styles;
     placeholder?: Placeholders;
   }
+
+  export interface Methods {
+    focus(): void;
+    blur(): void;
+    clear(): void;
+  }
 }


### PR DESCRIPTION
- expose CardField methods (focus, blur, clear)
- inject CardField reference to react-native InputState so the state of card field input can be handled via RN components like ScrollView

There is no need to use `StripeContainer` anymore since it's registered to RN InputState.

auto keyboard state example:
```
<ScrollView
      keyboardShouldPersistTaps="never" // <-- add this line 
>
      {children}
 </ScrollView>
```

example of methods usage:

```
// App.js

const ref = useRef(null)

const handleFocus = () => {
    ref.current.focus()
}

const handleBlur = () => {
    ref.current.blur()
}

const handleClear = () => {
    ref.current.clear()
}

return (
 <CardField
        ref={ref}
  />
)
```