### PR TITLE
feat: add ACHv2 to payment sheet on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - [#913](https://github.com/stripe/stripe-react-native/pull/913) chore: Updated `stripe-ios` from 22.0.0 to 22.2.0.
 - [#914](https://github.com/stripe/stripe-react-native/pull/914) fix: add `fingerprint` to Card result object on Android (already present on iOS)
 - [#912](https://github.com/stripe/stripe-react-native/pull/912) fix: allow for providing zip code straight from `CardField` component on Android
-- [#925](https://github.com/stripe/stripe-react-native/pull/925) Feat: `us_bank_account` payment method is now available in the payment sheet. (& Updated `stripe-ios` from 22.2.0 to 22.3.0)
+- [#925](https://github.com/stripe/stripe-react-native/pull/925) Feat: `us_bank_account` payment method is now available in the payment sheet on iOS. (& Updated `stripe-ios` from 22.2.0 to 22.3.0)
 
 ## 0.8.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [#913](https://github.com/stripe/stripe-react-native/pull/913) chore: Updated `stripe-ios` from 22.0.0 to 22.2.0.
 - [#914](https://github.com/stripe/stripe-react-native/pull/914) fix: add `fingerprint` to Card result object on Android (already present on iOS)
 - [#912](https://github.com/stripe/stripe-react-native/pull/912) fix: allow for providing zip code straight from `CardField` component on Android
+- [#925](https://github.com/stripe/stripe-react-native/pull/925) Feat: `us_bank_account` payment method is now available in the payment sheet. (& Updated `stripe-ios` from 22.2.0 to 22.3.0)
 
 ## 0.8.0
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Get started with our [📚 integration guides](https://stripe.com/docs/payments/
 
 **Native UI**: We provide native screens and elements to securely collect payment details on Android and iOS.
 
-**PaymentSheet**: [Learn how to integrate](https://stripe.com/docs/payments/accept-a-payment) PaymentSheet, our new pre-built payments UI for mobile apps. PaymentSheet lets you accept cards, Apple Pay, Google Pay, and much more out of the box and also supports saving & reusing payment methods. PaymentSheet currently accepts the following payment methods: Card, Apple Pay, Google Pay, SEPA Debit, Bancontact, iDEAL, EPS, P24, Afterpay/Clearpay, Klarna, Giropay, and Sofort.
+**PaymentSheet**: [Learn how to integrate](https://stripe.com/docs/payments/accept-a-payment) PaymentSheet, our new pre-built payments UI for mobile apps. PaymentSheet lets you accept cards, Apple Pay, Google Pay, and much more out of the box and also supports saving & reusing payment methods. PaymentSheet currently accepts the following payment methods: Card, Apple Pay, Google Pay, SEPA Debit, Bancontact, iDEAL, EPS, P24, Afterpay/Clearpay, Klarna, Giropay, Sofort, and ACH.
 
 #### Recommended usage
 

--- a/e2e/screenObject/BasicPaymentScreen.ts
+++ b/e2e/screenObject/BasicPaymentScreen.ts
@@ -85,25 +85,28 @@ class BasicPaymentScreen {
 
           button = $(`//input[@name='confirmAccountNumber']`);
           button.click();
-          button.sendKeys(['000123456789\n']);
-          driver.pause(2000);
-
-          button = $(`//input[@name='routingNumber']`);
-          button.click();
-          button.click();
-          button.sendKeys(['110000000\n']);
+          button.sendKeys(['000123456789']);
           driver.pause(2000);
 
           button = $(`//input[@name='accountNumber']`);
           button.click();
           button.click();
-          button.sendKeys(['000123456789\n']);
+          button.pressKeyCode;
+          button.sendKeys(['000123456789']);
           driver.pause(2000);
+
+          button = $(`//input[@name='routingNumber']`);
+          button.click();
+          button.click();
+          button.sendKeys(['110000000']);
+          driver.pause(2000);
+
+          button = $(`//input[@name='accountNumber']`);
+          button.click();
 
           button = $(`button*=Continue`);
           button.click();
-          button.click();
-          driver.pause(5000);
+          driver.pause(2000);
 
           button = $(`button*=Done`);
           button.click();

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -287,27 +287,27 @@ PODS:
   - RNScreens (3.10.2):
     - React-Core
     - React-RCTImage
-  - Stripe (22.2.0):
-    - Stripe/Stripe3DS2 (= 22.2.0)
-    - StripeApplePay (= 22.2.0)
-    - StripeCore (= 22.2.0)
-    - StripeUICore (= 22.2.0)
+  - Stripe (22.3.0):
+    - Stripe/Stripe3DS2 (= 22.3.0)
+    - StripeApplePay (= 22.3.0)
+    - StripeCore (= 22.3.0)
+    - StripeUICore (= 22.3.0)
   - stripe-react-native (0.8.0):
     - React-Core
-    - Stripe (~> 22.2.0)
-    - StripeFinancialConnections (~> 22.2.0)
-  - Stripe/Stripe3DS2 (22.2.0):
-    - StripeApplePay (= 22.2.0)
-    - StripeCore (= 22.2.0)
-    - StripeUICore (= 22.2.0)
-  - StripeApplePay (22.2.0):
-    - StripeCore (= 22.2.0)
-  - StripeCore (22.2.0)
-  - StripeFinancialConnections (22.2.0):
-    - StripeCore (= 22.2.0)
-    - StripeUICore (= 22.2.0)
-  - StripeUICore (22.2.0):
-    - StripeCore (= 22.2.0)
+    - Stripe (~> 22.3.0)
+    - StripeFinancialConnections (~> 22.3.0)
+  - Stripe/Stripe3DS2 (22.3.0):
+    - StripeApplePay (= 22.3.0)
+    - StripeCore (= 22.3.0)
+    - StripeUICore (= 22.3.0)
+  - StripeApplePay (22.3.0):
+    - StripeCore (= 22.3.0)
+  - StripeCore (22.3.0)
+  - StripeFinancialConnections (22.3.0):
+    - StripeCore (= 22.3.0)
+    - StripeUICore (= 22.3.0)
+  - StripeUICore (22.3.0):
+    - StripeCore (= 22.3.0)
   - Yoga (1.14.0)
 
 DEPENDENCIES:
@@ -469,12 +469,12 @@ SPEC CHECKSUMS:
   RNCMaskedView: c298b644a10c0c142055b3ae24d83879ecb13ccd
   RNCPicker: cb57c823d5ce8d2d0b5dfb45ad97b737260dc59e
   RNScreens: d6da2b9e29cf523832c2542f47bf1287318b1868
-  Stripe: 33cb13d41868ad64a6eabda23c920c5ffa724fa6
-  stripe-react-native: bff4d8028167e1cbf67cc870bc2075f2db7ed315
-  StripeApplePay: 77bbdb76f77e5e387c393e1512d111ee4818e384
-  StripeCore: 5703818b3a9949d8fce1a1b09e51fbe8953eb0ed
-  StripeFinancialConnections: 115d05b11a627e64d2402065b816e1aebae10951
-  StripeUICore: e1829301ad5de8831bc269a8ce8f73c31c26ce42
+  Stripe: b2426ce648aa240a812b6749c09d3839111a9cbb
+  stripe-react-native: 279c702d7c954317913c74594439d48b022b7c74
+  StripeApplePay: 0b0b744805d36940fd58d0a928c54beb04f1136c
+  StripeCore: 88a3b50b3237b8e1661e48905f2813dedf200540
+  StripeFinancialConnections: d817bcfea7c6c9728dc6801afff813ff77828c65
+  StripeUICore: 5e5abb79e87b86b54919ed7c9d14446254d012a0
   Yoga: e7dc4e71caba6472ff48ad7d234389b91dadc280
 
 PODFILE CHECKSUM: 72bfeab5bf84b6ab4999227a1d3e012ee6b3f46e

--- a/example/server/index.ts
+++ b/example/server/index.ts
@@ -545,6 +545,7 @@ app.post('/payment-sheet', async (_, res) => {
       // 'eps',
       // 'afterpay_clearpay',
       // 'klarna',
+      // 'us_bank_account',
     ],
   });
   return res.json({

--- a/stripe-react-native.podspec
+++ b/stripe-react-native.podspec
@@ -1,6 +1,7 @@
 require 'json'
 
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+stripe_version = '~> 22.3.0'
 
 Pod::Spec.new do |s|
   s.name         = 'stripe-react-native'
@@ -16,6 +17,6 @@ Pod::Spec.new do |s|
   s.source_files = 'ios/**/*.{h,m,mm,swift}'
 
   s.dependency 'React-Core'
-  s.dependency 'Stripe', '~> 22.2.0'
-  s.dependency 'StripeFinancialConnections', '~> 22.2.0'
+  s.dependency 'Stripe', stripe_version
+  s.dependency 'StripeFinancialConnections', stripe_version
 end


### PR DESCRIPTION
## Summary

Updated stripe-ios dependency & example server

## Motivation

to support `us_bank_account` in the payment sheet

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [ ] I added automated tests

<img width="442" alt="Screen Shot 2022-05-05 at 10 20 43 AM" src="https://user-images.githubusercontent.com/97612659/166945459-a79f91ae-9882-4893-b866-ffa843032294.png">


## Documentation

Select one: 
- [x] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
