### PR TITLE
fix: correctly overwrite package.json import via babel

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -7,7 +7,7 @@ module.exports = {
           ImportDeclaration(path) {
             let importResource = path.node.source.value ?? '';
             if (importResource.includes('../package.json')) {
-              importResource = '../' + importResource;
+              path.node.source.value = '../' + importResource;
             }
           },
         },

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -469,12 +469,12 @@ SPEC CHECKSUMS:
   RNCMaskedView: c298b644a10c0c142055b3ae24d83879ecb13ccd
   RNCPicker: cb57c823d5ce8d2d0b5dfb45ad97b737260dc59e
   RNScreens: d6da2b9e29cf523832c2542f47bf1287318b1868
-  Stripe: ee32e594fa4dee4bdf2a8a3039f7fb07a21075dc
-  stripe-react-native: 8fe9d3c3b022646b4fca9fe9fa7417e191ba11aa
-  StripeApplePay: e09964f3e2c6b318e53a05c12f3cb7efc592484d
-  StripeConnections: d3068bf688679a51932abb94d956d8a73c213bd7
-  StripeCore: 689b9605ccb78e507f59ddc5e677615e0af16583
-  StripeUICore: f5fe5ad283e132b40077b5eb85b625ebf7de034a
+  Stripe: 33cb13d41868ad64a6eabda23c920c5ffa724fa6
+  stripe-react-native: bff4d8028167e1cbf67cc870bc2075f2db7ed315
+  StripeApplePay: 77bbdb76f77e5e387c393e1512d111ee4818e384
+  StripeCore: 5703818b3a9949d8fce1a1b09e51fbe8953eb0ed
+  StripeFinancialConnections: 115d05b11a627e64d2402065b816e1aebae10951
+  StripeUICore: e1829301ad5de8831bc269a8ce8f73c31c26ce42
   Yoga: e7dc4e71caba6472ff48ad7d234389b91dadc280
 
 PODFILE CHECKSUM: 72bfeab5bf84b6ab4999227a1d3e012ee6b3f46e


### PR DESCRIPTION
## Summary and Motivation
https://github.com/stripe/stripe-react-native/pull/902 introduced a fix, but it didn't work because it was modifying the value of `importResource` and wasn't (by reference) modifying `path.node.source.value`

## Testing

manually checked the build files

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
