### PR TITLE
fix: pass null instead of empty string for routing number

### DIFF
--- a/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
+++ b/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
@@ -417,29 +417,30 @@ class StripeSdkModule(private val reactContext: ReactApplicationContext) : React
   }
 
   private fun createTokenFromBankAccount(params: ReadableMap, promise: Promise) {
-    val accountHolderName = getValOr(params, "accountHolderName")
-    val accountHolderType = getValOr(params, "accountHolderType")
+    val accountHolderName = getValOr(params, "accountHolderName", null)
+    val accountHolderType = getValOr(params, "accountHolderType", null)
     val accountNumber = getValOr(params, "accountNumber", null)
     val country = getValOr(params, "country", null)
     val currency = getValOr(params, "currency", null)
-    val routingNumber = getValOr(params, "routingNumber")
+    val routingNumber = getValOr(params, "routingNumber", null)
 
-    runCatching {
-      val bankAccountParams = BankAccountTokenParams(
-        country = country!!,
-        currency = currency!!,
-        accountNumber = accountNumber!!,
-        accountHolderName = accountHolderName,
-        routingNumber = routingNumber,
-        accountHolderType = mapToBankAccountType(accountHolderType)
-      )
-      CoroutineScope(Dispatchers.IO).launch {
+    val bankAccountParams = BankAccountTokenParams(
+      country = country!!,
+      currency = currency!!,
+      accountNumber = accountNumber!!,
+      accountHolderName = accountHolderName,
+      routingNumber = routingNumber,
+      accountHolderType = mapToBankAccountType(accountHolderType)
+    )
+    CoroutineScope(Dispatchers.IO).launch {
+      runCatching {
         val token = stripe.createBankAccountToken(bankAccountParams, null, stripeAccountId)
         promise.resolve(createResult("token", mapFromToken(token)))
+      }.onFailure {
+        promise.resolve(createError(CreateTokenErrorType.Failed.toString(), it.message))
       }
-    }.onFailure {
-      promise.resolve(createError(CreateTokenErrorType.Failed.toString(), it.message))
     }
+
   }
 
   private fun createTokenFromCard(params: ReadableMap, promise: Promise) {

--- a/e2e/payments.test.ts
+++ b/e2e/payments.test.ts
@@ -189,4 +189,30 @@ describe('Common payment scenarios', () => {
     });
     expect(alert.getText()).toEqual('Success');
   });
+
+  it('Create tokens with a bank account and with a card', function () {
+    this.retries(1);
+    homeScreen.goTo('More payment scenarios');
+    homeScreen.goTo('Create tokens');
+
+    $('~payment-screen').waitForDisplayed({ timeout: 30000 });
+
+    getElementByText('Create a token from a bank account').click();
+    let alert = getElementByText('Success');
+    alert.waitForDisplayed({
+      timeout: 20000,
+    });
+    expect(alert.getText()).toEqual('Success');
+    alert.dismissAlert();
+
+    cardField.setCardNumber('4242424242424242');
+    cardField.setExpiryDate('12/22');
+    cardField.setCvcNumber('123');
+    getElementByText('Create a token from a card').click();
+    alert = getElementByText('Success');
+    alert.waitForDisplayed({
+      timeout: 20000,
+    });
+    expect(alert.getText()).toEqual('Success');
+  });
 });

--- a/e2e/screenObject/HomeScreen.ts
+++ b/e2e/screenObject/HomeScreen.ts
@@ -3,6 +3,7 @@
 const SCREENS = <const>[
   'Accept a payment',
   'More payment scenarios',
+  'Create tokens',
   'Set up future payments',
   'inalize payments on the server',
   'Bank Debits',

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -8,6 +8,7 @@ import ApplePayScreen from './screens/ApplePayScreen';
 import SetupFuturePaymentScreen from './screens/SetupFuturePaymentScreen';
 import { StatusBar } from 'react-native';
 import { colors } from './colors';
+import CreateTokenScreen from './screens/CreateTokenScreen';
 import PaymentsUICompleteScreen from './screens/PaymentsUICompleteScreen';
 import PaymentsUICustomScreen from './screens/PaymentsUICustomScreen';
 import CVCReCollectionScreen from './screens/CVCReCollectionScreen';
@@ -39,6 +40,7 @@ export type RootStackParamList = {
   WebhookPaymentScreen: undefined;
   HomeScreen: undefined;
   NoWebhookPaymentScreen: undefined;
+  CreateTokenScreen: undefined;
   ApplePayScreen: undefined;
   SetupFuturePaymentScreen: undefined;
   PaymentsUICompleteScreen: undefined;
@@ -114,7 +116,10 @@ export default function App() {
             name="AuBECSDebitSetupPaymentScreen"
             component={AuBECSDebitSetupPaymentScreen}
           />
-
+          <Stack.Screen
+            name="CreateTokenScreen"
+            component={CreateTokenScreen}
+          />
           <Stack.Screen name="ApplePayScreen" component={ApplePayScreen} />
           <Stack.Screen
             name="SetupFuturePaymentScreen"

--- a/example/src/screens/CreateTokenScreen.tsx
+++ b/example/src/screens/CreateTokenScreen.tsx
@@ -44,7 +44,11 @@ export default function CreateTokenScreen() {
         accessibilityLabel="Create a token from a bank account"
       />
       <Text style={styles.or}>OR</Text>
-      <CardField cardStyle={inputStyles} style={styles.cardField} />
+      <CardField
+        cardStyle={inputStyles}
+        style={styles.cardField}
+        postalCodeEnabled={false}
+      />
       <Button
         variant="primary"
         onPress={() => _createToken('Card')}

--- a/example/src/screens/CreateTokenScreen.tsx
+++ b/example/src/screens/CreateTokenScreen.tsx
@@ -1,0 +1,77 @@
+import {
+  CardField,
+  CardFieldInput,
+  useStripe,
+} from '@stripe/stripe-react-native';
+import React from 'react';
+import { Alert, StyleSheet, Text } from 'react-native';
+import Button from '../components/Button';
+import PaymentScreen from '../components/PaymentScreen';
+
+export default function CreateTokenScreen() {
+  const { createToken } = useStripe();
+
+  const _createToken = async (type: 'Card' | 'BankAccount') => {
+    const { error, token } = await createToken(
+      type === 'Card'
+        ? { type: 'Card' }
+        : {
+            type: 'BankAccount',
+            accountNumber: '000123456789',
+            routingNumber: '110000000', // Routing number is REQUIRED for US bank accounts
+            country: 'US',
+            currency: 'usd',
+          }
+    );
+
+    if (error) {
+      Alert.alert(`Error code: ${error.code}`, error.message);
+      console.log(`Error: ${JSON.stringify(error)}`);
+    } else if (token) {
+      Alert.alert(
+        'Success',
+        `The token was created successfully! token: ${token.id}`
+      );
+    }
+  };
+
+  return (
+    <PaymentScreen>
+      <Button
+        variant="primary"
+        onPress={() => _createToken('BankAccount')}
+        title="Create a token from a bank account"
+        accessibilityLabel="Create a token from a bank account"
+      />
+      <Text style={styles.or}>OR</Text>
+      <CardField cardStyle={inputStyles} style={styles.cardField} />
+      <Button
+        variant="primary"
+        onPress={() => _createToken('Card')}
+        title="Create a token from a card"
+        accessibilityLabel="Create a token from a card"
+      />
+    </PaymentScreen>
+  );
+}
+
+const styles = StyleSheet.create({
+  cardField: {
+    width: '100%',
+    height: 50,
+    marginVertical: 30,
+  },
+  or: {
+    textAlign: 'center',
+    marginTop: 30,
+  },
+});
+
+const inputStyles: CardFieldInput.Styles = {
+  borderWidth: 1,
+  backgroundColor: '#FFFFFF',
+  borderColor: '#000000',
+  borderRadius: 8,
+  fontSize: 14,
+  placeholderColor: '#999999',
+};

--- a/example/src/screens/HomeScreen.tsx
+++ b/example/src/screens/HomeScreen.tsx
@@ -112,7 +112,7 @@ export default function HomeScreen() {
           </View>
           <View style={styles.buttonContainer}>
             <Button
-              title="Create tokens to attach to customers"
+              title="Create tokens"
               onPress={() => {
                 navigation.navigate('CreateTokenScreen');
               }}

--- a/example/src/screens/HomeScreen.tsx
+++ b/example/src/screens/HomeScreen.tsx
@@ -110,6 +110,14 @@ export default function HomeScreen() {
               }}
             />
           </View>
+          <View style={styles.buttonContainer}>
+            <Button
+              title="Create tokens to attach to customers"
+              onPress={() => {
+                navigation.navigate('CreateTokenScreen');
+              }}
+            />
+          </View>
         </>
       </Collapse>
 

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -1,4 +1,5 @@
 import { createError, isAndroid, isiOS } from './helpers';
+import { MissingRoutingNumber } from './types/Errors';
 import NativeStripeSdk from './NativeStripeSdk';
 import {
   ApplePay,
@@ -57,6 +58,16 @@ export const createPaymentMethod = async (
 export const createToken = async (
   params: CreateTokenParams
 ): Promise<CreateTokenResult> => {
+  if (
+    params.type === 'BankAccount' &&
+    params.country?.toLowerCase() === 'us' &&
+    !params.routingNumber
+  ) {
+    return {
+      error: MissingRoutingNumber,
+    };
+  }
+
   try {
     const { token, error } = await NativeStripeSdk.createToken(params);
 

--- a/src/types/Errors.ts
+++ b/src/types/Errors.ts
@@ -66,3 +66,9 @@ export enum GooglePayError {
   Canceled = 'Canceled',
   Unknown = 'Unknown',
 }
+
+export const MissingRoutingNumber = {
+  code: CreateTokenError.Failed,
+  message:
+    'You must provide a routing number for US bank accounts. This should be the ACH routing number.',
+};


### PR DESCRIPTION
## Summary
Android apps would crash if routing number passed was an empty string, so now we default to null. Also added a check to help out folks in the US- routing numbers **are** required for US bank accounts.

Additionally, the `runCatching` block wasn't catching errors thrown inside of `CoroutineScope`, so moved that inside the block.

## Motivation
Fixes https://github.com/stripe/stripe-react-native/issues/807

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [x] I added automated tests

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
