### PR TITLE
fix: add check to avoid crashes when currentActivity is null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # CHANGELOG
 
+- [#846](https://github.com/stripe/stripe-react-native/pull/846) Fix: Avoid crashes when `currentActivity` is null
 - [#879](https://github.com/stripe/stripe-react-native/pull/879) Feat: Add support for ACHv2 payments on Android (already existed on iOS).
 - [#879](https://github.com/stripe/stripe-react-native/pull/879) Chore: Upgraded `stripe-android` from v19.3.+ to v20.0.+
 - [#837](https://github.com/stripe/stripe-react-native/pull/837) BREAKING CHANGE: Mostly fixes and changes to types, but some method's now accept slightly different parameters:

--- a/android/src/main/java/com/reactnativestripesdk/CollectBankAccountLauncherFragment.kt
+++ b/android/src/main/java/com/reactnativestripesdk/CollectBankAccountLauncherFragment.kt
@@ -8,6 +8,7 @@ import android.widget.FrameLayout
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.ReactApplicationContext
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.SetupIntent
 import com.stripe.android.model.StripeIntent
@@ -16,7 +17,7 @@ import com.stripe.android.payments.bankaccount.CollectBankAccountLauncher
 import com.stripe.android.payments.bankaccount.navigation.CollectBankAccountResult
 
 class CollectBankAccountLauncherFragment(
-  private val activity: AppCompatActivity,
+  private val context: ReactApplicationContext,
   private val publishableKey: String,
   private val clientSecret: String,
   private val isPaymentIntent: Boolean,
@@ -77,7 +78,7 @@ class CollectBankAccountLauncherFragment(
           promise.resolve(createError(ErrorType.Failed.toString(), result.error))
         }
       }
-      activity.supportFragmentManager.beginTransaction().remove(this).commit()
+      (context.currentActivity as? AppCompatActivity)?.supportFragmentManager?.beginTransaction()?.remove(this)?.commit()
     }
   }
 }

--- a/android/src/main/java/com/reactnativestripesdk/Constants.kt
+++ b/android/src/main/java/com/reactnativestripesdk/Constants.kt
@@ -5,7 +5,6 @@ var ON_PAYMENT_OPTION_ACTION = "com.reactnativestripesdk.PAYMENT_OPTION_ACTION"
 var ON_CONFIGURE_FLOW_CONTROLLER = "com.reactnativestripesdk.CONFIGURE_FLOW_CONTROLLER_ACTION"
 var ON_INIT_PAYMENT_SHEET = "com.reactnativestripesdk.INIT_PAYMENT_SHEET"
 
-var ON_GOOGLE_PAY_FRAGMENT_CREATED = "com.reactnativestripesdk.ON_GOOGLE_PAY_FRAGMENT_CREATED"
 var ON_INIT_GOOGLE_PAY = "com.reactnativestripesdk.ON_INIT_GOOGLE_PAY"
 var ON_GOOGLE_PAY_RESULT = "com.reactnativestripesdk.ON_GOOGLE_PAY_RESULT"
 var ON_GOOGLE_PAYMENT_METHOD_RESULT = "com.reactnativestripesdk.ON_GOOGLE_PAYMENT_METHOD_RESULT"

--- a/android/src/main/java/com/reactnativestripesdk/Errors.kt
+++ b/android/src/main/java/com/reactnativestripesdk/Errors.kt
@@ -59,6 +59,16 @@ internal fun createError(code: String, message: String?): WritableMap {
   return mapError(code, message, message, null, null, null)
 }
 
+internal fun createMissingActivityError(): WritableMap {
+  return mapError(
+    "Failed",
+    "Activity doesn't exist yet. You can safely retry this method.",
+    null,
+    null,
+    null,
+    null)
+}
+
 internal fun createError(code: String, error: PaymentIntent.Error?): WritableMap {
   return mapError(code, error?.message, error?.message, error?.declineCode, error?.type?.code, error?.code)
 }

--- a/android/src/main/java/com/reactnativestripesdk/GooglePayFragment.kt
+++ b/android/src/main/java/com/reactnativestripesdk/GooglePayFragment.kt
@@ -87,9 +87,6 @@ class GooglePayFragment : Fragment() {
       readyCallback = ::onGooglePayLauncherReady,
       resultCallback = ::onGooglePayResult
     )
-
-    val intent = Intent(ON_GOOGLE_PAY_FRAGMENT_CREATED)
-    localBroadcastManager.sendBroadcast(intent)
   }
 
   fun presentForPaymentIntent(clientSecret: String) {

--- a/android/src/main/java/com/reactnativestripesdk/GooglePayPaymentMethodLauncherFragment.kt
+++ b/android/src/main/java/com/reactnativestripesdk/GooglePayPaymentMethodLauncherFragment.kt
@@ -8,11 +8,12 @@ import android.widget.FrameLayout
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.ReactApplicationContext
 import com.stripe.android.googlepaylauncher.GooglePayEnvironment
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher
 
 class GooglePayPaymentMethodLauncherFragment(
-  private val activity: AppCompatActivity,
+  private val context: ReactApplicationContext,
   private val isTestEnv: Boolean,
   private val paymentMethodRequired: Boolean,
   private val promise: Promise
@@ -36,7 +37,7 @@ class GooglePayPaymentMethodLauncherFragment(
       ),
       readyCallback = {
         promise.resolve(it)
-        activity.supportFragmentManager.beginTransaction().remove(this).commit()
+        (context.currentActivity as? AppCompatActivity)?.supportFragmentManager?.beginTransaction()?.remove(this)?.commit()
       },
       resultCallback = {}
     )

--- a/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
+++ b/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
@@ -50,9 +50,6 @@ class StripeSdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJ
   private var initGooglePayPromise: Promise? = null
   private var presentGooglePayPromise: Promise? = null
 
-  private val currentActivity: AppCompatActivity?
-    get() = (super.getCurrentActivity() as? AppCompatActivity)
-
   private val mActivityEventListener = object : BaseActivityEventListener() {
     override fun onActivityResult(activity: Activity, requestCode: Int, resultCode: Int, data: Intent?) {
       if (::stripe.isInitialized) {
@@ -239,7 +236,7 @@ class StripeSdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJ
   @ReactMethod
   @SuppressWarnings("unused")
   fun initPaymentSheet(params: ReadableMap, promise: Promise) {
-    currentActivity?.let { activity ->
+    getCurrentActivityOrResolveWithError(promise)?.let { activity ->
       this.initPaymentSheetPromise = promise
 
       paymentSheetFragment = PaymentSheetFragment().also {
@@ -249,8 +246,6 @@ class StripeSdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJ
       activity.supportFragmentManager.beginTransaction()
         .add(paymentSheetFragment!!, "payment_sheet_launch_fragment")
         .commit()
-    } ?: run {
-      promise.resolve(createMissingActivityError())
     }
   }
 
@@ -269,14 +264,12 @@ class StripeSdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJ
   }
 
   private fun payWithFpx() {
-    currentActivity?.let {
+    getCurrentActivityOrResolveWithError(confirmPromise)?.let {
       AddPaymentMethodActivityStarter(it)
         .startForResult(AddPaymentMethodActivityStarter.Args.Builder()
                           .setPaymentMethodType(PaymentMethod.Type.Fpx)
                           .build()
         )
-    } ?: run {
-      confirmPromise?.resolve(createMissingActivityError())
     }
   }
 
@@ -562,7 +555,7 @@ class StripeSdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJ
   @ReactMethod
   @SuppressWarnings("unused")
   fun isGooglePaySupported(params: ReadableMap?, promise: Promise) {
-    currentActivity?.let {
+    getCurrentActivityOrResolveWithError(promise)?.let {
       val fragment = GooglePayPaymentMethodLauncherFragment(
         it,
         getBooleanOrFalse(params, "testEnv"),
@@ -573,8 +566,6 @@ class StripeSdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJ
       it.supportFragmentManager.beginTransaction()
         .add(fragment, "google_pay_support_fragment")
         .commit()
-    } ?: run {
-      promise.resolve(createMissingActivityError())
     }
   }
 
@@ -586,14 +577,12 @@ class StripeSdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJ
       it.arguments = bundle
     }
 
-    currentActivity?.let {
+    getCurrentActivityOrResolveWithError(promise)?.let {
       initGooglePayPromise = promise
 
       it.supportFragmentManager.beginTransaction()
         .add(googlePayFragment!!, "google_pay_launch_fragment")
         .commit()
-    } ?: run {
-      promise.resolve(createMissingActivityError())
     }
   }
 

--- a/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
+++ b/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
@@ -50,6 +50,9 @@ class StripeSdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJ
   private var initGooglePayPromise: Promise? = null
   private var presentGooglePayPromise: Promise? = null
 
+  private val currentActivity: AppCompatActivity?
+    get() = (super.getCurrentActivity() as? AppCompatActivity)
+
   private val mActivityEventListener = object : BaseActivityEventListener() {
     override fun onActivityResult(activity: Activity, requestCode: Int, resultCode: Int, data: Intent?) {
       if (::stripe.isInitialized) {
@@ -90,7 +93,7 @@ class StripeSdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJ
   private val googlePayReceiver: BroadcastReceiver = object : BroadcastReceiver() {
     override fun onReceive(context: Context?, intent: Intent) {
       if (intent.action == ON_GOOGLE_PAY_FRAGMENT_CREATED) {
-        (currentActivity as? AppCompatActivity)?.let {
+        currentActivity?.let {
           googlePayFragment = it.supportFragmentManager.findFragmentByTag("google_pay_launch_fragment") as GooglePayFragment
         }
       }
@@ -238,7 +241,7 @@ class StripeSdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJ
   @ReactMethod
   @SuppressWarnings("unused")
   fun initPaymentSheet(params: ReadableMap, promise: Promise) {
-    (currentActivity as? AppCompatActivity)?.let { activity ->
+    currentActivity?.let { activity ->
       this.initPaymentSheetPromise = promise
 
       paymentSheetFragment = PaymentSheetFragment().also {
@@ -268,7 +271,7 @@ class StripeSdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJ
   }
 
   private fun payWithFpx() {
-    (currentActivity as? AppCompatActivity)?.let {
+    currentActivity?.let {
       AddPaymentMethodActivityStarter(it)
         .startForResult(AddPaymentMethodActivityStarter.Args.Builder()
                           .setPaymentMethodType(PaymentMethod.Type.Fpx)
@@ -561,7 +564,7 @@ class StripeSdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJ
   @ReactMethod
   @SuppressWarnings("unused")
   fun isGooglePaySupported(params: ReadableMap?, promise: Promise) {
-    (currentActivity as? AppCompatActivity)?.let {
+    currentActivity?.let {
       val fragment = GooglePayPaymentMethodLauncherFragment(
         it,
         getBooleanOrFalse(params, "testEnv"),
@@ -585,7 +588,7 @@ class StripeSdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJ
       it.arguments = bundle
     }
 
-    (currentActivity as? AppCompatActivity)?.let {
+    currentActivity?.let {
       initGooglePayPromise = promise
 
       it.supportFragmentManager.beginTransaction()

--- a/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
+++ b/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
@@ -238,14 +238,14 @@ class StripeSdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJ
   @ReactMethod
   @SuppressWarnings("unused")
   fun initPaymentSheet(params: ReadableMap, promise: Promise) {
-    (currentActivity as? AppCompatActivity)?.let {
+    (currentActivity as? AppCompatActivity)?.let { activity ->
       this.initPaymentSheetPromise = promise
 
       paymentSheetFragment = PaymentSheetFragment().also {
         val bundle = toBundleObject(params)
         it.arguments = bundle
       }
-      it.supportFragmentManager.beginTransaction()
+      activity.supportFragmentManager.beginTransaction()
         .add(paymentSheetFragment!!, "payment_sheet_launch_fragment")
         .commit()
     } ?: run {


### PR DESCRIPTION
## Summary

We weren't always appropriately null-checking `currentActivity`, and the typecast could result in crashes. We now resolve with a consistent and useful error telling the user they can retry the method.

## Motivation
closes https://github.com/stripe/stripe-react-native/issues/844 and I'm sure other instances of crashes on Android
closes https://github.com/stripe/stripe-react-native/issues/881

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [ ] I tested this manually
- [ ] I added automated tests

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
