### PR TITLE
fix: incorrect payment sheet shown

### DIFF
--- a/ios/StripeSdk.swift
+++ b/ios/StripeSdk.swift
@@ -156,6 +156,7 @@ class StripeSdk: RCTEventEmitter, STPApplePayContextDelegate, STPBankSelectionVi
                 }
             } else {
                 self.paymentSheet = PaymentSheet(paymentIntentClientSecret: paymentIntentClientSecret, configuration: configuration)
+                self.paymentSheetFlowController = nil
                 resolve([])
             }
         } else if let setupIntentClientSecret = params["setupIntentClientSecret"] as? String {
@@ -171,6 +172,7 @@ class StripeSdk: RCTEventEmitter, STPApplePayContextDelegate, STPBankSelectionVi
                 }
             } else {
                 self.paymentSheet = PaymentSheet(setupIntentClientSecret: setupIntentClientSecret, configuration: configuration)
+                self.paymentSheetFlowController = nil
                 resolve([])
             }
         } else {

--- a/ios/StripeSdk.swift
+++ b/ios/StripeSdk.swift
@@ -65,6 +65,7 @@ class StripeSdk: RCTEventEmitter, STPApplePayContextDelegate, STPBankSelectionVi
     func initPaymentSheet(params: NSDictionary, resolver resolve: @escaping RCTPromiseResolveBlock,
                           rejecter reject: @escaping RCTPromiseRejectBlock) -> Void  {
         var configuration = PaymentSheet.Configuration()
+        self.paymentSheetFlowController = nil
         
         if  params["applePay"] as? Bool == true {
             if let merchantIdentifier = self.merchantIdentifier, let merchantCountryCode = params["merchantCountryCode"] as? String {
@@ -156,7 +157,6 @@ class StripeSdk: RCTEventEmitter, STPApplePayContextDelegate, STPBankSelectionVi
                 }
             } else {
                 self.paymentSheet = PaymentSheet(paymentIntentClientSecret: paymentIntentClientSecret, configuration: configuration)
-                self.paymentSheetFlowController = nil
                 resolve([])
             }
         } else if let setupIntentClientSecret = params["setupIntentClientSecret"] as? String {
@@ -172,7 +172,6 @@ class StripeSdk: RCTEventEmitter, STPApplePayContextDelegate, STPBankSelectionVi
                 }
             } else {
                 self.paymentSheet = PaymentSheet(setupIntentClientSecret: setupIntentClientSecret, configuration: configuration)
-                self.paymentSheetFlowController = nil
                 resolve([])
             }
         } else {


### PR DESCRIPTION
## Summary

On iOS, the "custom-flow"-PaymentSheet is presented also for "non-custom-flow"-PaymentSheets after it has been opened once during the session. In order to fix this bug, I added `self.paymentSheetFlowController = nil` in `initPaymentSheet` when `customFlow == false` in order to open the correct PaymentSheet in `presentPaymentSheet` later on.

## Motivation

Fixes #608 

## Testing

- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
