### PR TITLE
fix: wrap instances of framentManager.commit (or use commitAllowingStateLoss)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - [#912](https://github.com/stripe/stripe-react-native/pull/912) fix: allow for providing zip code straight from `CardField` component on Android
 - [#925](https://github.com/stripe/stripe-react-native/pull/925) Feat: `us_bank_account` payment method is now available in the payment sheet on iOS. (& Updated `stripe-ios` from 22.2.0 to 22.3.0)
 - [#932](https://github.com/stripe/stripe-react-native/pull/932) fix: manually forward activity results to paymentLauncherFragment
+- [#933](https://github.com/stripe/stripe-react-native/pull/933) fix: address "Can not perform this action after onSaveInstanceState" crashes on Android
 
 ## 0.8.0
 

--- a/android/src/main/java/com/reactnativestripesdk/CollectBankAccountLauncherFragment.kt
+++ b/android/src/main/java/com/reactnativestripesdk/CollectBankAccountLauncherFragment.kt
@@ -78,7 +78,7 @@ class CollectBankAccountLauncherFragment(
           promise.resolve(createError(ErrorType.Failed.toString(), result.error))
         }
       }
-      (context.currentActivity as? AppCompatActivity)?.supportFragmentManager?.beginTransaction()?.remove(this)?.commit()
+      (context.currentActivity as? AppCompatActivity)?.supportFragmentManager?.beginTransaction()?.remove(this)?.commitAllowingStateLoss()
     }
   }
 }

--- a/android/src/main/java/com/reactnativestripesdk/GooglePayPaymentMethodLauncherFragment.kt
+++ b/android/src/main/java/com/reactnativestripesdk/GooglePayPaymentMethodLauncherFragment.kt
@@ -37,7 +37,7 @@ class GooglePayPaymentMethodLauncherFragment(
       ),
       readyCallback = {
         promise.resolve(it)
-        (context.currentActivity as? AppCompatActivity)?.supportFragmentManager?.beginTransaction()?.remove(this)?.commit()
+        (context.currentActivity as? AppCompatActivity)?.supportFragmentManager?.beginTransaction()?.remove(this)?.commitAllowingStateLoss()
       },
       resultCallback = {}
     )

--- a/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
+++ b/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
@@ -228,9 +228,13 @@ class StripeSdkModule(private val reactContext: ReactApplicationContext) : React
 
     paymentLauncherFragment = PaymentLauncherFragment(stripe, publishableKey, stripeAccountId)
     getCurrentActivityOrResolveWithError(promise)?.let {
-      it.supportFragmentManager.beginTransaction()
-        .add(paymentLauncherFragment, "payment_launcher_fragment")
-        .commit()
+      try {
+        it.supportFragmentManager.beginTransaction()
+          .add(paymentLauncherFragment, "payment_launcher_fragment")
+          .commit()
+      } catch (error: IllegalStateException) {
+        promise.resolve(createError(ErrorType.Failed.toString(), error.message))
+      }
 
       val localBroadcastManager = LocalBroadcastManager.getInstance(reactApplicationContext)
       localBroadcastManager.registerReceiver(mPaymentSheetReceiver, IntentFilter(ON_PAYMENT_RESULT_ACTION))
@@ -255,9 +259,13 @@ class StripeSdkModule(private val reactContext: ReactApplicationContext) : React
         val bundle = toBundleObject(params)
         it.arguments = bundle
       }
-      activity.supportFragmentManager.beginTransaction()
-        .add(paymentSheetFragment!!, "payment_sheet_launch_fragment")
-        .commit()
+      try {
+        activity.supportFragmentManager.beginTransaction()
+          .add(paymentSheetFragment!!, "payment_sheet_launch_fragment")
+          .commit()
+      } catch (error: IllegalStateException) {
+        promise.resolve(createError(ErrorType.Failed.toString(), error.message))
+      }
     }
   }
 
@@ -565,9 +573,13 @@ class StripeSdkModule(private val reactContext: ReactApplicationContext) : React
     )
 
     getCurrentActivityOrResolveWithError(promise)?.let {
-      it.supportFragmentManager.beginTransaction()
-        .add(fragment, "google_pay_support_fragment")
-        .commit()
+      try {
+        it.supportFragmentManager.beginTransaction()
+          .add(fragment, "google_pay_support_fragment")
+          .commit()
+      } catch (error: IllegalStateException) {
+        promise.resolve(createError(ErrorType.Failed.toString(), error.message))
+      }
     }
   }
 
@@ -581,9 +593,13 @@ class StripeSdkModule(private val reactContext: ReactApplicationContext) : React
     getCurrentActivityOrResolveWithError(promise)?.let {
       initGooglePayPromise = promise
 
-      it.supportFragmentManager.beginTransaction()
-        .add(googlePayFragment!!, "google_pay_launch_fragment")
-        .commit()
+      try {
+        it.supportFragmentManager.beginTransaction()
+          .add(googlePayFragment!!, "google_pay_launch_fragment")
+          .commit()
+      } catch (error: IllegalStateException) {
+        promise.resolve(createError(ErrorType.Failed.toString(), error.message))
+      }
     }
   }
 
@@ -661,9 +677,13 @@ class StripeSdkModule(private val reactContext: ReactApplicationContext) : React
       promise
     )
     getCurrentActivityOrResolveWithError(promise)?.let {
-      it.supportFragmentManager.beginTransaction()
-        .add(fragment, "collect_bank_account_launcher_fragment")
-        .commit()
+      try {
+        it.supportFragmentManager.beginTransaction()
+          .add(fragment, "collect_bank_account_launcher_fragment")
+          .commit()
+      } catch (error: IllegalStateException) {
+        promise.resolve(createError(ErrorType.Failed.toString(), error.message))
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

To avoid the crash detailed in https://github.com/stripe/stripe-react-native/issues/887, we can move the "optional" commits over to `commitAllowingStateLoss`, since it's not really a terrible event if those two commits are lost, they're essentially cleanup. 

The other instances are all in exposed React methods, so if we encounter this error we should resolve the promise with an error, and then the user can handle that as they wish (AKA retry)

## Motivation
fixes https://github.com/stripe/stripe-react-native/issues/887
## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
