### PR TITLE
fix: pull error info from Throwables on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Fixes
 
+- Improved error messages on Android for failed `confirmPayment` and `confirmSetupIntent` calls, and any Google Pay related methods. [#957](https://github.com/stripe/stripe-react-native/pull/957)
+
 ## 0.10.0
 
 ### Breaking changes

--- a/android/src/main/java/com/reactnativestripesdk/Errors.kt
+++ b/android/src/main/java/com/reactnativestripesdk/Errors.kt
@@ -96,5 +96,16 @@ internal fun createError(code: String, error: Exception): WritableMap {
 }
 
 internal fun createError(code: String, error: Throwable): WritableMap {
-  return mapError(code, error.message, error.localizedMessage, null, null, null)
+  (error as? Exception)?.let {
+    return createError(
+      code,
+      it)
+  }
+  return mapError(
+    code,
+    error.message,
+    error.localizedMessage,
+    null,
+    null,
+    null)
 }

--- a/android/src/main/java/com/reactnativestripesdk/GooglePayFragment.kt
+++ b/android/src/main/java/com/reactnativestripesdk/GooglePayFragment.kt
@@ -111,7 +111,7 @@ class GooglePayFragment(private val initPromise: Promise) : Fragment() {
       presentPromise = promise
       launcher.presentForPaymentIntent(clientSecret)
     }.onFailure {
-      promise.resolve(createError(GooglePayErrorType.Failed.toString(), it.localizedMessage))
+      promise.resolve(createError(GooglePayErrorType.Failed.toString(), it))
     }
   }
 
@@ -124,7 +124,7 @@ class GooglePayFragment(private val initPromise: Promise) : Fragment() {
       presentPromise = promise
       launcher.presentForSetupIntent(clientSecret, currencyCode)
     }.onFailure {
-      promise.resolve(createError(GooglePayErrorType.Failed.toString(), it.localizedMessage))
+      promise.resolve(createError(GooglePayErrorType.Failed.toString(), it))
     }
   }
 
@@ -141,7 +141,7 @@ class GooglePayFragment(private val initPromise: Promise) : Fragment() {
         amount = amount
       )
     }.onFailure {
-      promise.resolve(createError(GooglePayErrorType.Failed.toString(), it.localizedMessage))
+      promise.resolve(createError(GooglePayErrorType.Failed.toString(), it))
     }
   }
 

--- a/android/src/main/java/com/reactnativestripesdk/PaymentLauncherFragment.kt
+++ b/android/src/main/java/com/reactnativestripesdk/PaymentLauncherFragment.kt
@@ -70,7 +70,7 @@ class PaymentLauncherFragment(
             ?: throw Exception("No promise is set to handle payment results.")
         }
         is PaymentResult.Failed -> {
-          promise?.resolve(createError(ConfirmPaymentErrorType.Failed.toString(), paymentResult.throwable.localizedMessage))
+          promise?.resolve(createError(ConfirmPaymentErrorType.Failed.toString(), paymentResult.throwable))
             ?: throw Exception("No promise is set to handle payment results.")
         }
       }


### PR DESCRIPTION
## Summary

safe cast Throwables as Exceptions

## Motivation

We can pull the expected fields out of Exceptions, giving more info on error events

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
