### PR TITLE
fix: adds cardFormView to the createToken

### DIFF
--- a/ios/StripeSdk.swift
+++ b/ios/StripeSdk.swift
@@ -520,7 +520,7 @@ class StripeSdk: RCTEventEmitter, STPApplePayContextDelegate, STPBankSelectionVi
             }
         }
         
-        guard let cardParams = cardFieldView?.cardParams else {
+        guard let cardParams = cardFieldView?.cardParams ?? cardFormView?.cardParams else {
             resolve(Errors.createError(CreateTokenErrorType.Failed.rawValue, "Card details not complete"))
             return
         }


### PR DESCRIPTION
The createToken call was only using the cardFieldView when trying to create the token on iOS. 

I am having trouble running the android project, so didn't test it out there. Do note that the [code](https://github.com/stripe/stripe-react-native/blob/c6ca57bea9217dbaf656b887323457002ca57495/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt#L404) suggests it's already working fine in Android.