### PR TITLE
fix: removing usage of the map for cardview reference

### DIFF
--- a/ios/CardFieldDelegate.swift
+++ b/ios/CardFieldDelegate.swift
@@ -1,6 +1,0 @@
-import Foundation
-
-protocol CardFieldDelegate {
-    func onDidCreateViewInstance(id: String, reference: Any?) -> Void
-    func onDidDestroyViewInstance(id: String) -> Void
-}

--- a/ios/CardFieldManager.swift
+++ b/ios/CardFieldManager.swift
@@ -2,14 +2,10 @@ import Foundation
 
 @objc(CardFieldManager)
 class CardFieldManager: RCTViewManager {
-    private var cardField: CardFieldView?
-    
-    public func getCardFieldReference() -> Any? {
-        return cardField
-    }
-    
     override func view() -> UIView! {
-        cardField = CardFieldView()
+        let cardField = CardFieldView()
+        let stripeSdk = bridge.module(forName: "StripeSdk") as? StripeSdk
+        stripeSdk?.cardFieldView = cardField;
         return cardField
     }
     

--- a/ios/CardFieldManager.swift
+++ b/ios/CardFieldManager.swift
@@ -1,27 +1,16 @@
 import Foundation
 
 @objc(CardFieldManager)
-class CardFieldManager: RCTViewManager, CardFieldDelegate {
-    public let cardFieldMap: NSMutableDictionary = [:]
+class CardFieldManager: RCTViewManager {
+    private var cardField: CardFieldView?
     
-    func onDidCreateViewInstance(id: String, reference: Any?) -> Void {
-        cardFieldMap[id] = reference
-    }
-    
-    func onDidDestroyViewInstance(id: String) {
-        cardFieldMap[id] = nil
-    }
-    
-    public func getCardFieldReference(id: String) -> Any? {
-        return self.cardFieldMap[id]
+    public func getCardFieldReference() -> Any? {
+        return cardField
     }
     
     override func view() -> UIView! {
-        // as it's reasonable we handle only one CardField component on the same screen
-        if (cardFieldMap[CARD_FIELD_INSTANCE_ID] != nil) {
-            // TODO: throw an exception
-        }
-        return CardFieldView(delegate: self)
+        cardField = CardFieldView()
+        return cardField
     }
     
     

--- a/ios/CardFieldView.swift
+++ b/ios/CardFieldView.swift
@@ -12,7 +12,7 @@ class CardFieldView: UIView, STPPaymentCardTextFieldDelegate {
     private var cardField = STPPaymentCardTextField()
     
     public var cardParams: STPPaymentMethodCardParams? = nil
-        
+    
     @objc var postalCodeEnabled: Bool = true {
         didSet {
             cardField.postalCodeEntryEnabled = postalCodeEnabled
@@ -104,7 +104,6 @@ class CardFieldView: UIView, STPPaymentCardTextFieldDelegate {
     func clear() {
         cardField.clear()
     }
-
     
     func paymentCardTextFieldDidEndEditing(_ textField: STPPaymentCardTextField) {
         onFocusChange?(["focusedField": NSNull()])

--- a/ios/CardFieldView.swift
+++ b/ios/CardFieldView.swift
@@ -12,9 +12,7 @@ class CardFieldView: UIView, STPPaymentCardTextFieldDelegate {
     private var cardField = STPPaymentCardTextField()
     
     public var cardParams: STPPaymentMethodCardParams? = nil
-    
-    public var delegate: CardFieldDelegate?
-    
+        
     @objc var postalCodeEnabled: Bool = true {
         didSet {
             cardField.postalCodeEntryEnabled = postalCodeEnabled
@@ -95,13 +93,6 @@ class CardFieldView: UIView, STPPaymentCardTextFieldDelegate {
         self.addSubview(cardField)
     }
     
-    convenience init(delegate: CardFieldDelegate) {
-        self.init(frame: CGRect.zero)
-        self.delegate = delegate
-        
-        self.delegate?.onDidCreateViewInstance(id: CARD_FIELD_INSTANCE_ID, reference: self)
-    }
-    
     func focus() {
         cardField.becomeFirstResponder()
     }
@@ -113,10 +104,7 @@ class CardFieldView: UIView, STPPaymentCardTextFieldDelegate {
     func clear() {
         cardField.clear()
     }
-    
-    override func removeFromSuperview() {
-        self.delegate?.onDidDestroyViewInstance(id: CARD_FIELD_INSTANCE_ID)
-    }
+
     
     func paymentCardTextFieldDidEndEditing(_ textField: STPPaymentCardTextField) {
         onFocusChange?(["focusedField": NSNull()])

--- a/ios/StripeSdk.swift
+++ b/ios/StripeSdk.swift
@@ -215,7 +215,7 @@ class StripeSdk: RCTEventEmitter, STPApplePayContextDelegate, STPBankSelectionVi
         }
         
         let cardFieldUIManager = bridge.module(forName: "CardFieldManager") as? CardFieldManager
-        let cardFieldView = cardFieldUIManager?.getCardFieldReference(id: CARD_FIELD_INSTANCE_ID) as? CardFieldView
+        let cardFieldView = cardFieldUIManager?.getCardFieldReference() as? CardFieldView
 
         var paymentMethodParams: STPPaymentMethodParams?
         let factory = PaymentMethodFactory.init(params: params, cardFieldView: cardFieldView)
@@ -454,7 +454,7 @@ class StripeSdk: RCTEventEmitter, STPApplePayContextDelegate, STPBankSelectionVi
         }
         
         let cardFieldUIManager = bridge.module(forName: "CardFieldManager") as? CardFieldManager
-        let cardFieldView = cardFieldUIManager?.getCardFieldReference(id: CARD_FIELD_INSTANCE_ID) as? CardFieldView
+        let cardFieldView = cardFieldUIManager?.getCardFieldReference() as? CardFieldView
         
         var paymentMethodParams: STPPaymentMethodParams?
         let factory = PaymentMethodFactory.init(params: params, cardFieldView: cardFieldView)
@@ -499,7 +499,7 @@ class StripeSdk: RCTEventEmitter, STPApplePayContextDelegate, STPBankSelectionVi
         }
         
         let cardFieldUIManager = bridge.module(forName: "CardFieldManager") as? CardFieldManager
-        let cardFieldView = cardFieldUIManager?.getCardFieldReference(id: CARD_FIELD_INSTANCE_ID) as? CardFieldView
+        let cardFieldView = cardFieldUIManager?.getCardFieldReference() as? CardFieldView
         
         guard let cardParams = cardFieldView?.cardParams else {
             resolve(Errors.createError(CreateTokenErrorType.Failed.rawValue, "Card details not complete"))
@@ -566,7 +566,7 @@ class StripeSdk: RCTEventEmitter, STPApplePayContextDelegate, STPBankSelectionVi
         self.confirmPaymentClientSecret = paymentIntentClientSecret
         
         let cardFieldUIManager = bridge.module(forName: "CardFieldManager") as? CardFieldManager
-        let cardFieldView = cardFieldUIManager?.getCardFieldReference(id: CARD_FIELD_INSTANCE_ID) as? CardFieldView
+        let cardFieldView = cardFieldUIManager?.getCardFieldReference() as? CardFieldView
                 
         let paymentMethodId = params["paymentMethodId"] as? String
         let paymentIntentParams = STPPaymentIntentParams(clientSecret: paymentIntentClientSecret)

--- a/ios/StripeSdk.swift
+++ b/ios/StripeSdk.swift
@@ -3,6 +3,7 @@ import Stripe
 
 @objc(StripeSdk)
 class StripeSdk: RCTEventEmitter, STPApplePayContextDelegate, STPBankSelectionViewControllerDelegate, UIAdaptivePresentationControllerDelegate {
+    public var cardFieldView: CardFieldView? = nil
     var merchantIdentifier: String? = nil
     
     private var paymentSheet: PaymentSheet?
@@ -213,9 +214,6 @@ class StripeSdk: RCTEventEmitter, STPApplePayContextDelegate, STPBankSelectionVi
             resolve(Errors.createError(ConfirmPaymentErrorType.Failed.rawValue, "You must provide paymentMethodType"))
             return
         }
-        
-        let cardFieldUIManager = bridge.module(forName: "CardFieldManager") as? CardFieldManager
-        let cardFieldView = cardFieldUIManager?.getCardFieldReference() as? CardFieldView
 
         var paymentMethodParams: STPPaymentMethodParams?
         let factory = PaymentMethodFactory.init(params: params, cardFieldView: cardFieldView)
@@ -453,9 +451,6 @@ class StripeSdk: RCTEventEmitter, STPApplePayContextDelegate, STPBankSelectionVi
             return
         }
         
-        let cardFieldUIManager = bridge.module(forName: "CardFieldManager") as? CardFieldManager
-        let cardFieldView = cardFieldUIManager?.getCardFieldReference() as? CardFieldView
-        
         var paymentMethodParams: STPPaymentMethodParams?
         let factory = PaymentMethodFactory.init(params: params, cardFieldView: cardFieldView)
         
@@ -497,9 +492,6 @@ class StripeSdk: RCTEventEmitter, STPApplePayContextDelegate, STPBankSelectionVi
                 resolve(Errors.createError(CreateTokenErrorType.Failed.rawValue, type + " type is not supported yet"))
             }
         }
-        
-        let cardFieldUIManager = bridge.module(forName: "CardFieldManager") as? CardFieldManager
-        let cardFieldView = cardFieldUIManager?.getCardFieldReference() as? CardFieldView
         
         guard let cardParams = cardFieldView?.cardParams else {
             resolve(Errors.createError(CreateTokenErrorType.Failed.rawValue, "Card details not complete"))
@@ -564,9 +556,6 @@ class StripeSdk: RCTEventEmitter, STPApplePayContextDelegate, STPBankSelectionVi
     ) -> Void {
         self.confirmPaymentResolver = resolve
         self.confirmPaymentClientSecret = paymentIntentClientSecret
-        
-        let cardFieldUIManager = bridge.module(forName: "CardFieldManager") as? CardFieldManager
-        let cardFieldView = cardFieldUIManager?.getCardFieldReference() as? CardFieldView
                 
         let paymentMethodId = params["paymentMethodId"] as? String
         let paymentIntentParams = STPPaymentIntentParams(clientSecret: paymentIntentClientSecret)


### PR DESCRIPTION
An attempt to fix #391

In order to fix the deallocation issue and make the code a little bit more readable I moved the CardFieldView reference from manager to StripeSdk. Thanks to that we don't have to cache anything in ViewManager and accessing card reference is easier from StripeSdk.

This solution works with assumption that there can only be one CardField rendered at once

TODO:
- [x] implement POC solution|
- [x] refactor implmented solution
- [x] test that this change doesn't break anything

closes #391