### PR TITLE
Fix custom flow.

### DIFF
--- a/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
+++ b/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
@@ -246,6 +246,7 @@ class StripeSdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJ
         } else {
           presentPaymentSheetPromise?.resolve(WritableNativeMap())
         }
+        presentPaymentSheetPromise = null
       }
       else if (intent.action == ON_INIT_PAYMENT_SHEET) {
         initPaymentSheetPromise?.resolve(WritableNativeMap())


### PR DESCRIPTION
While payment sheet is in custom flow `presentPaymentSheetPromise` is called twice, on `ON_PAYMENT_OPTION_ACTION` and `ON_PAYMENT_RESULT_ACTION` intents.

This breaks the flutter plugin, as the promised is expected to be returned only once.