### PR TITLE
fix: create custom babel plugin for package.json imports in `src/`

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -4,10 +4,10 @@ module.exports = {
     function ModifyPackageJsonImportForTranspilation() {
       return {
         visitor: {
-          ImportDeclaration(path, _state) {
-            const { node } = path;
-            if (node.source.value === '../../package.json') {
-              node.source.value = '../../../package.json';
+          ImportDeclaration(path) {
+            let importResource = path.node.source.value ?? '';
+            if (importResource.includes('../package.json')) {
+              importResource = '../' + importResource;
             }
           },
         },

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,3 +1,17 @@
 module.exports = {
   presets: ['module:metro-react-native-babel-preset'],
+  plugins: [
+    function ModifyPackageJsonImportForTranspilation() {
+      return {
+        visitor: {
+          ImportDeclaration(path, _state) {
+            const { node } = path;
+            if (node.source.value === '../../package.json') {
+              node.source.value = '../../../package.json';
+            }
+          },
+        },
+      };
+    },
+  ],
 };


### PR DESCRIPTION
## Summary

babel plugin identifies import declarations that need to be modified for transpilation. right now, that's only the `../../package.json` import

## Motivation
fixes https://github.com/stripe/stripe-react-native/issues/841

## Testing

run `yarn prepare` with these changes, and `lib/commonjs/components/StripeProvider.js` and `lib/module/components/StripeProvider.js` have the correct file path


