### PR TITLE
fix: add fingerprint to Card result on android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Unreleased
+
+- [#914](https://github.com/stripe/stripe-react-native/pull/914) fix: add `fingerprint` to Card result object on Android (already present on iOS)
+
 ## 0.8.0
 
 - [#902](https://github.com/stripe/stripe-react-native/pull/902) fix: create custom babel plugin for package.json imports in src/

--- a/android/src/main/java/com/reactnativestripesdk/Mappers.kt
+++ b/android/src/main/java/com/reactnativestripesdk/Mappers.kt
@@ -317,7 +317,6 @@ internal fun mapFromPaymentMethod(paymentMethod: PaymentMethod): WritableMap {
 
   card.putString("brand", mapCardBrand(paymentMethod.card?.brand))
   card.putString("country", paymentMethod.card?.country)
-
   paymentMethod.card?.expiryYear?.let {
     card.putInt("expYear", it)
   }
@@ -326,6 +325,7 @@ internal fun mapFromPaymentMethod(paymentMethod: PaymentMethod): WritableMap {
   }
   card.putString("funding", paymentMethod.card?.funding)
   card.putString("last4", paymentMethod.card?.last4)
+  card.putString("fingerprint", paymentMethod.card?.fingerprint)
 
   sepaDebit.putString("bankCode", paymentMethod.sepaDebit?.bankCode)
   sepaDebit.putString("country", paymentMethod.sepaDebit?.country)


### PR DESCRIPTION
## Summary
include `fingerprint` in the Card result on android

## Motivation
closes https://github.com/stripe/stripe-react-native/issues/907

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
