### PR TITLE
fix: fix an issue where card field was set to null

### DIFF
--- a/android/src/main/java/com/reactnativestripesdk/StripeSdkCardViewManager.kt
+++ b/android/src/main/java/com/reactnativestripesdk/StripeSdkCardViewManager.kt
@@ -54,14 +54,15 @@ class StripeSdkCardViewManager : SimpleViewManager<StripeSdkCardView>() {
 //      exceptionManager?.reportException(error)
 //    }
 
+    // Handle only one CardField component on the same screen
+    cardViewInstanceMap[CARD_FIELD_INSTANCE_NAME] = null
+
     cardViewInstanceMap[CARD_FIELD_INSTANCE_NAME] = StripeSdkCardView(reactContext)
     return cardViewInstanceMap[CARD_FIELD_INSTANCE_NAME] as StripeSdkCardView
   }
 
   override fun onDropViewInstance(view: StripeSdkCardView) {
     super.onDropViewInstance(view)
-
-    this.cardViewInstanceMap[CARD_FIELD_INSTANCE_NAME] = null
   }
 
   fun getCardViewInstance(): StripeSdkCardView? {

--- a/ios/CardFieldManager.swift
+++ b/ios/CardFieldManager.swift
@@ -5,12 +5,12 @@ class CardFieldManager: RCTViewManager, CardFieldDelegate {
     public let cardFieldMap: NSMutableDictionary = [:]
 
     func onDidCreateViewInstance(id: String, reference: Any?) -> Void {
+        // Handle only one CardField component on the same screen
+        cardFieldMap[id] = nil
         cardFieldMap[id] = reference
     }
     
-    func onDidDestroyViewInstance(id: String) {
-        cardFieldMap[id] = nil
-    }
+    func onDidDestroyViewInstance(id: String) { }
         
     public func getCardFieldReference(id: String) -> Any? {
         return self.cardFieldMap[id]


### PR DESCRIPTION
As described on issue #371, the card field component was returning null when doing the confirmSetup call, which caused this method to return the error saying that card details were missing, this PR aims to fix this issue.