### PR TITLE
Handle 'token' and 'paymentMethodId' in confirmSetupIntent

### DIFF
--- a/android/src/main/java/com/reactnativestripesdk/PaymentMethodCreateParamsFactory.kt
+++ b/android/src/main/java/com/reactnativestripesdk/PaymentMethodCreateParamsFactory.kt
@@ -157,9 +157,23 @@ class PaymentMethodCreateParamsFactory(private val clientSecret: String, private
 
   @Throws(PaymentMethodCreateParamsException::class)
   private fun createCardPaymentSetupParams(): ConfirmSetupIntentParams {
-    val paymentMethodCreateParams = PaymentMethodCreateParams.create(cardParams!!, billingDetailsParams)
-    return ConfirmSetupIntentParams
-      .create(paymentMethodCreateParams, clientSecret)
+   val paymentMethodId = getValOr(params, "paymentMethodId", null)
+   val token = getValOr(params, "token", null)
+
+   if (cardParams == null && paymentMethodId == null && token == null) {
+     throw PaymentMethodCreateParamsException("Card details not complete")
+   }
+
+   return if (paymentMethodId != null) {
+     ConfirmSetupIntentParams.create(paymentMethodId, clientSecret)
+   } else {
+     var card = cardParams
+     if (token != null) {
+       card = PaymentMethodCreateParams.Card.create(token)
+     }
+     val paymentMethodCreateParams = PaymentMethodCreateParams.create(card!!, billingDetailsParams)
+     ConfirmSetupIntentParams.create(paymentMethodCreateParams, clientSecret)
+   }
   }
 
   @Throws(PaymentMethodCreateParamsException::class)

--- a/src/types/SetupIntent.ts
+++ b/src/types/SetupIntent.ts
@@ -34,9 +34,15 @@ export namespace ConfirmSetupIntent {
     billingDetails?: PaymentMethods.BillingDetails;
   }
 
-  export interface CardParams extends BaseParams {
-    type: 'Card';
-  }
+  export type CardParams =
+    | (BaseParams & {
+        type: 'Card';
+        token?: string;
+      })
+    | (BaseParams & {
+        type: 'Card';
+        paymentMethodId?: string;
+      });
 
   export interface IdealParams extends BaseParams {
     type: 'Ideal';


### PR DESCRIPTION
## Description
This PR tries to fix issues we found when migrating from tipsi-stripe to official stripe react native library. Please see this https://github.com/stripe/stripe-react-native/issues/371#issuecomment-874022323 to get more context.

We have seen that there are these issues when confirming a setup intent:
- Typescript spec doesn't consider `token` or `paymentMethodId` as possible parameters in ConfirmSetupIntent.Params
- iOS react native implementation supports `token`, but completely ignores `paymentMethodId`
- Android react native implementation does not consider any of these parameters and crashes if called when there is no view instance available.

We have created a fork and got our flow working with small fixes to the above mentioned issues. I am creating this PR in case it is useful for anyone else having the same issues.

__Note:__ I am very new to Stripe and I am sure there will be cases I didn't considered or there might be better way of solving things, so please, feel free to comment or suggest any changes.
