### PR TITLE
Unsupported text input method

### DIFF
--- a/src/components/CardField.tsx
+++ b/src/components/CardField.tsx
@@ -17,9 +17,8 @@ import {
 } from 'react-native';
 const TextInputState = require('react-native/Libraries/Components/TextInput/TextInputState');
 
-const CardFieldNative = requireNativeComponent<CardFieldInput.NativeProps>(
-  'CardField'
-);
+const CardFieldNative =
+  requireNativeComponent<CardFieldInput.NativeProps>('CardField');
 
 const unsupportedMethodMessage = (field: string) =>
   `${field} method is not supported. Consider to upgrade react-native version to 0.63.x or higher`;
@@ -28,7 +27,9 @@ const focusInput = (ref: React.MutableRefObject<any>) => {
   if ('focusInput' in TextInputState) {
     TextInputState.focusInput(ref);
   } else {
-    console.warn(unsupportedMethodMessage('focusInput'));
+    if (__DEV__) {
+      console.log(unsupportedMethodMessage('focusInput'));
+    }
   }
 };
 
@@ -36,7 +37,9 @@ const registerInput = (ref: React.MutableRefObject<any>) => {
   if ('registerInput' in TextInputState) {
     TextInputState.registerInput(ref);
   } else {
-    console.warn(unsupportedMethodMessage('registerInput'));
+    if (__DEV__) {
+      console.log(unsupportedMethodMessage('registerInput'));
+    }
   }
 };
 
@@ -44,15 +47,19 @@ const unregisterInput = (ref: React.MutableRefObject<any>) => {
   if ('unregisterInput' in TextInputState) {
     TextInputState.unregisterInput(ref);
   } else {
-    console.warn(unsupportedMethodMessage('unregisterInput'));
+    if (__DEV__) {
+      console.log(unsupportedMethodMessage('unregisterInput'));
+    }
   }
 };
 
 const currentlyFocusedInput = () => {
   if ('currentlyFocusedInput' in TextInputState) {
-    TextInputState.currentlyFocusedInput();
+    return TextInputState.currentlyFocusedInput();
   } else {
-    console.warn(unsupportedMethodMessage('currentlyFocusedInput'));
+    if (__DEV__) {
+      console.log(unsupportedMethodMessage('currentlyFocusedInput'));
+    }
   }
 };
 

--- a/src/components/CardField.tsx
+++ b/src/components/CardField.tsx
@@ -22,7 +22,7 @@ const CardFieldNative = requireNativeComponent<CardFieldInput.NativeProps>(
 );
 
 const unsupportedMethodMessage = (field: string) =>
-  `${field} method is not supported. Consider to upgrade react-native version to 0.63.x at least`;
+  `${field} method is not supported. Consider to upgrade react-native version to 0.63.x or higher`;
 
 const focusInput = (ref: React.MutableRefObject<any>) => {
   if ('focusInput' in TextInputState) {

--- a/src/components/CardField.tsx
+++ b/src/components/CardField.tsx
@@ -21,6 +21,33 @@ const CardFieldNative = requireNativeComponent<CardFieldInput.NativeProps>(
   'CardField'
 );
 
+const unsupportedMethodMessage = (field: string) =>
+  `${field} method is not supported. Consider to upgrade react-native version to 0.63.x at least`;
+
+const focusInput = (ref: React.MutableRefObject<any>) => {
+  if ('focusInput' in TextInputState) {
+    TextInputState.focusInput(ref);
+  } else {
+    console.warn(unsupportedMethodMessage('focusInput'));
+  }
+};
+
+const registerInput = (ref: React.MutableRefObject<any>) => {
+  if ('registerInput' in TextInputState) {
+    TextInputState.registerInput(ref);
+  } else {
+    console.warn(unsupportedMethodMessage('registerInput'));
+  }
+};
+
+const unregisterInput = (ref: React.MutableRefObject<any>) => {
+  if ('unregisterInput' in TextInputState) {
+    TextInputState.unregisterInput(ref);
+  } else {
+    console.warn(unsupportedMethodMessage('unregisterInput'));
+  }
+};
+
 /**
  *  Card Field Component Props
  */
@@ -108,7 +135,7 @@ export const CardField = forwardRef<CardFieldInput.Methods, Props>(
       (event) => {
         const { focusedField } = event.nativeEvent;
         if (focusedField) {
-          TextInputState.focusInput(inputRef.current);
+          focusInput(inputRef.current);
           onFocus?.(focusedField);
         } else {
           onBlur?.();
@@ -150,9 +177,9 @@ export const CardField = forwardRef<CardFieldInput.Methods, Props>(
     useLayoutEffect(() => {
       const inputRefValue = inputRef.current;
       if (inputRefValue !== null) {
-        TextInputState.registerInput(inputRefValue);
+        registerInput(inputRefValue);
         return () => {
-          TextInputState.unregisterInput(inputRefValue);
+          unregisterInput(inputRefValue);
           if (TextInputState.currentlyFocusedInput() === inputRefValue) {
             inputRefValue.blur();
           }

--- a/src/components/CardField.tsx
+++ b/src/components/CardField.tsx
@@ -48,6 +48,14 @@ const unregisterInput = (ref: React.MutableRefObject<any>) => {
   }
 };
 
+const currentlyFocusedInput = () => {
+  if ('currentlyFocusedInput' in TextInputState) {
+    TextInputState.currentlyFocusedInput();
+  } else {
+    console.warn(unsupportedMethodMessage('currentlyFocusedInput'));
+  }
+};
+
 /**
  *  Card Field Component Props
  */
@@ -180,7 +188,7 @@ export const CardField = forwardRef<CardFieldInput.Methods, Props>(
         registerInput(inputRefValue);
         return () => {
           unregisterInput(inputRefValue);
-          if (TextInputState.currentlyFocusedInput() === inputRefValue) {
+          if (currentlyFocusedInput() === inputRefValue) {
             inputRefValue.blur();
           }
         };


### PR DESCRIPTION
resolves #440 

this fix resolves issue which throws exception if certain TextInputState methods are not available since it has been added from 
 react-native 0.63x. 
