### PR TITLE
fix: better error handling for createToken - android

### DIFF
--- a/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
+++ b/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
@@ -370,11 +370,15 @@ class StripeSdkModule(reactContext: ReactApplicationContext, cardFieldManager: S
       name = getValOr(params, "name", null)
     )
     runBlocking {
-      val token = stripe.createCardToken(
-        cardParams = params,
-        stripeAccountId = stripeAccountId
-      )
-      promise.resolve(createResult("token", mapFromToken(token)))
+      try {
+        val token = stripe.createCardToken(
+          cardParams = params,
+          stripeAccountId = stripeAccountId
+        )
+        promise.resolve(createResult("token", mapFromToken(token)))
+      } catch (e: Exception) {
+        promise.resolve(createError(CreateTokenErrorType.Failed.toString(), e.message))
+      }
     }
   }
 


### PR DESCRIPTION
Better error handling for createToken function. Now exceptions about not valid year or card number can be catched.

This is to stop issues like #405 