### PR TITLE
chore: rename confirmPaymentMethod to confirmPayment

### DIFF
--- a/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
+++ b/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
@@ -407,7 +407,7 @@ class StripeSdkModule(reactContext: ReactApplicationContext, cardFieldManager: S
   }
 
   @ReactMethod
-  fun confirmPaymentMethod(paymentIntentClientSecret: String, params: ReadableMap, options: ReadableMap, promise: Promise) {
+  fun confirmPayment(paymentIntentClientSecret: String, params: ReadableMap, options: ReadableMap, promise: Promise) {
     confirmPromise = promise
     confirmPaymentClientSecret = paymentIntentClientSecret
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -263,7 +263,7 @@ PODS:
     - React-Core
   - Stripe (21.6.0):
     - Stripe/Stripe3DS2 (= 21.6.0)
-  - stripe-react-native (0.1.2):
+  - stripe-react-native (0.1.4):
     - React
     - Stripe (~> 21.6.0)
   - Stripe/Stripe3DS2 (21.6.0)
@@ -417,7 +417,7 @@ SPEC CHECKSUMS:
   RNReanimated: e03f7425cb7a38dcf1b644d680d1bfc91c3337ad
   RNScreens: 2ad555d4d9fa10b91bb765ca07fe9b29d59573f0
   Stripe: 6cc7bb348f4b1fad111129f6ee40eb6682deaefb
-  stripe-react-native: c0d6639ec0c1642655166d75d34881dca7a464b6
+  stripe-react-native: 86469904cad7d2a2e07f38f5d10c003048d5d6fc
   Yoga: 4bd86afe9883422a7c4028c00e34790f560923d6
 
 PODFILE CHECKSUM: 0f58dfe67906daa74ee6ff868f720d3c1014bac9

--- a/ios/StripeSdk.m
+++ b/ios/StripeSdk.m
@@ -89,7 +89,7 @@ RCT_EXTERN_METHOD(
                   )
 
 RCT_EXTERN_METHOD(
-                  confirmPaymentMethod:(NSString *)paymentIntentClientSecret
+                  confirmPayment:(NSString *)paymentIntentClientSecret
                   data:(NSDictionary *)data
                   options:(NSDictionary *)options
                   resolver: (RCTPromiseResolveBlock)resolve

--- a/ios/StripeSdk.swift
+++ b/ios/StripeSdk.swift
@@ -550,8 +550,8 @@ class StripeSdk: RCTEventEmitter, STPApplePayContextDelegate, STPBankSelectionVi
         }
     }
     
-    @objc(confirmPaymentMethod:data:options:resolver:rejecter:)
-    func confirmPaymentMethod(
+    @objc(confirmPayment:data:options:resolver:rejecter:)
+    func confirmPayment(
         paymentIntentClientSecret: String,
         params: NSDictionary,
         options: NSDictionary,

--- a/src/NativeStripeSdk.tsx
+++ b/src/NativeStripeSdk.tsx
@@ -8,7 +8,7 @@ import type {
   CreatePaymentMethodResult,
   RetrievePaymentIntentResult,
   RetrieveSetupIntentResult,
-  ConfirmPaymentMethodResult,
+  ConfirmPaymentResult,
   HandleCardActionResult,
   ConfirmSetupIntentResult,
   CreateTokenForCVCUpdateResult,
@@ -28,11 +28,11 @@ type NativeStripeSdkType = {
   handleCardAction(
     paymentIntentClientSecret: string
   ): Promise<HandleCardActionResult>;
-  confirmPaymentMethod(
+  confirmPayment(
     paymentIntentClientSecret: string,
     data: PaymentMethodCreateParams.Params,
     options: PaymentMethodCreateParams.Options
-  ): Promise<ConfirmPaymentMethodResult>;
+  ): Promise<ConfirmPaymentResult>;
   isApplePaySupported(): Promise<boolean>;
   presentApplePay(params: ApplePay.PresentParams): Promise<ApplePayResult>;
   confirmApplePayPayment(clientSecret: string): Promise<void>;

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -4,7 +4,7 @@ import {
   ApplePay,
   ApplePayError,
   ApplePayResult,
-  ConfirmPaymentMethodResult,
+  ConfirmPaymentResult,
   ConfirmPaymentSheetPaymentResult,
   ConfirmSetupIntent,
   ConfirmSetupIntentResult,
@@ -109,13 +109,13 @@ export const retrieveSetupIntent = async (
   }
 };
 
-export const confirmPaymentMethod = async (
+export const confirmPayment = async (
   paymentIntentClientSecret: string,
   data: PaymentMethodCreateParams.Params,
   options: PaymentMethodCreateParams.Options = {}
-): Promise<ConfirmPaymentMethodResult> => {
+): Promise<ConfirmPaymentResult> => {
   try {
-    const { paymentIntent, error } = await NativeStripeSdk.confirmPaymentMethod(
+    const { paymentIntent, error } = await NativeStripeSdk.confirmPayment(
       paymentIntentClientSecret,
       data,
       options

--- a/src/hooks/useConfirmPayment.tsx
+++ b/src/hooks/useConfirmPayment.tsx
@@ -7,9 +7,9 @@ import { useStripe } from './useStripe';
  */
 export function useConfirmPayment() {
   const [loading, setLoading] = useState(false);
-  const { confirmPayment: confirmPaymentMethod } = useStripe();
+  const { confirmPayment } = useStripe();
 
-  const confirmPayment = useCallback(
+  const _confirmPayment = useCallback(
     async (
       paymentIntentClientSecret: string,
       data: PaymentMethodCreateParams.Params,
@@ -17,7 +17,7 @@ export function useConfirmPayment() {
     ) => {
       setLoading(true);
 
-      const result = await confirmPaymentMethod(
+      const result = await confirmPayment(
         paymentIntentClientSecret,
         data,
         options
@@ -27,11 +27,11 @@ export function useConfirmPayment() {
 
       return result;
     },
-    [confirmPaymentMethod]
+    [confirmPayment]
   );
 
   return {
-    confirmPayment,
+    confirmPayment: _confirmPayment,
     loading,
   };
 }

--- a/src/hooks/useStripe.tsx
+++ b/src/hooks/useStripe.tsx
@@ -5,7 +5,7 @@ import type {
   CreatePaymentMethodResult,
   RetrievePaymentIntentResult,
   RetrieveSetupIntentResult,
-  ConfirmPaymentMethodResult,
+  ConfirmPaymentResult,
   HandleCardActionResult,
   ConfirmSetupIntentResult,
   CreateTokenForCVCUpdateResult,
@@ -23,7 +23,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { isiOS } from '../helpers';
 import NativeStripeSdk from '../NativeStripeSdk';
 import {
-  confirmPaymentMethod,
+  confirmPayment,
   createPaymentMethod,
   retrievePaymentIntent,
   retrieveSetupIntent,
@@ -87,13 +87,13 @@ export function useStripe() {
     []
   );
 
-  const _confirmPaymentMethod = useCallback(
+  const _confirmPayment = useCallback(
     async (
       paymentIntentClientSecret: string,
       data: PaymentMethodCreateParams.Params,
       options: PaymentMethodCreateParams.Options = {}
-    ): Promise<ConfirmPaymentMethodResult> => {
-      return confirmPaymentMethod(paymentIntentClientSecret, data, options);
+    ): Promise<ConfirmPaymentResult> => {
+      return confirmPayment(paymentIntentClientSecret, data, options);
     },
     []
   );
@@ -186,7 +186,7 @@ export function useStripe() {
   return {
     retrievePaymentIntent: _retrievePaymentIntent,
     retrieveSetupIntent: _retrieveSetupIntent,
-    confirmPayment: _confirmPaymentMethod,
+    confirmPayment: _confirmPayment,
     createPaymentMethod: _createPaymentMethod,
     handleCardAction: _handleCardAction,
     isApplePaySupported: isApplePaySupported,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -78,7 +78,7 @@ export type RetrieveSetupIntentResult =
       error: StripeError<RetrieveSetupIntentError>;
     };
 
-export type ConfirmPaymentMethodResult =
+export type ConfirmPaymentResult =
   | {
       paymentIntent: PaymentIntent;
       error?: undefined;


### PR DESCRIPTION
It's creating some confusion that `functions` is exporting `confirmPaymentMethod` whereas `useStripe` is exporting `confirmPayment`: https://github.com/stripe/stripe-react-native/issues/318

This PR is unifying it and getting rid of `confirmPaymentMethod` across the board as it also doesn't make too much sense since one does confirm the payment intent, not the method.