### PR TITLE
Remove params for presentPaymentSheet

### DIFF
--- a/android/src/main/java/com/reactnativestripesdk/PaymentSheetFragment.kt
+++ b/android/src/main/java/com/reactnativestripesdk/PaymentSheetFragment.kt
@@ -97,15 +97,15 @@ class PaymentSheetFragment : Fragment() {
   }
 
   fun present() {
-    if (!paymentIntentClientSecret.isNullOrEmpty()) {
-      paymentSheet?.presentWithPaymentIntent(paymentIntentClientSecret!!, paymentSheetConfiguration)
-    } else if (!setupIntentClientSecret.isNullOrEmpty()) {
-      paymentSheet?.presentWithSetupIntent(setupIntentClientSecret!!, paymentSheetConfiguration)
+    if(paymentSheet != null) {
+      if (!paymentIntentClientSecret.isNullOrEmpty()) {
+        paymentSheet?.presentWithPaymentIntent(paymentIntentClientSecret!!, paymentSheetConfiguration)
+      } else if (!setupIntentClientSecret.isNullOrEmpty()) {
+        paymentSheet?.presentWithSetupIntent(setupIntentClientSecret!!, paymentSheetConfiguration)
+      }
+    } else if(flowController != null) {
+      flowController?.presentPaymentOptions()
     }
-  }
-
-  fun presentPaymentOptions() {
-    flowController?.presentPaymentOptions()
   }
 
   fun confirmPayment() {

--- a/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
+++ b/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
@@ -325,14 +325,9 @@ class StripeSdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJ
   }
 
   @ReactMethod
-  fun presentPaymentSheet(params: ReadableMap?, promise: Promise) {
-    val confirmPayment = getBooleanOrNull(params, "confirmPayment")
+  fun presentPaymentSheet(promise: Promise) {
     this.presentPaymentSheetPromise = promise
-    if (confirmPayment == false) {
-      paymentSheetFragment?.presentPaymentOptions()
-    } else {
-      paymentSheetFragment?.present()
-    }
+    paymentSheetFragment?.present()
   }
 
   @ReactMethod

--- a/example/src/screens/PaymentsUICompleteScreen.tsx
+++ b/example/src/screens/PaymentsUICompleteScreen.tsx
@@ -32,9 +32,7 @@ export default function PaymentsUICompleteScreen() {
       return;
     }
     setLoadng(true);
-    const { error } = await presentPaymentSheet({
-      clientSecret,
-    });
+    const { error } = await presentPaymentSheet();
 
     if (error) {
       Alert.alert(`Error code: ${error.code}`, error.message);

--- a/example/src/screens/PaymentsUICustomScreen.tsx
+++ b/example/src/screens/PaymentsUICustomScreen.tsx
@@ -66,9 +66,7 @@ export default function PaymentsUICustomScreen() {
   };
 
   const choosePaymentOption = async () => {
-    const { error, paymentOption } = await presentPaymentSheet({
-      confirmPayment: false,
-    });
+    const { error, paymentOption } = await presentPaymentSheet();
 
     if (error) {
       console.log('error', error);

--- a/ios/StripeSdk.m
+++ b/ios/StripeSdk.m
@@ -78,8 +78,7 @@ RCT_EXTERN_METHOD(
                   )
 
 RCT_EXTERN_METHOD(
-                  presentPaymentSheet:(NSDictionary)params
-                  resolver: (RCTPromiseResolveBlock)resolve
+                  presentPaymentSheet:(RCTPromiseResolveBlock)resolve
                   rejecter: (RCTPromiseRejectBlock)reject
                   )
 

--- a/src/NativeStripeSdk.tsx
+++ b/src/NativeStripeSdk.tsx
@@ -60,9 +60,7 @@ type NativeStripeSdkType = {
   initPaymentSheet(
     params: PaymentSheet.SetupParams
   ): Promise<InitPaymentSheetResult>;
-  presentPaymentSheet(
-    params?: PaymentSheet.PresentParams
-  ): Promise<PresentPaymentSheetResult>;
+  presentPaymentSheet(): Promise<PresentPaymentSheetResult>;
   confirmPaymentSheetPayment(): Promise<ConfirmPaymentSheetPaymentResult>;
   createTokenForCVCUpdate(cvc: string): Promise<CreateTokenForCVCUpdateResult>;
   handleURLCallback(url: string): Promise<boolean>;

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -324,13 +324,10 @@ export const initPaymentSheet = async (
   }
 };
 
-export const presentPaymentSheet = async (
-  params?: PaymentSheet.PresentParams
-): Promise<PresentPaymentSheetResult> => {
+export const presentPaymentSheet = 
+  async (): Promise<PresentPaymentSheetResult> => {
   try {
-    const { paymentOption, error } = await NativeStripeSdk.presentPaymentSheet(
-      params
-    );
+    const { paymentOption, error } = await NativeStripeSdk.presentPaymentSheet();
     if (error) {
       return {
         error,

--- a/src/hooks/usePaymentSheet.tsx
+++ b/src/hooks/usePaymentSheet.tsx
@@ -20,9 +20,9 @@ export function usePaymentSheet() {
     return result;
   };
 
-  const presentPaymentSheet = async (params: PaymentSheet.PresentParams) => {
+  const presentPaymentSheet = async () => {
     setLoading(true);
-    const result = await presentPaymentSheetNative(params);
+    const result = await presentPaymentSheetNative();
     setLoading(false);
     return result;
   };

--- a/src/hooks/useStripe.tsx
+++ b/src/hooks/useStripe.tsx
@@ -170,14 +170,10 @@ export function useStripe() {
     []
   );
 
-  const _presentPaymentSheet = useCallback(
-    async (
-      params?: PaymentSheet.PresentParams
-    ): Promise<PresentPaymentSheetResult> => {
-      return presentPaymentSheet(params);
-    },
-    []
-  );
+  const _presentPaymentSheet = 
+    useCallback(async (): Promise<PresentPaymentSheetResult> => {
+      return presentPaymentSheet();
+    }, []);
 
   const _confirmPaymentSheetPayment =
     useCallback(async (): Promise<ConfirmPaymentSheetPaymentResult> => {

--- a/src/types/PaymentSheet.ts
+++ b/src/types/PaymentSheet.ts
@@ -9,11 +9,6 @@ export declare namespace PaymentSheet {
       style?: 'alwaysLight' | 'alwaysDark' | 'automatic';
     };
 
-  export type PresentParams = {
-    confirmPayment?: boolean;
-    clientSecret?: string;
-  };
-
   type ClientSecretParams =
     | {
         paymentIntentClientSecret: string;


### PR DESCRIPTION
Right now presentPaymentSheets has two params:

 - `clientSecret` not used anywhere
 - `confirmPayment`, used to differentiate between single-step and multipe-step payment sheets.

This last param is not very clear for developers as it always needs to be the opposite of the param `customFlow` from initPaymentSheet. This could be simplified to inherit the config from initPaymentSheet, or otherwise explain better and throw an error in the case  `customFlow` and `confirmPayment` are the same.

My proposal is to remove both params. This would look like the native implementations that don't need any params in the respective methods
  