### PR TITLE
breaking: use a cardDetails prop for AddToWalletButton component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,13 @@
 
 ## Unreleased
 
-- [#913](https://github.com/stripe/stripe-react-native/pull/913) chore: Updated `stripe-ios` from 22.0.0 to 22.2.0.
-- [#913](https://github.com/stripe/stripe-react-native/pull/913) BREAKING CHANGE: Changed props for the `AddToWalletButton` component. Instead of passing `cardHolderName`, `cardLastFour`, `cardDescription`, and `cardBrand` directly as props, you will instead pass a `cardDetails` prop, which is an object containing the following fields:
+- [#913](https://github.com/stripe/stripe-react-native/pull/913) BREAKING CHANGE: Changed props for the `<AddToWalletButton />` component. Instead of passing `cardHolderName`, `cardLastFour`, `cardDescription`, and `cardBrand` directly as props, you will instead pass a `cardDetails` prop, which is an object containing the following fields:
   - `primaryAccountIdentifier`: The `wallet.primary_account_identifier` value from the issued card.
   - `name`: The card holder name (previously `cardHolderName`).
   - `description`: A user-facing description of the card (previously `cardDescription`).
   - `lastFour`: Last 4 digits of the card, optional (previously `cardLastFour`).
   - `brand`: The card brand, optional (previously `cardBrand`).
+- [#913](https://github.com/stripe/stripe-react-native/pull/913) chore: Updated `stripe-ios` from 22.0.0 to 22.2.0.
 
 ## 0.8.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+## Unreleased
+
+- [#913](https://github.com/stripe/stripe-react-native/pull/913) chore: Updated `stripe-ios` from 22.0.0 to 22.2.0.
+- [#913](https://github.com/stripe/stripe-react-native/pull/913) BREAKING CHANGE: Changed props for the `AddToWalletButton` component. Instead of passing `cardHolderName`, `cardLastFour`, `cardDescription`, and `cardBrand` directly as props, you will instead pass a `cardDetails` prop, which is an object containing the following fields:
+  - `primaryAccountIdentifier`: The `wallet.primary_account_identifier` value from the issued card.
+  - `name`: The card holder name (previously `cardHolderName`).
+  - `description`: A user-facing description of the card (previously `cardDescription`).
+  - `lastFour`: Last 4 digits of the card, optional (previously `cardLastFour`).
+  - `brand`: The card brand, optional (previously `cardBrand`).
+
 ## 0.8.0
 
 - [#902](https://github.com/stripe/stripe-react-native/pull/902) fix: create custom babel plugin for package.json imports in src/

--- a/android/src/main/java/com/reactnativestripesdk/pushprovisioning/AddToWalletButtonManager.kt
+++ b/android/src/main/java/com/reactnativestripesdk/pushprovisioning/AddToWalletButtonManager.kt
@@ -38,14 +38,9 @@ class AddToWalletButtonManager(applicationContext: ReactApplicationContext) : Si
     view.setSourceMap(source)
   }
 
-  @ReactProp(name = "cardDescription")
-  fun cardDescription(view: AddToWalletButtonView, cardDescription: String) {
-    view.setCardDescription(cardDescription)
-  }
-
-  @ReactProp(name = "cardLastFour")
-  fun cardLastFour(view: AddToWalletButtonView, last4: String) {
-    view.setCardLastFour(last4)
+  @ReactProp(name = "cardDetails")
+  fun cardDetails(view: AddToWalletButtonView, cardDetails: ReadableMap) {
+    view.setCardDetails(cardDetails)
   }
 
   @ReactProp(name = "ephemeralKey")

--- a/android/src/main/java/com/reactnativestripesdk/pushprovisioning/AddToWalletButtonView.kt
+++ b/android/src/main/java/com/reactnativestripesdk/pushprovisioning/AddToWalletButtonView.kt
@@ -22,8 +22,7 @@ import com.reactnativestripesdk.createError
 
 
 class AddToWalletButtonView(private val context: ThemedReactContext, private val requestManager: RequestManager) : AppCompatImageView(context) {
-  private var cardDescription: String? = null
-  private var cardLastFour: String? = null
+  private var cardDetails: ReadableMap? = null
   private var ephemeralKey: String? = null
   private var sourceMap: ReadableMap? = null
   private var token: ReadableMap? = null
@@ -35,7 +34,8 @@ class AddToWalletButtonView(private val context: ThemedReactContext, private val
 
   override fun performClick(): Boolean {
     super.performClick()
-    cardDescription?.let { cardDescription ->
+
+    cardDetails?.getString("description")?.let { cardDescription ->
       ephemeralKey?.let { ephemeralKey ->
         PushProvisioningProxy.invoke(
           context.reactApplicationContext,
@@ -50,7 +50,7 @@ class AddToWalletButtonView(private val context: ThemedReactContext, private val
       }
     } ?: run {
       dispatchEvent(
-        createError("Failed", "Missing parameters. `cardDescription` must be supplied in the props to <AddToWalletButton />")
+        createError("Failed", "Missing parameters. `cardDetails.cardDescription` must be supplied in the props to <AddToWalletButton />")
       )
     }
     return true
@@ -125,12 +125,8 @@ class AddToWalletButtonView(private val context: ThemedReactContext, private val
     sourceMap = map
   }
 
-  fun setCardDescription(description: String) {
-    cardDescription = description
-  }
-
-  fun setCardLastFour(last4: String) {
-    cardLastFour = last4
+  fun setCardDetails(detailsMap: ReadableMap) {
+    cardDetails = detailsMap
   }
 
   fun setEphemeralKey(map: ReadableMap) {

--- a/e2e/payments.test.ts
+++ b/e2e/payments.test.ts
@@ -232,19 +232,29 @@ describe('Common payment scenarios', () => {
     BasicPaymentScreen.authorizeACH();
     driver.pause(3000);
 
-    expect(driver.getAlertText()).toContain('RequiresConfirmation');
-    driver.dismissAlert();
+    let alert = getElementByText('RequiresConfirmation');
+    alert.waitForDisplayed({
+      timeout: 20000,
+    });
+    alert.dismissAlert();
 
     clickButtonContainingText('Confirm');
     driver.pause(3000);
 
-    expect(driver.getAlertText()).toContain('Awaiting verification');
-    driver.dismissAlert();
+    alert = getElementByText('Awaiting verification');
+    alert.waitForDisplayed({
+      timeout: 20000,
+    });
+    alert.dismissAlert();
 
     getElementByText('Verify microdeposit').click();
     driver.pause(3000);
 
-    expect(driver.getAlertText()).toContain('Processing');
+    alert = getElementByText('Processing');
+    alert.waitForDisplayed({
+      timeout: 20000,
+    });
+    alert.dismissAlert();
   });
 
   it('ACH Setup', function () {
@@ -259,18 +269,28 @@ describe('Common payment scenarios', () => {
     BasicPaymentScreen.authorizeACH();
     driver.pause(3000);
 
-    expect(driver.getAlertText()).toContain('RequiresConfirmation');
-    driver.dismissAlert();
+    let alert = getElementByText('RequiresConfirmation');
+    alert.waitForDisplayed({
+      timeout: 20000,
+    });
+    alert.dismissAlert();
 
     clickButtonContainingText('Confirm');
     driver.pause(3000);
 
-    expect(driver.getAlertText()).toContain('Awaiting verification');
-    driver.dismissAlert();
+    alert = getElementByText('Awaiting verification');
+    alert.waitForDisplayed({
+      timeout: 20000,
+    });
+    alert.dismissAlert();
 
     getElementByText('Verify microdeposit').click();
     driver.pause(3000);
 
-    expect(driver.getAlertText()).toContain('Succeeded');
+    alert = getElementByText('Succeeded');
+    alert.waitForDisplayed({
+      timeout: 20000,
+    });
+    alert.dismissAlert();
   });
 });

--- a/e2e/payments.test.ts
+++ b/e2e/payments.test.ts
@@ -231,7 +231,7 @@ describe('Common payment scenarios', () => {
 
     BasicPaymentScreen.authorizeACH();
 
-    let alert = getElementByText('RequiresConfirmation');
+    let alert = getElementByText('Requires Confirmation');
     alert.waitForDisplayed({
       timeout: 20000,
     });
@@ -267,7 +267,7 @@ describe('Common payment scenarios', () => {
 
     BasicPaymentScreen.authorizeACH();
 
-    let alert = getElementByText('RequiresConfirmation');
+    let alert = getElementByText('Requires Confirmation');
     alert.waitForDisplayed({
       timeout: 20000,
     });

--- a/e2e/payments.test.ts
+++ b/e2e/payments.test.ts
@@ -221,7 +221,7 @@ describe('Common payment scenarios', () => {
   });
 
   it('ACH Payment', function () {
-    this.retries(3);
+    this.retries(2);
 
     homeScreen.goTo('Bank Debits');
     homeScreen.goTo('ACH payment');
@@ -230,7 +230,6 @@ describe('Common payment scenarios', () => {
     clickButtonContainingText('Collect bank account');
 
     BasicPaymentScreen.authorizeACH();
-    driver.pause(3000);
 
     let alert = getElementByText('RequiresConfirmation');
     alert.waitForDisplayed({
@@ -258,7 +257,7 @@ describe('Common payment scenarios', () => {
   });
 
   it('ACH Setup', function () {
-    this.retries(3);
+    this.retries(2);
 
     homeScreen.goTo('Bank Debits');
     homeScreen.goTo('ACH setup');
@@ -267,7 +266,6 @@ describe('Common payment scenarios', () => {
     clickButtonContainingText('Collect bank account');
 
     BasicPaymentScreen.authorizeACH();
-    driver.pause(3000);
 
     let alert = getElementByText('RequiresConfirmation');
     alert.waitForDisplayed({

--- a/e2e/screenObject/BasicPaymentScreen.ts
+++ b/e2e/screenObject/BasicPaymentScreen.ts
@@ -104,7 +104,6 @@ class BasicPaymentScreen {
 
           button = $(`button*=Done`);
           button.click();
-          driver.pause(5000);
           break;
         }
       } catch (e) {
@@ -114,6 +113,7 @@ class BasicPaymentScreen {
       }
     }
     driver.switchContext(getNativeContext());
+    driver.pause(5000);
   }
 }
 

--- a/e2e/screenObject/BasicPaymentScreen.ts
+++ b/e2e/screenObject/BasicPaymentScreen.ts
@@ -81,21 +81,24 @@ class BasicPaymentScreen {
         let button = $(`button*=Manually verify instead`);
         if (button.isDisplayed()) {
           button.click();
-          driver.pause(5000);
+          driver.pause(2000);
 
           button = $(`//input[@name='confirmAccountNumber']`);
           button.click();
           button.sendKeys(['000123456789\n']);
+          driver.pause(2000);
 
           button = $(`//input[@name='routingNumber']`);
           button.click();
           button.click();
           button.sendKeys(['110000000\n']);
+          driver.pause(2000);
 
           button = $(`//input[@name='accountNumber']`);
           button.click();
           button.click();
           button.sendKeys(['000123456789\n']);
+          driver.pause(2000);
 
           button = $(`button*=Continue`);
           button.click();

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -287,27 +287,27 @@ PODS:
   - RNScreens (3.10.2):
     - React-Core
     - React-RCTImage
-  - Stripe (22.0.0):
-    - Stripe/Stripe3DS2 (= 22.0.0)
-    - StripeApplePay (= 22.0.0)
-    - StripeCore (= 22.0.0)
-    - StripeUICore (= 22.0.0)
-  - stripe-react-native (0.7.0):
+  - Stripe (22.2.0):
+    - Stripe/Stripe3DS2 (= 22.2.0)
+    - StripeApplePay (= 22.2.0)
+    - StripeCore (= 22.2.0)
+    - StripeUICore (= 22.2.0)
+  - stripe-react-native (0.8.0):
     - React-Core
-    - Stripe (~> 22.0.0)
-    - StripeConnections (~> 22.0.0)
-  - Stripe/Stripe3DS2 (22.0.0):
-    - StripeApplePay (= 22.0.0)
-    - StripeCore (= 22.0.0)
-    - StripeUICore (= 22.0.0)
-  - StripeApplePay (22.0.0):
-    - StripeCore (= 22.0.0)
-  - StripeConnections (22.0.0):
-    - StripeCore (= 22.0.0)
-    - StripeUICore (= 22.0.0)
-  - StripeCore (22.0.0)
-  - StripeUICore (22.0.0):
-    - StripeCore (= 22.0.0)
+    - Stripe (~> 22.2.0)
+    - StripeFinancialConnections (~> 22.2.0)
+  - Stripe/Stripe3DS2 (22.2.0):
+    - StripeApplePay (= 22.2.0)
+    - StripeCore (= 22.2.0)
+    - StripeUICore (= 22.2.0)
+  - StripeApplePay (22.2.0):
+    - StripeCore (= 22.2.0)
+  - StripeCore (22.2.0)
+  - StripeFinancialConnections (22.2.0):
+    - StripeCore (= 22.2.0)
+    - StripeUICore (= 22.2.0)
+  - StripeUICore (22.2.0):
+    - StripeCore (= 22.2.0)
   - Yoga (1.14.0)
 
 DEPENDENCIES:
@@ -355,8 +355,8 @@ SPEC REPOS:
     - fmt
     - Stripe
     - StripeApplePay
-    - StripeConnections
     - StripeCore
+    - StripeFinancialConnections
     - StripeUICore
 
 EXTERNAL SOURCES:
@@ -469,12 +469,12 @@ SPEC CHECKSUMS:
   RNCMaskedView: c298b644a10c0c142055b3ae24d83879ecb13ccd
   RNCPicker: cb57c823d5ce8d2d0b5dfb45ad97b737260dc59e
   RNScreens: d6da2b9e29cf523832c2542f47bf1287318b1868
-  Stripe: ee32e594fa4dee4bdf2a8a3039f7fb07a21075dc
-  stripe-react-native: 165df7efcedb14f15b8e2ddff20cedd6e6c42fca
-  StripeApplePay: e09964f3e2c6b318e53a05c12f3cb7efc592484d
-  StripeConnections: d3068bf688679a51932abb94d956d8a73c213bd7
-  StripeCore: 689b9605ccb78e507f59ddc5e677615e0af16583
-  StripeUICore: f5fe5ad283e132b40077b5eb85b625ebf7de034a
+  Stripe: 33cb13d41868ad64a6eabda23c920c5ffa724fa6
+  stripe-react-native: bff4d8028167e1cbf67cc870bc2075f2db7ed315
+  StripeApplePay: 77bbdb76f77e5e387c393e1512d111ee4818e384
+  StripeCore: 5703818b3a9949d8fce1a1b09e51fbe8953eb0ed
+  StripeFinancialConnections: 115d05b11a627e64d2402065b816e1aebae10951
+  StripeUICore: e1829301ad5de8831bc269a8ce8f73c31c26ce42
   Yoga: e7dc4e71caba6472ff48ad7d234389b91dadc280
 
 PODFILE CHECKSUM: 72bfeab5bf84b6ab4999227a1d3e012ee6b3f46e

--- a/example/ios/StripeSdkExample.xcodeproj/project.pbxproj
+++ b/example/ios/StripeSdkExample.xcodeproj/project.pbxproj
@@ -228,8 +228,8 @@
 				"${PODS_CONFIGURATION_BUILD_DIR}/React-Core/AccessibilityResources.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/Stripe/Stripe.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/Stripe/Stripe3DS2.bundle",
-				"${PODS_CONFIGURATION_BUILD_DIR}/StripeConnections/StripeConnections.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/StripeCore/StripeCore.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/StripeFinancialConnections/StripeFinancialConnections.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/StripeUICore/StripeUICore.bundle",
 			);
 			name = "[CP] Copy Pods Resources";
@@ -237,8 +237,8 @@
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/AccessibilityResources.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/Stripe.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/Stripe3DS2.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/StripeConnections.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/StripeCore.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/StripeFinancialConnections.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/StripeUICore.bundle",
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/example/src/screens/ACHPaymentScreen.tsx
+++ b/example/src/screens/ACHPaymentScreen.tsx
@@ -65,7 +65,7 @@ export default function ACHPaymentScreen() {
       ) {
         setAwaitingVerification(true);
         Alert.alert(
-          'Awaiting verification:',
+          'Awaiting verification',
           'The payment must be verified. Please provide the verification input values below.'
         );
       } else {
@@ -116,7 +116,7 @@ export default function ACHPaymentScreen() {
       ) {
         setAwaitingVerification(true);
         Alert.alert(
-          'Awaiting verification:',
+          'Awaiting verification',
           'The payment must be verified. Please provide the verification input values below.'
         );
       } else {
@@ -155,7 +155,7 @@ export default function ACHPaymentScreen() {
     } else if (paymentIntent) {
       if (paymentIntent.status === PaymentIntent.Status.RequiresConfirmation) {
         Alert.alert(
-          'Payment status: RequiresConfirmation',
+          'Requires Confirmation',
           "You may now press the first 'Confirm' button."
         );
       } else {

--- a/example/src/screens/ACHSetupScreen.tsx
+++ b/example/src/screens/ACHSetupScreen.tsx
@@ -60,7 +60,7 @@ export default function ACHSetupScreen() {
       ) {
         setAwaitingVerification(true);
         Alert.alert(
-          'Awaiting verification:',
+          'Awaiting verification',
           'The setup must be verified. Please provide the verification input values below.'
         );
       } else {
@@ -108,7 +108,7 @@ export default function ACHSetupScreen() {
       ) {
         setAwaitingVerification(true);
         Alert.alert(
-          'Awaiting verification:',
+          'Awaiting verification',
           'The setup must be verified. Please provide the verification input values below.'
         );
       } else {
@@ -147,7 +147,7 @@ export default function ACHSetupScreen() {
     } else if (setupIntent) {
       if (setupIntent.status === SetupIntent.Status.RequiresConfirmation) {
         Alert.alert(
-          'Setup status: RequiresConfirmation',
+          'Requires Confirmation',
           "You may now press the first 'Confirm' button."
         );
       } else {

--- a/example/src/screens/ApplePayScreen.tsx
+++ b/example/src/screens/ApplePayScreen.tsx
@@ -190,7 +190,7 @@ export default function ApplePayScreen() {
               cardDetails={{
                 name: cardDetails?.cardholder?.name,
                 primaryAccountIdentifier:
-                  cardDetails?.wallet?.primary_account_identifier,
+                  cardDetails?.wallets?.primary_account_identifier,
                 lastFour: cardDetails?.last4,
                 description: 'Added by Stripe',
               }}

--- a/example/src/screens/ApplePayScreen.tsx
+++ b/example/src/screens/ApplePayScreen.tsx
@@ -187,9 +187,13 @@ export default function ApplePayScreen() {
               testEnv={true}
               style={styles.payButton}
               iOSButtonStyle="onLightBackground"
-              cardHolderName={cardDetails?.cardholder?.name}
-              cardDescription={'Added by Stripe'}
-              cardLastFour={cardDetails?.last4}
+              cardDetails={{
+                name: cardDetails?.cardholder?.name,
+                primaryAccountIdentifier:
+                  cardDetails?.wallet?.primary_account_identifier,
+                lastFour: cardDetails?.last4,
+                description: 'Added by Stripe',
+              }}
               ephemeralKey={ephemeralKey}
               onComplete={({ error }) => {
                 Alert.alert(

--- a/example/src/screens/GooglePayScreen.tsx
+++ b/example/src/screens/GooglePayScreen.tsx
@@ -183,9 +183,13 @@ export default function GooglePayScreen() {
         <AddToWalletButton
           androidAssetSource={Image.resolveAssetSource(AddToGooglePayPNG)}
           style={styles.payButton}
-          cardHolderName={cardDetails?.cardholder?.name}
-          cardDescription={'Added by Stripe'}
-          cardLastFour={cardDetails?.last4}
+          cardDetails={{
+            name: cardDetails?.cardholder?.name,
+            primaryAccountIdentifier:
+              cardDetails?.wallet?.primary_account_identifier,
+            lastFour: cardDetails?.last4,
+            description: 'Added by Stripe',
+          }}
           token={androidCardToken}
           ephemeralKey={ephemeralKey}
           onComplete={({ error }) => {

--- a/ios/pushprovisioning/AddToWalletButtonManager.m
+++ b/ios/pushprovisioning/AddToWalletButtonManager.m
@@ -12,10 +12,7 @@
 @interface RCT_EXTERN_MODULE(AddToWalletButtonManager, RCTViewManager)
 RCT_EXPORT_VIEW_PROPERTY(testEnv, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(iOSButtonStyle, NSString)
-RCT_EXPORT_VIEW_PROPERTY(cardHolderName, NSString)
-RCT_EXPORT_VIEW_PROPERTY(cardDescription, NSString)
-RCT_EXPORT_VIEW_PROPERTY(cardLastFour, NSString)
-RCT_EXPORT_VIEW_PROPERTY(cardBrand, NSString)
+RCT_EXPORT_VIEW_PROPERTY(cardDetails, NSDictionary)
 RCT_EXPORT_VIEW_PROPERTY(ephemeralKey, NSDictionary)
 RCT_EXPORT_VIEW_PROPERTY(onCompleteAction, RCTDirectEventBlock)
 @end

--- a/src/components/AddToWalletButton.tsx
+++ b/src/components/AddToWalletButton.tsx
@@ -29,14 +29,19 @@ export interface Props extends AccessibilityProps {
   testID?: string;
   /** Only set to `false` when shipping through TestFlight || App Store */
   testEnv?: boolean;
-  /** Sets the card holder name (used only on iOS) */
-  cardHolderName: string;
-  /** Last 4 digits of the card. Required on Android. */
-  cardLastFour: string;
-  /** Sets the card holder name (used only on iOS) */
-  cardDescription?: string;
-  /** Optional, only used on iOS */
-  cardBrand?: Token.CardBrand;
+  /** Details of the Issued Card you'd like added to the device's wallet */
+  cardDetails: {
+    /** The `primary_account_identifier` value from the issued card. */
+    primaryAccountIdentifier: string;
+    /** The card holder name (used only on iOS) */
+    name: string;
+    /** A user-facing description of the card. Required on Android.*/
+    description: string;
+    /** Last 4 digits of the card, only used on iOS */
+    lastFour?: string;
+    /** Optional, only used on iOS */
+    brand?: Token.CardBrand;
+  };
   // Optional, only for Android and only for cards that are in the "yellow path" (as defined by Google- https://developers.google.com/pay/issuers/apis/push-provisioning/android/wallet-operations#resolving_yellow_path). Obtain this value via the `isCardInWallet` method.
   token?: GooglePayCardToken | null;
   /** Used by stripe to securely obtain card info of the card being provisioned. */
@@ -54,9 +59,11 @@ export interface Props extends AccessibilityProps {
  *    testEnv={true}
  *    style={styles.myButtonStyle}
  *    iOSButtonStyle="onLightBackground"
- *    cardHolderName="David Wallace"
- *    cardLastFour="4242"
- *    cardBrand="Visa"
+ *    cardDetails={{
+ *      primaryAccountIdentifier: "V-123",
+ *      name: "David Wallace",
+ *      lastFour: "4242",
+ *    }}
  *    ephemeralKey={myEphemeralKey} // This object is retrieved from your server. See https://stripe.com/docs/issuing/cards/digital-wallets?platform=react-native#update-your-backend
  *    onComplete={(error) => {
  *      Alert.alert(

--- a/src/components/AddToWalletButton.tsx
+++ b/src/components/AddToWalletButton.tsx
@@ -32,7 +32,7 @@ export interface Props extends AccessibilityProps {
   /** Details of the Issued Card you'd like added to the device's wallet */
   cardDetails: {
     /** The `primary_account_identifier` value from the issued card. */
-    primaryAccountIdentifier: string;
+    primaryAccountIdentifier: string | null;
     /** The card holder name (used only on iOS) */
     name: string;
     /** A user-facing description of the card. Required on Android.*/

--- a/stripe-react-native.podspec
+++ b/stripe-react-native.podspec
@@ -16,6 +16,6 @@ Pod::Spec.new do |s|
   s.source_files = 'ios/**/*.{h,m,mm,swift}'
 
   s.dependency 'React-Core'
-  s.dependency 'Stripe', '~> 22.0.0'
-  s.dependency 'StripeConnections', '~> 22.0.0'
+  s.dependency 'Stripe', '~> 22.2.0'
+  s.dependency 'StripeFinancialConnections', '~> 22.2.0'
 end


### PR DESCRIPTION
## Summary

Modified the props for the `AddToWalletButton` component. Instead of passing `cardHolderName`, `cardLastFour`, `cardDescription`, and `cardBrand` directly as props, you will instead pass a `cardDetails` prop, which is an object containing the following fields:
  - `primaryAccountIdentifier`: The `wallet.primary_account_identifier` value from the issued card.
  - `name`: The card holder name (previously `cardHolderName`).
  - `description`: A user-facing description of the card (previously `cardDescription`).
  - `lastFour`: Last 4 digits of the card, optional (previously `cardLastFour`).
  - `brand`: The card brand, optional (previously `cardBrand`).

## Motivation

Stripe iOS [recently updated to expose a method that sets the `primaryAccountIdentifier`](https://stripe.com/docs/issuing/cards/digital-wallets?platform=iOS), and without this push provisioning can fail on iOS. This provided a good opportunity to instead pass a `cardDetails` rather than individual props for each field. 

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [ ] I added automated tests

Note: This was tested via the `STPFakeAddPaymentPassViewController`

## Documentation

I will update https://stripe.com/docs/issuing/cards/digital-wallets?platform=react-native accordingly 
