### PR TITLE
fix: rename appearance.shadow.borderRadius to appearance.shadow.blurRadius

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+### Breaking changes
+
+- Renamed `appearance.shapes.shadow.borderRadius` to `appearance.shapes.shadow.blurRadius`, and `appearance.primaryButton.shapes.shadow.borderRadius` to `appearance.primaryButton.shapes.shadow.blurRadius`. [#962](https://github.com/stripe/stripe-react-native/pull/962)
+
+### New features
+
+### Fixes
+
+- Fixed `appearance.shapes.shadow.offset` and `appearance.primaryButton.shapes.shadow.offset` not applying the y-coordinate in the correct direction. [#962](https://github.com/stripe/stripe-react-native/pull/962)
+
 ## 0.11.0
 
 ### Breaking changes

--- a/example/src/screens/PaymentSheetAppearance.ts
+++ b/example/src/screens/PaymentSheetAppearance.ts
@@ -40,8 +40,8 @@ const appearance: PaymentSheet.AppearanceParams = {
     shadow: {
       opacity: 1,
       color: '#ffffff',
-      offset: { x: -5, y: 5 },
-      borderRadius: 1,
+      offset: { x: -5, y: -5 },
+      blurRadius: 1,
     },
   },
   primaryButton: {
@@ -55,9 +55,9 @@ const appearance: PaymentSheet.AppearanceParams = {
       borderWidth: 2,
       shadow: {
         opacity: 1,
-        color: '#22ffffff',
-        offset: { x: -5, y: 5 },
-        borderRadius: 1,
+        color: '#80ffffff',
+        offset: { x: 5, y: 5 },
+        blurRadius: 1,
       },
     },
   },

--- a/ios/PaymentSheetAppearance.swift
+++ b/ios/PaymentSheetAppearance.swift
@@ -77,12 +77,12 @@ extension StripeSdk {
         if let opacity = params[PaymentSheetAppearanceKeys.OPACITY] as? CGFloat {
             shadow.opacity = opacity
         }
-        if let radius = params[PaymentSheetAppearanceKeys.BORDER_RADIUS] as? CGFloat {
+        if let radius = params[PaymentSheetAppearanceKeys.BLUR_RADIUS] as? CGFloat {
             shadow.radius = radius
         }
         if let offsetParams = params[PaymentSheetAppearanceKeys.OFFSET] as? NSDictionary {
             if let x = offsetParams[PaymentSheetAppearanceKeys.X] as? CGFloat, let y = offsetParams[PaymentSheetAppearanceKeys.Y] as? CGFloat {
-                shadow.offset = CGSize(width: x, height:y)
+                shadow.offset = CGSize(width: x, height:-y)
             }
         }
 
@@ -199,6 +199,7 @@ private struct PaymentSheetAppearanceKeys {
     static let SHADOW_COLOR = "color"
     static let OPACITY = "opacity"
     static let OFFSET = "offset"
+    static let BLUR_RADIUS = "blurRadius"
     static let X = "x"
     static let Y = "y"
     

--- a/src/types/PaymentSheet.ts
+++ b/src/types/PaymentSheet.ts
@@ -103,10 +103,10 @@ export type ShadowConfig = {
    * @default {x: 0, y: 2}
    */
   offset: { x: number; y: number };
-  /** The border radius of the shadow.
+  /** The blur radius of the shadow.
    * @default 4
    */
-  borderRadius: number;
+  blurRadius: number;
 };
 
 export type GlobalColorConfig = {


### PR DESCRIPTION
## Summary

rename `appearance.shadow.borderRadius` to `appearance.shadow.blurRadius`

also fixed the offset to have the component itself be the origin (0,0), and behavior matches the docstring example now

## Motivation

More descriptive of what's actually being changed. same behavior as https://developer.apple.com/documentation/quartzcore/calayer/1410819-shadowradius

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one: 
- [x] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
