### PR TITLE
docs: Correct default for existingPaymentMethodRequired

### DIFF
--- a/src/types/GooglePay.ts
+++ b/src/types/GooglePay.ts
@@ -46,7 +46,7 @@ export namespace GooglePay {
      * If `true`, Google Pay is considered ready if the customer's Google Pay wallet
      * has existing payment methods.
      *
-     * Default to `true`.
+     * Default to `false`.
      */
     existingPaymentMethodRequired?: boolean;
   }


### PR DESCRIPTION
Tiny documentation correction for the [existingPaymentMethodRequired](https://github.com/stripe/stripe-react-native/blob/master/src/types/GooglePay.ts#L51)  param which suggests it defaults to `true` where it actually defaults to `false`.

Source: https://github.com/stripe/stripe-react-native/blob/master/android/src/main/java/com/reactnativestripesdk/GooglePayFragment.kt#L53
