### PR TITLE
chore: upgrade to appcompat 1.4.1

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -134,7 +134,7 @@ dependencies {
   implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.3.1"
   implementation 'com.stripe:stripe-android:19.3.+'
   implementation 'com.google.android.material:material:1.3.0'
-  implementation 'androidx.appcompat:appcompat:1.2.0'
+  implementation 'androidx.appcompat:appcompat:1.4.1'
   implementation 'androidx.legacy:legacy-support-v4:1.0.0'
   implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.0'
 }


### PR DESCRIPTION
## Summary
Upgrade appcompat dependency

## Motivation
Match stripe-android version, and this should be upgraded before RN 68 release anyways.

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
