### PR TITLE
feat: add token & paymentMethodId handling to confirmPayment for Cards

### DIFF
--- a/android/src/main/java/com/reactnativestripesdk/PaymentMethodCreateParamsFactory.kt
+++ b/android/src/main/java/com/reactnativestripesdk/PaymentMethodCreateParamsFactory.kt
@@ -172,8 +172,16 @@ class PaymentMethodCreateParamsFactory(
 
   @Throws(PaymentMethodCreateParamsException::class)
   private fun createCardPaymentSetupParams(): ConfirmSetupIntentParams {
+    val paymentMethodId = getValOr(paymentMethodData, "paymentMethodId", null)
     val token = getValOr(paymentMethodData, "token", null)
     val cardParams = cardFieldView?.cardParams ?: cardFormView?.cardParams
+
+    if (paymentMethodId != null) {
+      return ConfirmSetupIntentParams.create(
+        paymentMethodId,
+        clientSecret
+      )
+    }
 
     val paymentMethodCreateParams =
       if (token != null)

--- a/android/src/main/java/com/reactnativestripesdk/PaymentMethodCreateParamsFactory.kt
+++ b/android/src/main/java/com/reactnativestripesdk/PaymentMethodCreateParamsFactory.kt
@@ -172,14 +172,23 @@ class PaymentMethodCreateParamsFactory(
 
   @Throws(PaymentMethodCreateParamsException::class)
   private fun createCardPaymentSetupParams(): ConfirmSetupIntentParams {
+    val token = getValOr(paymentMethodData, "token", null)
     val cardParams = cardFieldView?.cardParams ?: cardFormView?.cardParams
-    ?: throw PaymentMethodCreateParamsException("Card details not complete")
 
     val paymentMethodCreateParams =
-      PaymentMethodCreateParams.create(cardParams, billingDetailsParams)
+      if (token != null)
+        PaymentMethodCreateParams.create(PaymentMethodCreateParams.Card.create(token), billingDetailsParams)
+      else if (cardParams != null)
+        PaymentMethodCreateParams.create(cardParams, billingDetailsParams)
+      else
+        null
 
-    return ConfirmSetupIntentParams
-      .create(paymentMethodCreateParams, clientSecret)
+    if (paymentMethodCreateParams != null) {
+      return ConfirmSetupIntentParams
+        .create(paymentMethodCreateParams, clientSecret)
+    } else {
+      throw PaymentMethodCreateParamsException("Card details not complete")
+    }
   }
 
   @Throws(PaymentMethodCreateParamsException::class)

--- a/e2e/payments.test.ts
+++ b/e2e/payments.test.ts
@@ -149,7 +149,7 @@ describe('Common payment scenarios', () => {
     cardField.setExpiryDate('12/22');
     cardField.setCvcNumber('123');
 
-    getElementByText('Save').click();
+    getElementByText('Save via card input form').click();
     const alert = getElementByText('Success');
     alert.waitForDisplayed({
       timeout: 20000,


### PR DESCRIPTION
## Summary

Adds the ability to confirm card payments via either a paymentMethodId or a token on Android (already exists on iOS)

## Motivation
closes https://github.com/stripe/stripe-react-native/issues/643

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [ ] I tested this manually
- [x] I added automated tests

## Documentation

Select one: 
- [] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
