### PR TITLE
feat: add ios support for all aubecsform styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # CHANGELOG
 
+- [#845](https://github.com/stripe/stripe-react-native/pull/845) Feat: Added support for `placeholderColor`, `textErrorColor `, `borderColor`, `borderRadius`, and `borderWidth` for `AuBECSDebitForm` on iOS
+
 ## 0.4.0
 
 - [#821](https://github.com/stripe/stripe-react-native/pull/821) Feat: Add support for Klarna

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -292,7 +292,7 @@ PODS:
     - StripeApplePay (= 21.12.0)
     - StripeCore (= 21.12.0)
     - StripeUICore (= 21.12.0)
-  - stripe-react-native (0.3.0):
+  - stripe-react-native (0.4.0):
     - React-Core
     - Stripe (~> 21.12.0)
   - Stripe/Stripe3DS2 (21.12.0):
@@ -465,7 +465,7 @@ SPEC CHECKSUMS:
   RNCPicker: cb57c823d5ce8d2d0b5dfb45ad97b737260dc59e
   RNScreens: d6da2b9e29cf523832c2542f47bf1287318b1868
   Stripe: c3692f360abcdfeef9751e3c240e7efbc68b921f
-  stripe-react-native: a8e376386d39d8668c399eec23ca9fee3f23f97f
+  stripe-react-native: 624b96fa6725576f96d1c4af566ac00c3f1c3e8d
   StripeApplePay: 14db90fdf89abb2809ce41fc68bc6b1a86221408
   StripeCore: 5e38cdea3dc176a32d8797ef312fe1ab41571272
   StripeUICore: c28e371b385f968388ae38bedb93a2723c078442

--- a/example/src/screens/AuBECSDebitSetupPaymentScreen.tsx
+++ b/example/src/screens/AuBECSDebitSetupPaymentScreen.tsx
@@ -59,7 +59,16 @@ export default function AuBECSDebitSetupPaymentScreen() {
         onComplete={(value) => setFormDetails(value)}
         companyName="test"
         // eslint-disable-next-line react-native/no-inline-styles
-        formStyle={{ fontSize: 20 }}
+        formStyle={{
+          borderWidth: 2.5,
+          backgroundColor: '#ffffff',
+          borderColor: '#D3D3D3',
+          borderRadius: 10.9,
+          textColor: '#000000',
+          fontSize: 20,
+          placeholderColor: '#D3D3D3',
+          textErrorColor: '#ff0000',
+        }}
       />
 
       <View style={styles.buttonContainer}>

--- a/ios/AuBECSDebitFormView.swift
+++ b/ios/AuBECSDebitFormView.swift
@@ -43,6 +43,21 @@ class AuBECSDebitFormView: UIView, STPAUBECSDebitFormViewDelegate {
         if let backgroundColor = formStyle["backgroundColor"] as? String {
             auBecsFormView?.formBackgroundColor = UIColor(hexString: backgroundColor)
         }
+        if let placeholderColor = formStyle["placeholderColor"] as? String {
+            auBecsFormView?.formPlaceholderColor = UIColor(hexString: placeholderColor)
+        }
+        if let textErrorColor = formStyle["textErrorColor"] as? String {
+            auBecsFormView?.formTextErrorColor = UIColor(hexString: textErrorColor)
+        }
+        if let borderColor = formStyle["borderColor"] as? String {
+            auBecsFormView?.layer.borderColor = UIColor(hexString: borderColor).cgColor
+        }
+        if let borderRadius = formStyle["borderRadius"] as? CGFloat {
+            auBecsFormView?.layer.cornerRadius = borderRadius
+        }
+        if let borderWidth = formStyle["borderWidth"] as? CGFloat {
+            auBecsFormView?.layer.borderWidth = borderWidth
+        }
     }
     
     func auBECSDebitForm(_ form: STPAUBECSDebitFormView, didChangeToStateComplete complete: Bool) {


### PR DESCRIPTION
## Summary
Added support for `placeholderColor`, `textErrorColor `, `borderColor`, `borderRadius`, and `borderWidth` for `AuBECSDebitForm` on iOS

## Motivation
Platform compatibility- these styles were supported on Android, but not on iOS

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
- [x] Typescript autodocs
