### PR TITLE
TS issue with 0.2.3 StripeProvider cannot be used as a JSX component

### DIFF
--- a/src/components/StripeProvider.tsx
+++ b/src/components/StripeProvider.tsx
@@ -103,5 +103,5 @@ export function StripeProvider({
     setUrlSchemeOnAndroid,
   ]);
 
-  return <>children</>;
+  return <>{children}</>;
 }


### PR DESCRIPTION
With 0.2.3 i have a TS break.
```
StripeProvider' cannot be used as a JSX component.
  Its return type 'ReactElement<any, string | JSXElementConstructor<any>> | ReactElement<any, string | JSXElementConstructor<any>>[]' is not a valid JSX element.
    Type 'ReactElement<any, string | JSXElementConstructor<any>>[]' is missing the following properties from type 'ReactElement<any, any>': type, props, key
```

This is due of the typing of children. The easiest way is to force with fragments to ensure this is a proper JSX component.