### PR TITLE
chore: Remove usage of LocalBroadCastManager

### DIFF
--- a/android/src/main/java/com/reactnativestripesdk/Constants.kt
+++ b/android/src/main/java/com/reactnativestripesdk/Constants.kt
@@ -1,10 +1,5 @@
 package com.reactnativestripesdk
 
-var ON_PAYMENT_RESULT_ACTION = "com.reactnativestripesdk.PAYMENT_RESULT_ACTION"
-var ON_PAYMENT_OPTION_ACTION = "com.reactnativestripesdk.PAYMENT_OPTION_ACTION"
-var ON_CONFIGURE_FLOW_CONTROLLER = "com.reactnativestripesdk.CONFIGURE_FLOW_CONTROLLER_ACTION"
-var ON_INIT_PAYMENT_SHEET = "com.reactnativestripesdk.INIT_PAYMENT_SHEET"
-
 var ON_INIT_GOOGLE_PAY = "com.reactnativestripesdk.ON_INIT_GOOGLE_PAY"
 var ON_GOOGLE_PAY_RESULT = "com.reactnativestripesdk.ON_GOOGLE_PAY_RESULT"
 var ON_GOOGLE_PAYMENT_METHOD_RESULT = "com.reactnativestripesdk.ON_GOOGLE_PAYMENT_METHOD_RESULT"

--- a/android/src/main/java/com/reactnativestripesdk/Constants.kt
+++ b/android/src/main/java/com/reactnativestripesdk/Constants.kt
@@ -1,5 +1,0 @@
-package com.reactnativestripesdk
-
-var ON_INIT_GOOGLE_PAY = "com.reactnativestripesdk.ON_INIT_GOOGLE_PAY"
-var ON_GOOGLE_PAY_RESULT = "com.reactnativestripesdk.ON_GOOGLE_PAY_RESULT"
-var ON_GOOGLE_PAYMENT_METHOD_RESULT = "com.reactnativestripesdk.ON_GOOGLE_PAYMENT_METHOD_RESULT"

--- a/android/src/main/java/com/reactnativestripesdk/GooglePayFragment.kt
+++ b/android/src/main/java/com/reactnativestripesdk/GooglePayFragment.kt
@@ -1,44 +1,30 @@
 package com.reactnativestripesdk
 
-import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
 import androidx.fragment.app.Fragment
-import androidx.localbroadcastmanager.content.LocalBroadcastManager
+import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.WritableNativeMap
 import com.stripe.android.googlepaylauncher.GooglePayEnvironment
 import com.stripe.android.googlepaylauncher.GooglePayLauncher
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher
 
-class GooglePayFragment : Fragment() {
+class GooglePayFragment(private val initPromise: Promise) : Fragment() {
   private var googlePayLauncher: GooglePayLauncher? = null
   private var googlePayMethodLauncher: GooglePayPaymentMethodLauncher? = null
   private var isGooglePayMethodLauncherReady: Boolean = false
   private var isGooglePayLauncherReady: Boolean = false
-  private lateinit var localBroadcastManager: LocalBroadcastManager
-
-  private fun onGooglePayMethodLauncherReady(isReady: Boolean) {
-    isGooglePayMethodLauncherReady = true
-    if (isGooglePayLauncherReady) {
-      onGooglePayReady(isReady)
-    }
-  }
-
-  private fun onGooglePayLauncherReady(isReady: Boolean) {
-    isGooglePayLauncherReady = true
-    if (isGooglePayMethodLauncherReady) {
-      onGooglePayReady(isReady)
-    }
-  }
+  private var presentPromise: Promise? = null
+  private var createPaymentMethodPromise: Promise? = null
 
   override fun onCreateView(
     inflater: LayoutInflater,
     container: ViewGroup?,
     savedInstanceState: Bundle?
   ): View {
-    localBroadcastManager = LocalBroadcastManager.getInstance(requireContext())
     return FrameLayout(requireActivity()).also {
       it.visibility = View.GONE
     }
@@ -89,74 +75,104 @@ class GooglePayFragment : Fragment() {
     )
   }
 
-  fun presentForPaymentIntent(clientSecret: String) {
+  private fun onGooglePayMethodLauncherReady(isReady: Boolean) {
+    isGooglePayMethodLauncherReady = true
+    if (isGooglePayLauncherReady) {
+      onGooglePayReady(isReady)
+    }
+  }
+
+  private fun onGooglePayLauncherReady(isReady: Boolean) {
+    isGooglePayLauncherReady = true
+    if (isGooglePayMethodLauncherReady) {
+      onGooglePayReady(isReady)
+    }
+  }
+
+  private fun onGooglePayReady(isReady: Boolean) {
+    if (isReady) {
+      initPromise.resolve(WritableNativeMap())
+    } else {
+      initPromise.resolve(
+        createError(
+          GooglePayErrorType.Failed.toString(),
+          "Google Pay is not available on this device. You can use isGooglePaySupported to preemptively check for Google Pay support."
+        )
+      )
+    }
+  }
+
+  fun presentForPaymentIntent(clientSecret: String, promise: Promise) {
     val launcher = googlePayLauncher ?: run {
-      val intent = Intent(ON_GOOGLE_PAY_RESULT)
-      intent.putExtra("error", "GooglePayLauncher is not initialized.")
-      localBroadcastManager.sendBroadcast(intent)
+      promise.resolve(createError(GooglePayErrorType.Failed.toString(), "GooglePay is not initialized."))
       return
     }
     runCatching {
+      presentPromise = promise
       launcher.presentForPaymentIntent(clientSecret)
     }.onFailure {
-      val intent = Intent(ON_GOOGLE_PAY_RESULT)
-      intent.putExtra("error", it.localizedMessage)
-      localBroadcastManager.sendBroadcast(intent)
+      promise.resolve(createError(GooglePayErrorType.Failed.toString(), it.localizedMessage))
     }
   }
 
-  fun presentForSetupIntent(clientSecret: String, currencyCode: String) {
+  fun presentForSetupIntent(clientSecret: String, currencyCode: String, promise: Promise) {
     val launcher = googlePayLauncher ?: run {
-      val intent = Intent(ON_GOOGLE_PAY_RESULT)
-      intent.putExtra("error", "GooglePayLauncher is not initialized.")
-      localBroadcastManager.sendBroadcast(intent)
+      promise.resolve(createError(GooglePayErrorType.Failed.toString(), "GooglePay is not initialized."))
       return
     }
     runCatching {
+      presentPromise = promise
       launcher.presentForSetupIntent(clientSecret, currencyCode)
     }.onFailure {
-      val intent = Intent(ON_GOOGLE_PAY_RESULT)
-      intent.putExtra("error", it.localizedMessage)
-      localBroadcastManager.sendBroadcast(intent)
+      promise.resolve(createError(GooglePayErrorType.Failed.toString(), it.localizedMessage))
     }
   }
 
-  fun createPaymentMethod(currencyCode: String, amount: Int) {
+  fun createPaymentMethod(currencyCode: String, amount: Int, promise: Promise) {
     val launcher = googlePayMethodLauncher ?: run {
-      val intent = Intent(ON_GOOGLE_PAYMENT_METHOD_RESULT)
-      intent.putExtra("error", "GooglePayPaymentMethodLauncher is not initialized.")
-      localBroadcastManager.sendBroadcast(intent)
+      promise.resolve(createError(GooglePayErrorType.Failed.toString(), "GooglePayPaymentMethodLauncher is not initialized."))
       return
     }
 
     runCatching {
+      createPaymentMethodPromise = promise
       launcher.present(
         currencyCode = currencyCode,
         amount = amount
       )
     }.onFailure {
-      val intent = Intent(ON_GOOGLE_PAYMENT_METHOD_RESULT)
-      intent.putExtra("error", it.localizedMessage)
-      localBroadcastManager.sendBroadcast(intent)
+      promise.resolve(createError(GooglePayErrorType.Failed.toString(), it.localizedMessage))
     }
   }
 
-  private fun onGooglePayReady(isReady: Boolean) {
-    val intent = Intent(ON_INIT_GOOGLE_PAY)
-    intent.putExtra("isReady", isReady)
-    localBroadcastManager.sendBroadcast(intent)
-  }
-
   private fun onGooglePayResult(result: GooglePayLauncher.Result) {
-    val intent = Intent(ON_GOOGLE_PAY_RESULT)
-    intent.putExtra("paymentResult", result)
-    localBroadcastManager.sendBroadcast(intent)
+    when (result) {
+      GooglePayLauncher.Result.Completed -> {
+        presentPromise?.resolve(WritableNativeMap())
+      }
+      GooglePayLauncher.Result.Canceled -> {
+        presentPromise?.resolve(createError(GooglePayErrorType.Canceled.toString(), "Google Pay has been canceled"))
+      }
+      is GooglePayLauncher.Result.Failed -> {
+        presentPromise?.resolve(createError(GooglePayErrorType.Failed.toString(), result.error))
+      }
+    }
+    presentPromise = null
   }
 
   private fun onGooglePayResult(result: GooglePayPaymentMethodLauncher.Result) {
-    val intent = Intent(ON_GOOGLE_PAYMENT_METHOD_RESULT)
-    intent.putExtra("paymentResult", result)
-    localBroadcastManager.sendBroadcast(intent)
+    when (result) {
+      is GooglePayPaymentMethodLauncher.Result.Completed -> {
+        createPaymentMethodPromise?.resolve(createResult("paymentMethod", mapFromPaymentMethod(result.paymentMethod)))
+      }
+      GooglePayPaymentMethodLauncher.Result.Canceled -> {
+        createPaymentMethodPromise?.resolve(createError(GooglePayErrorType.Canceled.toString(), "Google Pay has been canceled"))
+      }
+      is GooglePayPaymentMethodLauncher.Result.Failed -> {
+        createPaymentMethodPromise?.resolve(createError(GooglePayErrorType.Failed.toString(), result.error))
+      }
+    }
+    createPaymentMethodPromise = null
   }
 
   private fun mapToGooglePayLauncherBillingAddressConfig(formatString: String, isRequired: Boolean, isPhoneNumberRequired: Boolean): GooglePayLauncher.BillingAddressConfig {

--- a/android/src/main/java/com/reactnativestripesdk/PaymentSheetFragment.kt
+++ b/android/src/main/java/com/reactnativestripesdk/PaymentSheetFragment.kt
@@ -15,7 +15,6 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.core.graphics.drawable.DrawableCompat
 import androidx.fragment.app.Fragment
-import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.WritableMap
@@ -35,7 +34,6 @@ class PaymentSheetFragment(
   private var paymentIntentClientSecret: String? = null
   private var setupIntentClientSecret: String? = null
   private lateinit var paymentSheetConfiguration: PaymentSheet.Configuration
-  private lateinit var localBroadcastManager: LocalBroadcastManager
   private var confirmPromise: Promise? = null
   private var presentPromise: Promise? = null
 
@@ -44,7 +42,6 @@ class PaymentSheetFragment(
     container: ViewGroup?,
     savedInstanceState: Bundle?
   ): View {
-    localBroadcastManager = LocalBroadcastManager.getInstance(requireContext())
     return FrameLayout(requireActivity()).also {
       it.visibility = View.GONE
     }

--- a/android/src/main/java/com/reactnativestripesdk/PaymentSheetFragment.kt
+++ b/android/src/main/java/com/reactnativestripesdk/PaymentSheetFragment.kt
@@ -1,7 +1,6 @@
 package com.reactnativestripesdk
 
 import android.content.Context
-import android.content.Intent
 import android.content.res.ColorStateList
 import android.graphics.Bitmap
 import android.graphics.Canvas
@@ -12,22 +11,33 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
+import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.core.graphics.drawable.DrawableCompat
 import androidx.fragment.app.Fragment
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
+import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.WritableMap
+import com.facebook.react.bridge.WritableNativeMap
 import com.stripe.android.paymentsheet.PaymentOptionCallback
 import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.PaymentSheetResult
 import com.stripe.android.paymentsheet.PaymentSheetResultCallback
 import java.io.ByteArrayOutputStream
 
-class PaymentSheetFragment : Fragment() {
+class PaymentSheetFragment(
+  private val context: ReactApplicationContext,
+  private val initPromise: Promise
+) : Fragment() {
   private var paymentSheet: PaymentSheet? = null
   private var flowController: PaymentSheet.FlowController? = null
   private var paymentIntentClientSecret: String? = null
   private var setupIntentClientSecret: String? = null
   private lateinit var paymentSheetConfiguration: PaymentSheet.Configuration
   private lateinit var localBroadcastManager: LocalBroadcastManager
+  private var confirmPromise: Promise? = null
+  private var presentPromise: Promise? = null
 
   override fun onCreateView(
     inflater: LayoutInflater,
@@ -56,23 +66,39 @@ class PaymentSheetFragment : Fragment() {
     setupIntentClientSecret = arguments?.getString("setupIntentClientSecret").orEmpty()
 
     val paymentOptionCallback = PaymentOptionCallback { paymentOption ->
-      val intent = Intent(ON_PAYMENT_OPTION_ACTION)
-
       if (paymentOption != null) {
         val bitmap = getBitmapFromVectorDrawable(context, paymentOption.drawableResourceId)
         val imageString = getBase64FromBitmap(bitmap)
-
-        intent.putExtra("label", paymentOption.label)
-        intent.putExtra("image", imageString)
+        val option: WritableMap = WritableNativeMap()
+        option.putString("label", paymentOption.label)
+        option.putString("image", imageString)
+        presentPromise?.resolve(createResult("paymentOption", option))
       }
-      localBroadcastManager.sendBroadcast(intent)
+      presentPromise?.resolve(WritableNativeMap())
     }
 
     val paymentResultCallback = PaymentSheetResultCallback { paymentResult ->
-      val intent = Intent(ON_PAYMENT_RESULT_ACTION)
-
-      intent.putExtra("paymentResult", paymentResult)
-      localBroadcastManager.sendBroadcast(intent)
+      when (paymentResult) {
+        is PaymentSheetResult.Canceled -> {
+          val message = "The payment has been canceled"
+          confirmPromise?.resolve(createError(PaymentSheetErrorType.Canceled.toString(), message))
+            ?: run {
+              presentPromise?.resolve(createError(PaymentSheetErrorType.Canceled.toString(), message))
+            }
+        }
+        is PaymentSheetResult.Failed -> {
+          confirmPromise?.resolve(createError(PaymentSheetErrorType.Failed.toString(), paymentResult.error))
+            ?: run {
+              presentPromise?.resolve(createError(PaymentSheetErrorType.Failed.toString(), paymentResult.error))
+            }
+        }
+        is PaymentSheetResult.Completed -> {
+          confirmPromise?.resolve(WritableNativeMap()) ?: run {
+            presentPromise?.resolve(WritableNativeMap())
+          }
+        }
+      }
+      (context.currentActivity as? AppCompatActivity)?.supportFragmentManager?.beginTransaction()?.remove(this)?.commitAllowingStateLoss()
     }
 
     var primaryButtonColor: ColorStateList? = null
@@ -118,12 +144,12 @@ class PaymentSheetFragment : Fragment() {
       configureFlowController()
     } else {
       paymentSheet = PaymentSheet(this, paymentResultCallback)
-      val intent = Intent(ON_INIT_PAYMENT_SHEET)
-      localBroadcastManager.sendBroadcast(intent)
+      initPromise.resolve(WritableNativeMap())
     }
   }
 
-  fun present() {
+  fun present(promise: Promise) {
+    this.presentPromise = promise
     if(paymentSheet != null) {
       if (!paymentIntentClientSecret.isNullOrEmpty()) {
         paymentSheet?.presentWithPaymentIntent(paymentIntentClientSecret!!, paymentSheetConfiguration)
@@ -135,23 +161,24 @@ class PaymentSheetFragment : Fragment() {
     }
   }
 
-  fun confirmPayment() {
+  fun confirmPayment(promise: Promise) {
+    this.confirmPromise = promise
     flowController?.confirm()
   }
 
   private fun configureFlowController() {
     val onFlowControllerConfigure = PaymentSheet.FlowController.ConfigCallback { _, _ ->
-      val paymentOption = flowController?.getPaymentOption()
-      val intent = Intent(ON_CONFIGURE_FLOW_CONTROLLER)
-
-      paymentOption?.let {
+      val result = flowController?.getPaymentOption()?.let {
         val bitmap = getBitmapFromVectorDrawable(context, it.drawableResourceId)
         val imageString = getBase64FromBitmap(bitmap)
-
-        intent.putExtra("label", it.label)
-        intent.putExtra("image", imageString)
+        val option: WritableMap = WritableNativeMap()
+        option.putString("label", it.label)
+        option.putString("image", imageString)
+        createResult("paymentOption", option)
+      } ?: run {
+        WritableNativeMap()
       }
-      localBroadcastManager.sendBroadcast(intent)
+      initPromise.resolve(result)
     }
 
     if (!paymentIntentClientSecret.isNullOrEmpty()) {


### PR DESCRIPTION
## Summary

We used to rely on LocalBroadcastManager to send/receive intents in order to resolve promises based on behavior in fragments.

## Motivation

We don't need to rely on intents for this: it's confusing, more bug prone, and although it's safe to use LocalBroadcastManager, some folks assume we're using BroadcastManager which is **not** secure (to be clear, we are NOT using BroadcastManager).

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
