### PR TITLE
Depend on any minor version of Stripe Android 18.1.x

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -132,7 +132,7 @@ dependencies {
   api 'com.facebook.react:react-native:+'
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
   implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.3.1"
-  implementation 'com.stripe:stripe-android:18.1.0'
+  implementation 'com.stripe:stripe-android:18.1.+'
   implementation 'com.google.android.material:material:1.3.0'
   implementation 'androidx.appcompat:appcompat:1.2.0'
   implementation 'androidx.legacy:legacy-support-v4:1.0.0'


### PR DESCRIPTION
Currently the gradle file requires 18.1.0, but I'm thinking we should allow for wildcard matching on the minor version so we can get minor version updates for free.
On iOS we use the optimistic operator in the podspec so we will get minor updates for free on iOS.