### PR TITLE
Add capabilityCredit and capabilityDebit merchantCapability options for Apple Pay

### DIFF
--- a/ios/StripeSdk.swift
+++ b/ios/StripeSdk.swift
@@ -472,6 +472,13 @@ class StripeSdk: RCTEventEmitter, STPApplePayContextDelegate, STPBankSelectionVi
         let merchantIdentifier = self.merchantIdentifier ?? ""
         let paymentRequest = StripeAPI.paymentRequest(withMerchantIdentifier: merchantIdentifier, country: country, currency: currency)
         
+        if (params["capabilityCredit"] as? Bool ?? false) {
+          paymentRequest.merchantCapabilities.update(with: .capabilityCredit)
+        }
+        if (params["capabilityDebit"] as? Bool ?? false) {
+          paymentRequest.merchantCapabilities.update(with: .capabilityDebit)
+        }
+        
         let requiredShippingAddressFields = params["requiredShippingAddressFields"] as? NSArray ?? NSArray()
         let requiredBillingContactFields = params["requiredBillingContactFields"] as? NSArray ?? NSArray()
         let shippingMethods = params["shippingMethods"] as? NSArray ?? NSArray()

--- a/src/types/ApplePay.ts
+++ b/src/types/ApplePay.ts
@@ -59,6 +59,8 @@ export namespace ApplePay {
   }
 
   export interface PresentParams {
+    capabilityCredit?: Boolean;
+    capabilityDebit?: Boolean;
     cartItems: CartSummaryItem[];
     country: string;
     currency: string;


### PR DESCRIPTION
These allow developers to pass `capabilityCredit: true` or `capabilityDebit: true` when opening
an Apple Pay interface to filter to only credit or debit cards.

See: https://developer.apple.com/documentation/apple_pay_on_the_web/applepaypaymentrequest/1916123-merchantcapabilities

Fixes #728 