### PR TITLE
Feat: add `isGooglePaySupported` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Unreleased
 
-- Fix: properly assign `cursorColor` style on Android `CardField` (requires Android 10 or higher).
+- [#810](https://github.com/stripe/stripe-react-native/pull/810) Feat: add `isGooglePaySupported` method
+- [#806](https://github.com/stripe/stripe-react-native/pull/806) Fix: properly assign `cursorColor` style on Android `CardField` (requires Android 10 or higher).
 
 ## 0.2.4 - 2022-02-10
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -137,4 +137,5 @@ dependencies {
   implementation 'androidx.appcompat:appcompat:1.2.0'
   implementation 'androidx.legacy:legacy-support-v4:1.0.0'
   implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.0'
+  implementation 'com.google.android.gms:play-services-wallet:19.0.1'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -137,5 +137,4 @@ dependencies {
   implementation 'androidx.appcompat:appcompat:1.2.0'
   implementation 'androidx.legacy:legacy-support-v4:1.0.0'
   implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.0'
-  implementation 'com.google.android.gms:play-services-wallet:19.0.1'
 }

--- a/android/src/main/java/com/reactnativestripesdk/GooglePayPaymentMethodLauncherFragment.kt
+++ b/android/src/main/java/com/reactnativestripesdk/GooglePayPaymentMethodLauncherFragment.kt
@@ -31,8 +31,8 @@ class GooglePayPaymentMethodLauncherFragment(
       config = GooglePayPaymentMethodLauncher.Config(
         environment = if (isTestEnv) GooglePayEnvironment.Test else GooglePayEnvironment.Production,
         existingPaymentMethodRequired = paymentMethodRequired,
-        merchantCountryCode = "",
-        merchantName = "",
+        merchantCountryCode = "", // Unnecessary since all we are checking for is Google Pay availability
+        merchantName = "",        // Same as above
       ),
       readyCallback = {
         promise.resolve(it)

--- a/android/src/main/java/com/reactnativestripesdk/GooglePayPaymentMethodLauncherFragment.kt
+++ b/android/src/main/java/com/reactnativestripesdk/GooglePayPaymentMethodLauncherFragment.kt
@@ -1,0 +1,44 @@
+package com.reactnativestripesdk
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.FrameLayout
+import androidx.appcompat.app.AppCompatActivity
+import androidx.fragment.app.Fragment
+import com.facebook.react.bridge.Promise
+import com.stripe.android.googlepaylauncher.GooglePayEnvironment
+import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher
+
+class GooglePayPaymentMethodLauncherFragment(
+  private val activity: AppCompatActivity,
+  private val isTestEnv: Boolean,
+  private val paymentMethodRequired: Boolean,
+  private val promise: Promise
+  ) : Fragment() {
+  override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?,
+                            savedInstanceState: Bundle?): View? {
+    return FrameLayout(requireActivity()).also {
+      it.visibility = View.GONE
+    }
+  }
+
+  override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+    super.onViewCreated(view, savedInstanceState)
+    GooglePayPaymentMethodLauncher(
+      this,
+      config = GooglePayPaymentMethodLauncher.Config(
+        environment = if (isTestEnv) GooglePayEnvironment.Test else GooglePayEnvironment.Production,
+        existingPaymentMethodRequired = paymentMethodRequired,
+        merchantCountryCode = "",
+        merchantName = "",
+      ),
+      readyCallback = {
+        promise.resolve(it)
+        activity.supportFragmentManager.beginTransaction().remove(this).commit()
+      },
+      resultCallback = {}
+    )
+  }
+}

--- a/docs/GooglePay.md
+++ b/docs/GooglePay.md
@@ -43,7 +43,7 @@ function App() {
 
 ## Initialize Google Pay
 
-Next, initialize a Google Pay by calling `initGooglePay` method. Call this on initial render of your checkout screen for best performance.
+First, check whether or not the device supports Google Pay by calling `isGooglePaySupported`. Once you know it's supported, initialize Google Pay by calling `initGooglePay`. Call this on initial render of your checkout screen for best performance.
 
 `initGooglePay` accepts several configuration options that can be customized for your needs.
 See [SDK Reference](https://stripe.dev/stripe-react-native/api-reference/index.html) for more details.
@@ -52,11 +52,16 @@ See [SDK Reference](https://stripe.dev/stripe-react-native/api-reference/index.h
 import { useGooglePay } from 'stripe-react-native';
 
 function CheckoutScreen() {
-  const { initGooglePay } = useGooglePay();
+  const { isGooglePaySupported, initGooglePay } = useGooglePay();
   const [initialized, setInitialized] = useState(false);
 
   useEffect(() => {
     async function initialize() {
+      if (!(await isGooglePaySupported())) {
+        Alert.alert('Google Pay is not supported.');
+        return;
+      }
+
       const { error } = await initGooglePay({
         testEnv: true,
         merchantName: 'Widget Store',

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -200,7 +200,6 @@ android {
 
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
-    implementation 'com.google.android.gms:play-services-wallet:18.1.2'
     //noinspection GradleDynamicVersion
     implementation "com.facebook.react:react-native:+"  // From node_modules
     implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.0.0"

--- a/example/src/screens/GooglePayScreen.tsx
+++ b/example/src/screens/GooglePayScreen.tsx
@@ -6,6 +6,7 @@ import { Alert, StyleSheet, View } from 'react-native';
 
 export default function GooglePayScreen() {
   const {
+    isGooglePaySupported,
     initGooglePay,
     presentGooglePay,
     loading,
@@ -71,6 +72,11 @@ export default function GooglePayScreen() {
 
   // 1. Initialize Google Pay
   const initialize = async () => {
+    if (!(await isGooglePaySupported({ testEnv: true }))) {
+      Alert.alert('Google Pay is not supported.');
+      return;
+    }
+
     const { error } = await initGooglePay({
       testEnv: true,
       merchantName: 'Test',

--- a/src/NativeStripeSdk.tsx
+++ b/src/NativeStripeSdk.tsx
@@ -66,6 +66,9 @@ type NativeStripeSdkType = {
   createTokenForCVCUpdate(cvc: string): Promise<CreateTokenForCVCUpdateResult>;
   handleURLCallback(url: string): Promise<boolean>;
   createToken(params: CreateTokenParams): Promise<CreateTokenResult>;
+  isGooglePaySupported(
+    params: GooglePay.IsGooglePaySupportedParams
+  ): Promise<boolean>;
   initGooglePay(params: GooglePay.InitParams): Promise<GooglePayInitResult>;
   presentGooglePay(
     params: GooglePay.PresentGooglePayParams

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -1,4 +1,4 @@
-import { createError, isiOS } from './helpers';
+import { createError, isAndroid, isiOS } from './helpers';
 import NativeStripeSdk from './NativeStripeSdk';
 import {
   ApplePay,
@@ -361,6 +361,14 @@ export const confirmPaymentSheetPayment =
       };
     }
   };
+
+export const isGooglePaySupported = async (
+  params?: GooglePay.IsGooglePaySupportedParams
+): Promise<boolean> => {
+  return (
+    isAndroid && (await NativeStripeSdk.isGooglePaySupported(params ?? {}))
+  );
+};
 
 export const initGooglePay = async (
   params: GooglePay.InitParams

--- a/src/hooks/useGooglePay.tsx
+++ b/src/hooks/useGooglePay.tsx
@@ -6,9 +6,25 @@ import { useStripe } from './useStripe';
  * useGooglePay hook
  */
 export function useGooglePay() {
-  const { initGooglePay, presentGooglePay, createGooglePayPaymentMethod } =
-    useStripe();
+  const {
+    isGooglePaySupported,
+    initGooglePay,
+    presentGooglePay,
+    createGooglePayPaymentMethod,
+  } = useStripe();
   const [loading, setLoading] = useState(false);
+
+  const _isGooglePaySupported = useCallback(
+    async (params?: GooglePay.IsGooglePaySupportedParams) => {
+      setLoading(true);
+
+      const result = await isGooglePaySupported(params);
+      setLoading(false);
+
+      return result;
+    },
+    [isGooglePaySupported]
+  );
 
   const _initGooglePay = useCallback(
     async (params: GooglePay.InitParams) => {
@@ -48,6 +64,7 @@ export function useGooglePay() {
 
   return {
     loading,
+    isGooglePaySupported: _isGooglePaySupported,
     initGooglePay: _initGooglePay,
     presentGooglePay: _presentGooglePay,
     createGooglePayPaymentMethod: _createGooglePayPaymentMethod,

--- a/src/hooks/useStripe.tsx
+++ b/src/hooks/useStripe.tsx
@@ -43,6 +43,7 @@ import {
   presentPaymentSheet,
   confirmPaymentSheetPayment,
   createToken,
+  isGooglePaySupported,
   initGooglePay,
   createGooglePayPaymentMethod,
   presentGooglePay,
@@ -191,6 +192,13 @@ export function useStripe() {
     []
   );
 
+  const _isGooglePaySupported = useCallback(
+    async (params?: GooglePay.IsGooglePaySupportedParams): Promise<boolean> => {
+      return isGooglePaySupported(params);
+    },
+    []
+  );
+
   const _initGooglePay = useCallback(
     async (params: GooglePay.InitParams): Promise<GooglePayInitResult> => {
       return initGooglePay(params);
@@ -238,6 +246,7 @@ export function useStripe() {
     presentPaymentSheet: _presentPaymentSheet,
     initPaymentSheet: _initPaymentSheet,
     createToken: _createToken,
+    isGooglePaySupported: _isGooglePaySupported,
     initGooglePay: _initGooglePay,
     presentGooglePay: _presentGooglePay,
     createGooglePayPaymentMethod: _createGooglePayPaymentMethod,

--- a/src/types/GooglePay.ts
+++ b/src/types/GooglePay.ts
@@ -28,8 +28,7 @@ export namespace GooglePay {
     clientSecret: string;
   }
 
-  export interface InitParams {
-    testEnv: boolean;
+  export type InitParams = {
     merchantName: string;
     countryCode: string;
     /**
@@ -42,14 +41,16 @@ export namespace GooglePay {
      * Default to `false`.
      */
     isEmailRequired?: boolean;
+  } & IsGooglePaySupportedParams;
+
+  export type IsGooglePaySupportedParams = {
+    testEnv?: boolean;
     /**
      * If `true`, Google Pay is considered ready if the customer's Google Pay wallet
-     * has existing payment methods.
-     *
-     * Default to `false`.
+     * has an existing payment method.
      */
     existingPaymentMethodRequired?: boolean;
-  }
+  };
 
   export interface BillingAddressConfig {
     isRequired?: boolean;


### PR DESCRIPTION
## Summary
Currently people need to `initGooglePay` and `catch` an error to find out if the device supports Google pay, which isn't great. By adding this method, we have parity with the native wallets on android and ios (which offers `isApplePaySupported`).

## Motivation

Closes https://github.com/stripe/stripe-react-native/issues/683 (popular feature request)

This PR also closes https://github.com/stripe/stripe-react-native/issues/607, and closes https://github.com/stripe/stripe-react-native/issues/617, and closes https://github.com/stripe/stripe-react-native/issues/725


## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually (on devices with and without google play services)
- [ ] I added automated tests

## Documentation

Select one: 
- [x] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
