### PR TITLE
Allow payment sheets within modals

### DIFF
--- a/ios/StripeSdk.swift
+++ b/ios/StripeSdk.swift
@@ -157,7 +157,9 @@ class StripeSdk: RCTEventEmitter, STPApplePayContextDelegate, STPBankSelectionVi
         
         DispatchQueue.main.async {
             if (confirmPayment == false) {
-                self.paymentSheetFlowController?.presentPaymentOptions(from: findViewControllerPresenter(from: UIApplication.shared.delegate?.window??.rootViewController ?? UIViewController()) {
+                self.paymentSheetFlowController?.presentPaymentOptions(from: 
+                    findViewControllerPresenter(from: UIApplication.shared.delegate?.window??.rootViewController ?? UIViewController())
+                ) {
                     if let paymentOption = self.paymentSheetFlowController?.paymentOption {
                         let option: NSDictionary = [
                             "label": paymentOption.label,
@@ -169,7 +171,9 @@ class StripeSdk: RCTEventEmitter, STPApplePayContextDelegate, STPBankSelectionVi
                     }
                 }
             } else {
-                self.paymentSheet?.present(from: findViewControllerPresenter(from: UIApplication.shared.delegate?.window??.rootViewController ?? UIViewController()) { paymentResult in
+                self.paymentSheet?.present(from: 
+                    findViewControllerPresenter(from: UIApplication.shared.delegate?.window??.rootViewController ?? UIViewController())
+                ) { paymentResult in
                     switch paymentResult {
                     case .completed:
                         resolve([])

--- a/ios/StripeSdk.swift
+++ b/ios/StripeSdk.swift
@@ -157,7 +157,7 @@ class StripeSdk: RCTEventEmitter, STPApplePayContextDelegate, STPBankSelectionVi
         
         DispatchQueue.main.async {
             if (confirmPayment == false) {
-                self.paymentSheetFlowController?.presentPaymentOptions(from: UIApplication.shared.delegate?.window??.rootViewController ?? UIViewController()) {
+                self.paymentSheetFlowController?.presentPaymentOptions(from: findViewControllerPresenter(from: UIApplication.shared.delegate?.window??.rootViewController ?? UIViewController()) {
                     if let paymentOption = self.paymentSheetFlowController?.paymentOption {
                         let option: NSDictionary = [
                             "label": paymentOption.label,
@@ -169,7 +169,7 @@ class StripeSdk: RCTEventEmitter, STPApplePayContextDelegate, STPBankSelectionVi
                     }
                 }
             } else {
-                self.paymentSheet?.present(from: UIApplication.shared.delegate?.window??.rootViewController ?? UIViewController()) { paymentResult in
+                self.paymentSheet?.present(from: findViewControllerPresenter(from: UIApplication.shared.delegate?.window??.rootViewController ?? UIViewController()) { paymentResult in
                     switch paymentResult {
                     case .completed:
                         resolve([])


### PR DESCRIPTION
Currently when you try to call `presentPaymentSheet` from a modal, the app will crash. This has been reported in a few issues (#315, #290).

I am not entirely sure if this fix doesn't breaks non-modal use-cases. But at least it worked correctly within a modal for our use-case with this modification.