### PR TITLE
feat: Add validation state to CardField (#423)

### DIFF
--- a/android/src/main/java/com/reactnativestripesdk/CardChangedEvent.kt
+++ b/android/src/main/java/com/reactnativestripesdk/CardChangedEvent.kt
@@ -36,6 +36,9 @@ internal class CardChangedEvent constructor(viewTag: Int, private val cardDetail
     }
 
     eventData.putBoolean("complete", complete)
+    eventData.putString("validNumber", cardDetails["validNumber"]?.toString())
+    eventData.putString("validCVC", cardDetails["validCVC"]?.toString())
+    eventData.putString("validExpiryDate", cardDetails["validExpiryDate"]?.toString())
 
     if (postalCodeEnabled) {
       eventData.putString("postalCode", cardDetails["postalCode"]?.toString())

--- a/android/src/main/java/com/reactnativestripesdk/StripeSdkCardView.kt
+++ b/android/src/main/java/com/reactnativestripesdk/StripeSdkCardView.kt
@@ -21,11 +21,12 @@ import com.stripe.android.model.Address
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.view.CardInputListener
 import com.stripe.android.view.CardInputWidget
+import com.stripe.android.view.CardValidCallback
 
 
 class StripeSdkCardView(private val context: ThemedReactContext) : FrameLayout(context) {
   private var mCardWidget: CardInputWidget
-  val cardDetails: MutableMap<String, Any?> = mutableMapOf("brand" to "", "last4" to "", "expiryMonth" to null, "expiryYear" to null, "postalCode" to "")
+  val cardDetails: MutableMap<String, Any?> = mutableMapOf("brand" to "", "last4" to "", "expiryMonth" to null, "expiryYear" to null, "postalCode" to "", "validNumber" to "Unknown", "validCVC" to "Unknown", "validExpiryDate" to "Unknown")
   var cardParams: PaymentMethodCreateParams.Card? = null
   var cardAddress: Address? = null
   private var mEventDispatcher: EventDispatcher?
@@ -198,7 +199,10 @@ class StripeSdkCardView(private val context: ThemedReactContext) : FrameLayout(c
   }
 
   private fun setListeners() {
-    mCardWidget.setCardValidCallback { isValid, _ ->
+    mCardWidget.setCardValidCallback { isValid, invalidFields ->
+      cardDetails["validNumber"] = if (invalidFields.contains(CardValidCallback.Fields.Number)) "Invalid" else "Valid"
+      cardDetails["validCVC"] = if (invalidFields.contains(CardValidCallback.Fields.Cvc)) "Invalid" else "Valid"
+      cardDetails["validExpiryDate"] = if (invalidFields.contains(CardValidCallback.Fields.Expiry)) "Invalid" else "Valid"
       if (isValid) {
         onCardChanged()
       }

--- a/ios/CardFieldView.swift
+++ b/ios/CardFieldView.swift
@@ -127,12 +127,18 @@ class CardFieldView: UIView, STPPaymentCardTextFieldDelegate {
     func paymentCardTextFieldDidChange(_ textField: STPPaymentCardTextField) {
         if onCardChange != nil {
             let brand = STPCardValidator.brand(forNumber: textField.cardParams.number ?? "")
+            let validExpiryDate = STPCardValidator.validationState(forExpirationYear: textField.cardParams.expYear?.stringValue ?? "", inMonth: textField.cardParams.expMonth?.stringValue ?? "")
+            let validCVC = STPCardValidator.validationState(forCVC: textField.cardParams.cvc ?? "", cardBrand: brand)
+            let validNumber = STPCardValidator.validationState(forNumber: textField.cardParams.number ?? "", validatingCardBrand: true)
             var cardData: [String: Any?] = [
                 "expiryMonth": textField.cardParams.expMonth ?? NSNull(),
                 "expiryYear": textField.cardParams.expYear ?? NSNull(),
                 "complete": textField.isValid,
                 "brand": Mappers.mapCardBrand(brand) ?? NSNull(),
-                "last4": textField.cardParams.last4 ?? ""
+                "last4": textField.cardParams.last4 ?? "",
+                "validExpiryDate": Mappers.mapFromCardValidationState(state: validExpiryDate),
+                "validCVC": Mappers.mapFromCardValidationState(state: validCVC),
+                "validNumber": Mappers.mapFromCardValidationState(state: validNumber)
             ]
             if (cardField.postalCodeEntryEnabled) {
                 cardData["postalCode"] = textField.postalCode ?? ""

--- a/ios/Mappers.swift
+++ b/ios/Mappers.swift
@@ -829,4 +829,16 @@ class Mappers {
         }
         return nil
     }
+    
+    class func mapFromCardValidationState(state: STPCardValidationState?) -> String {
+        if let state = state {
+            switch state {
+            case STPCardValidationState.valid: return "Valid"
+            case STPCardValidationState.invalid: return "Invalid"
+            case STPCardValidationState.incomplete: return "Incomplete"
+            default: return "Unknown"
+            }
+        }
+        return "Unknown"
+    }
 }

--- a/src/components/CardField.tsx
+++ b/src/components/CardField.tsx
@@ -128,6 +128,9 @@ export const CardField = forwardRef<CardFieldInput.Methods, Props>(
           expiryYear: card.expiryYear,
           complete: card.complete,
           brand: card.brand,
+          validExpiryDate: card.validExpiryDate,
+          validNumber: card.validNumber,
+          validCVC: card.validCVC,
         };
 
         if (card.hasOwnProperty('postalCode')) {

--- a/src/types/components/CardFieldInput.ts
+++ b/src/types/components/CardFieldInput.ts
@@ -4,6 +4,12 @@ import type { Card } from '../Card';
 
 export namespace CardFieldInput {
   export type Names = 'CardNumber' | 'Cvc' | 'ExpiryDate' | 'PostalCode';
+  export enum ValidationState {
+    Valid = 'Valid',
+    Invalid = 'Invalid',
+    Incomplete = 'Incomplete',
+    Unknown = 'Unknown',
+  }
 
   export interface Details {
     last4: string;
@@ -12,6 +18,9 @@ export namespace CardFieldInput {
     postalCode?: string;
     brand: Card.Brand;
     complete: boolean;
+    validExpiryDate: ValidationState;
+    validCVC: ValidationState;
+    validNumber: ValidationState;
     /**
      * WARNING: Full card details are only returned when the `dangerouslyGetFullCardDetails` prop
      * on the `CardField` component is set to `true`.


### PR DESCRIPTION
Closes #423 

This adds three new fields to the card details returned by `onCardChange`: `validCVC`, `validExpiryDate`, and `validNumber`. On iOS, each field has a possible value of "Valid", "Invalid", "Incomplete", and "Unknown". The Android SDK doesn't seem to expose whether a field is incomplete or not, so Android has "Valid", "Invalid", and "Unknown".

This is my first time working on a native module so I'm not 100% on the Swift and Kotlin syntax, let me know if there's a better way to write this and I'll update it