### PR TITLE
Add `currencyCode` support to initPaymentSheet for Google Pay & Setup Intents

### DIFF
--- a/android/src/main/java/com/reactnativestripesdk/PaymentSheetFragment.kt
+++ b/android/src/main/java/com/reactnativestripesdk/PaymentSheetFragment.kt
@@ -46,6 +46,7 @@ class PaymentSheetFragment : Fragment() {
     val customerId = arguments?.getString("customerId").orEmpty()
     val customerEphemeralKeySecret = arguments?.getString("customerEphemeralKeySecret").orEmpty()
     val countryCode = arguments?.getString("merchantCountryCode").orEmpty()
+    val currencyCode = arguments?.getString("currencyCode").orEmpty()
     val googlePayEnabled = arguments?.getBoolean("googlePay")
     val testEnv = arguments?.getBoolean("testEnv")
     val allowsDelayedPaymentMethods = arguments?.getBoolean("allowsDelayedPaymentMethods")
@@ -109,7 +110,8 @@ class PaymentSheetFragment : Fragment() {
       ) else null,
       googlePay = if (googlePayEnabled == true) PaymentSheet.GooglePayConfiguration(
         environment = if (testEnv == true) PaymentSheet.GooglePayConfiguration.Environment.Test else PaymentSheet.GooglePayConfiguration.Environment.Production,
-        countryCode = countryCode
+        countryCode = countryCode,
+        currencyCode = currencyCode
       ) else null
     )
 

--- a/src/types/PaymentSheet.ts
+++ b/src/types/PaymentSheet.ts
@@ -37,11 +37,13 @@ export declare namespace PaymentSheet {
     | {
         googlePay?: true;
         merchantCountryCode: string;
+        currencyCode?: string;
         testEnv?: boolean;
       }
     | {
         googlePay?: false;
         merchantCountryCode?: string;
+        currencyCode?: string;
         testEnv?: boolean;
       };
   export interface Address {


### PR DESCRIPTION
Necessary to support Setup Intents including Google Pay

```
const { error } = await initPaymentSheet({
      customerId: customer,
      customerEphemeralKeySecret: ephemeralKey,
      setupIntentClientSecret: setupIntentClientSecret,
      customFlow: false,
      merchantDisplayName: 'Example Inc.',
      applePay: true,
      merchantCountryCode: 'US',
      currencyCode: 'USD', // this is required for setup intents
      style: 'automatic',
      googlePay: true,
      testEnv: true,
      primaryButtonColor: '#635BFF', // Blurple
      returnURL: 'stripe-example://stripe-redirect',
      defaultBillingDetails: billingDetails,
      allowsDelayedPaymentMethods: true,
    });
```