### PR TITLE
call ON_FRAGMENT_CREATED before INIT_PAYMENTSHEET to prevent potential null pointer crashes

### DIFF
--- a/android/src/main/java/com/reactnativestripesdk/PaymentSheetFragment.kt
+++ b/android/src/main/java/com/reactnativestripesdk/PaymentSheetFragment.kt
@@ -113,6 +113,10 @@ class PaymentSheetFragment : Fragment() {
       ) else null
     )
 
+    // Call ON_FRAGMENT_CREATED before ON_INIT_PAYMENT_SHEET
+    val intent = Intent(ON_FRAGMENT_CREATED)
+    localBroadcastManager.sendBroadcast(intent)
+
     if (arguments?.getBoolean("customFlow") == true) {
       flowController = PaymentSheet.FlowController.create(this, paymentOptionCallback, paymentResultCallback)
       configureFlowController()
@@ -122,8 +126,6 @@ class PaymentSheetFragment : Fragment() {
       localBroadcastManager.sendBroadcast(intent)
     }
 
-    val intent = Intent(ON_FRAGMENT_CREATED)
-    localBroadcastManager.sendBroadcast(intent)
   }
 
   fun present() {


### PR DESCRIPTION
We noticed that we get from the Flutter Stripe community some nullpinter exceptions that happen a bit randomly. See issue https://github.com/flutter-stripe/flutter_stripe/issues/416 .  In my current project I also saw this issue happen and it looks like a race condition that causes the following cast being executed in the StripeModule while the fragment is being null.

```kotlin
if (intent.action == ON_FRAGMENT_CREATED) {
        paymentSheetFragment = (currentActivity as AppCompatActivity).supportFragmentManager.findFragmentByTag("payment_sheet_launch_fragment") as PaymentSheetFragment
      }
```

After some investigation it looks like the promise is being resolved before the fragment is created. This fix will prevent this from happening.