### PR TITLE
change React to React-Core ood dependency

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -264,8 +264,8 @@ PODS:
   - Stripe (21.8.1):
     - Stripe/Stripe3DS2 (= 21.8.1)
     - StripeCore (= 21.8.1)
-  - stripe-react-native (0.2.1):
-    - React
+  - stripe-react-native (0.2.2):
+    - React-Core
     - Stripe (~> 21.8.1)
   - Stripe/Stripe3DS2 (21.8.1):
     - StripeCore (= 21.8.1)
@@ -421,7 +421,7 @@ SPEC CHECKSUMS:
   RNReanimated: e03f7425cb7a38dcf1b644d680d1bfc91c3337ad
   RNScreens: 2ad555d4d9fa10b91bb765ca07fe9b29d59573f0
   Stripe: 57c6997c64042a3f5aedae9b76e331942f8b75d2
-  stripe-react-native: e06c16c83cfce2884926941c0422f4299aeef02b
+  stripe-react-native: 8df9699a6788463d2a0febf481b429a1974321a4
   StripeCore: a6e50d58119a0c7601773b56f274db2d394dcdac
   Yoga: 4bd86afe9883422a7c4028c00e34790f560923d6
 

--- a/stripe-react-native.podspec
+++ b/stripe-react-native.podspec
@@ -17,6 +17,6 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
 
-  s.dependency "React"
+  s.dependency "React-Core"
   s.dependency 'Stripe', '~> 21.8.1'
 end


### PR DESCRIPTION
closes #632

This change should fix all the issues related with an error mentioned in the troubleshooting section https://github.com/stripe/stripe-react-native#undefined-symbols-for-architecture-x86_64-on-ios

Thanks @michaelbayday!