### PR TITLE
respect postal code from card field as a priority

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -264,7 +264,7 @@ PODS:
   - Stripe (21.7.0):
     - Stripe/Stripe3DS2 (= 21.7.0)
     - StripeCore (= 21.7.0)
-  - stripe-react-native (0.1.4):
+  - stripe-react-native (0.1.5):
     - React
     - Stripe (~> 21.7.0)
   - Stripe/Stripe3DS2 (21.7.0):
@@ -421,7 +421,7 @@ SPEC CHECKSUMS:
   RNReanimated: e03f7425cb7a38dcf1b644d680d1bfc91c3337ad
   RNScreens: 2ad555d4d9fa10b91bb765ca07fe9b29d59573f0
   Stripe: 90596971ef49bade169f68bc59369a796b30a045
-  stripe-react-native: 9d821daf7584f221ed87de5a02e202b2485d5c2e
+  stripe-react-native: f1b034cb702aa214078d9441b0a4313ac00c020d
   StripeCore: c09b492efc3b269a6ff875ad738ca366db97e03b
   Yoga: 4bd86afe9883422a7c4028c00e34790f560923d6
 

--- a/ios/CardFieldManager.swift
+++ b/ios/CardFieldManager.swift
@@ -9,7 +9,6 @@ class CardFieldManager: RCTViewManager {
         return cardField
     }
     
-    
     @objc func focus(_ reactTag: NSNumber) {
         self.bridge!.uiManager.addUIBlock { (_: RCTUIManager?, viewRegistry: [NSNumber: UIView]?) in
             let view: CardFieldView = (viewRegistry![reactTag] as? CardFieldView)!

--- a/ios/CardFieldView.swift
+++ b/ios/CardFieldView.swift
@@ -12,7 +12,8 @@ class CardFieldView: UIView, STPPaymentCardTextFieldDelegate {
     private var cardField = STPPaymentCardTextField()
     
     public var cardParams: STPPaymentMethodCardParams? = nil
-    
+    public var cardPostalCode: String? = nil
+
     @objc var postalCodeEnabled: Bool = true {
         didSet {
             cardField.postalCodeEntryEnabled = postalCodeEnabled
@@ -145,8 +146,10 @@ class CardFieldView: UIView, STPPaymentCardTextFieldDelegate {
         }
         if (textField.isValid) {
             self.cardParams = textField.cardParams
+            self.cardPostalCode = textField.postalCode
         } else {
             self.cardParams = nil
+            self.cardPostalCode = nil
         }
     }
     

--- a/ios/PaymentMethodFactory.swift
+++ b/ios/PaymentMethodFactory.swift
@@ -116,7 +116,14 @@ class PaymentMethodFactory {
             throw PaymentMethodError.cardPaymentMissingParams
         }
         if let postalCode = cardFieldView?.cardPostalCode {
-            billingDetailsParams?.address?.postalCode = postalCode
+            if (billingDetailsParams == nil) {
+                let bd = STPPaymentMethodBillingDetails()
+                bd.address = STPPaymentMethodAddress()
+                bd.address?.postalCode = postalCode
+                billingDetailsParams = bd
+            } else {
+                billingDetailsParams?.address?.postalCode = postalCode
+            }
         }
         
         return STPPaymentMethodParams(card: cardParams, billingDetails: billingDetailsParams, metadata: nil)

--- a/ios/PaymentMethodFactory.swift
+++ b/ios/PaymentMethodFactory.swift
@@ -115,6 +115,9 @@ class PaymentMethodFactory {
         guard let cardParams = cardFieldView?.cardParams else {
             throw PaymentMethodError.cardPaymentMissingParams
         }
+        if let postalCode = cardFieldView?.cardPostalCode {
+            billingDetailsParams?.address?.postalCode = postalCode
+        }
         
         return STPPaymentMethodParams(card: cardParams, billingDetails: billingDetailsParams, metadata: nil)
     }


### PR DESCRIPTION
resolves #420 
for now postal code from CardField is not included in the payment.
This fix makes SDK to respect a postal code from CardField and takes it as a priority. 
Postal code still can be provided from a billing details when postal code field is disabled (`postalCodeEnabled={false}`)