### PR TITLE
fix: only call requestLayout on focus change

### DIFF
--- a/android/src/main/java/com/reactnativestripesdk/CardFormView.kt
+++ b/android/src/main/java/com/reactnativestripesdk/CardFormView.kt
@@ -34,8 +34,6 @@ class CardFormView(private val context: ThemedReactContext) : FrameLayout(contex
 
     addView(cardForm)
     setListeners()
-
-    viewTreeObserver.addOnGlobalLayoutListener { requestLayout() }
   }
 
   fun setPostalCodeEnabled(value: Boolean) {
@@ -96,6 +94,7 @@ class CardFormView(private val context: ThemedReactContext) : FrameLayout(contex
   }
 
   private fun onChangeFocus() {
+    requestLayout()
     mEventDispatcher?.dispatchEvent(
       CardFocusEvent(id, currentFocusedField))
   }

--- a/android/src/main/java/com/reactnativestripesdk/StripeSdkCardView.kt
+++ b/android/src/main/java/com/reactnativestripesdk/StripeSdkCardView.kt
@@ -41,8 +41,6 @@ class StripeSdkCardView(private val context: ThemedReactContext) : FrameLayout(c
 
     addView(mCardWidget)
     setListeners()
-
-    viewTreeObserver.addOnGlobalLayoutListener { requestLayout() }
   }
 
   fun setAutofocus(value: Boolean) {
@@ -229,6 +227,7 @@ class StripeSdkCardView(private val context: ThemedReactContext) : FrameLayout(c
       override fun onPostalCodeComplete() {}
 
       override fun onFocusChange(focusField: CardInputListener.FocusField) {
+        requestLayout()
         if (mEventDispatcher != null) {
           mEventDispatcher?.dispatchEvent(
             CardFocusEvent(id, focusField.name))


### PR DESCRIPTION
## Summary & Motivation

Previously, we were calling `requestLayout` whenever the global layout state or the visibility of views within the view tree changed. Now, we only call it when we need to (when focus changes)

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
