### PR TITLE
fix: handle require payment method error on confirmSetupIntent on android

### DIFF
--- a/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
+++ b/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
@@ -66,6 +66,9 @@ class StripeSdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJ
               StripeIntent.Status.RequiresAction -> {
                 confirmSetupIntentPromise?.resolve(createError(ConfirmSetupIntentErrorType.Canceled.toString(), setupIntent.lastSetupError))
               }
+              StripeIntent.Status.RequiresPaymentMethod -> {
+                confirmSetupIntentPromise?.resolve(createError(ConfirmSetupIntentErrorType.Canceled.toString(), setupIntent.lastSetupError))
+              }
               else -> {
                 val errorMessage = "unhandled error: ${setupIntent.status}"
                 confirmSetupIntentPromise?.resolve(createError(ConfirmSetupIntentErrorType.Failed.toString(), errorMessage))


### PR DESCRIPTION
## Summary
Handle RequiresPaymentMethod error from confirmSetupIntent so that error information matches iOS implementation

## Motivation
Whilst testing our switch from tipsi-stripe to this package, I noticed a difference in the error's returned from confirmSetupIntent on iOS vs Android. If a card is declined the error is now available on android and iOS for display to the user. Previous to this PR - instead of the actual error android returned `unhandled error: requires payment method`

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
