### PR TITLE
[Android] fix: card field focus jumps back to the card number field

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -51,6 +51,7 @@ jobs:
         with:
           api-level: 30
           arch: x86_64
+          profile: Nexus 6
           target: google_apis
           force-avd-creation: false
           disable-animations: true

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -51,6 +51,7 @@ jobs:
         with:
           api-level: 30
           arch: x86_64
+          profile: Galaxy Nexus
           target: google_apis
           force-avd-creation: false
           disable-animations: true

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -51,7 +51,6 @@ jobs:
         with:
           api-level: 30
           arch: x86_64
-          profile: Nexus 6
           target: google_apis
           force-avd-creation: false
           disable-animations: true

--- a/android/src/main/java/com/reactnativestripesdk/StripeSdkCardView.kt
+++ b/android/src/main/java/com/reactnativestripesdk/StripeSdkCardView.kt
@@ -175,7 +175,7 @@ class StripeSdkCardView(private val context: ThemedReactContext) : FrameLayout(c
     return cardDetails
   }
 
-  fun onCardChanged() {
+  fun onValidCardChange() {
     mCardWidget.paymentMethodCard?.let {
       cardParams = it
       cardAddress = Address.Builder()
@@ -193,6 +193,10 @@ class StripeSdkCardView(private val context: ThemedReactContext) : FrameLayout(c
       cardDetails["brand"] = null
       cardDetails["last4"] = null
     }
+    sendCardDetailsEvent()
+  }
+
+  private fun sendCardDetailsEvent() {
     mEventDispatcher?.dispatchEvent(
       CardChangedEvent(id, cardDetails, mCardWidget.postalCodeEnabled, cardParams != null, dangerouslyGetFullCardDetails))
   }
@@ -200,7 +204,10 @@ class StripeSdkCardView(private val context: ThemedReactContext) : FrameLayout(c
   private fun setListeners() {
     mCardWidget.setCardValidCallback { isValid, _ ->
       if (isValid) {
-        onCardChanged()
+        onValidCardChange()
+      } else {
+        cardParams = null
+        cardAddress = null
       }
     }
 
@@ -228,7 +235,7 @@ class StripeSdkCardView(private val context: ThemedReactContext) : FrameLayout(c
           cardDetails["expiryYear"] = var1.toString().split("/")[1].toIntOrNull()
         }
 
-        onCardChanged()
+        sendCardDetailsEvent()
       }
     })
 
@@ -237,7 +244,8 @@ class StripeSdkCardView(private val context: ThemedReactContext) : FrameLayout(c
       override fun afterTextChanged(p0: Editable?) {}
       override fun onTextChanged(var1: CharSequence?, var2: Int, var3: Int, var4: Int) {
         cardDetails["postalCode"] = var1.toString()
-        onCardChanged()
+
+        sendCardDetailsEvent()
       }
     })
 
@@ -248,7 +256,7 @@ class StripeSdkCardView(private val context: ThemedReactContext) : FrameLayout(c
         if (dangerouslyGetFullCardDetails) {
           cardDetails["number"] = var1.toString().replace(" ", "")
         }
-        onCardChanged()
+        sendCardDetailsEvent()
       }
     })
 
@@ -256,7 +264,7 @@ class StripeSdkCardView(private val context: ThemedReactContext) : FrameLayout(c
       override fun beforeTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {}
       override fun afterTextChanged(p0: Editable?) {}
       override fun onTextChanged(var1: CharSequence?, var2: Int, var3: Int, var4: Int) {
-        onCardChanged()
+        sendCardDetailsEvent()
       }
     })
   }

--- a/android/src/main/java/com/reactnativestripesdk/StripeSdkCardView.kt
+++ b/android/src/main/java/com/reactnativestripesdk/StripeSdkCardView.kt
@@ -244,7 +244,6 @@ class StripeSdkCardView(private val context: ThemedReactContext) : FrameLayout(c
       override fun afterTextChanged(p0: Editable?) {}
       override fun onTextChanged(var1: CharSequence?, var2: Int, var3: Int, var4: Int) {
         cardDetails["postalCode"] = var1.toString()
-
         sendCardDetailsEvent()
       }
     })

--- a/example/index.js
+++ b/example/index.js
@@ -5,4 +5,5 @@ import App from './src/App';
 // registerRootComponent calls AppRegistry.registerComponent('main', () => App);
 // It also ensures that whether you load the app in the Expo client or in a native build,
 // the environment is set up appropriately
+
 registerRootComponent(App);

--- a/example/index.js
+++ b/example/index.js
@@ -5,5 +5,4 @@ import App from './src/App';
 // registerRootComponent calls AppRegistry.registerComponent('main', () => App);
 // It also ensures that whether you load the app in the Expo client or in a native build,
 // the environment is set up appropriately
-
 registerRootComponent(App);


### PR DESCRIPTION
closes #121
 `cardParams`, `paymentMethodCreateParams` and `paymentMethodCard` properties have the side effect that when called it will shift the focus to an invalid field. In order to avoid this, we  need to call it only when the card details are valid.