### PR TITLE
fix: instantiate PaymentLauncher as needed instead of on init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Breaking changes
+
+### New features
+
+### Fixes
+
+- Fixed cases where Android apps would crash with the error: `Unable to instantiate fragment com.reactnativestripesdk.PaymentLauncherFragment`. [#965](https://github.com/stripe/stripe-react-native/pull/965)
+
 ## 0.11.0
 
 ### Breaking changes

--- a/android/src/main/java/com/reactnativestripesdk/PaymentLauncherFragment.kt
+++ b/android/src/main/java/com/reactnativestripesdk/PaymentLauncherFragment.kt
@@ -5,8 +5,10 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
+import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.ReactApplicationContext
 import com.stripe.android.ApiResultCallback
 import com.stripe.android.Stripe
 import com.stripe.android.model.*
@@ -14,74 +16,142 @@ import com.stripe.android.payments.paymentlauncher.PaymentLauncher
 import com.stripe.android.payments.paymentlauncher.PaymentResult
 
 class PaymentLauncherFragment(
+  private val context: ReactApplicationContext,
   private val stripe: Stripe,
   private val publishableKey: String,
   private val stripeAccountId: String?,
+  private val promise: Promise,
+  private val paymentIntentClientSecret: String? = null,
+  private val confirmPaymentParams: ConfirmPaymentIntentParams? = null,
+  private val setupIntentClientSecret: String? = null,
+  private val confirmSetupParams: ConfirmSetupIntentParams? = null,
+  private val handleNextActionClientSecret: String? = null,
 ) : Fragment() {
   private lateinit var paymentLauncher: PaymentLauncher
-  private var clientSecret: String? = null
-  private var promise: Promise? = null
-  private var isPaymentIntent: Boolean = true
+
+  companion object {
+    fun forPayment(context: ReactApplicationContext,
+                   stripe: Stripe,
+                   publishableKey: String,
+                   stripeAccountId: String?,
+                   promise: Promise,
+                   paymentIntentClientSecret: String,
+                   confirmPaymentParams: ConfirmPaymentIntentParams) {
+      val paymentLauncherFragment = PaymentLauncherFragment(
+        context,
+        stripe,
+        publishableKey,
+        stripeAccountId,
+        promise,
+        paymentIntentClientSecret = paymentIntentClientSecret,
+        confirmPaymentParams = confirmPaymentParams
+      )
+      addFragment(paymentLauncherFragment, context, promise)
+    }
+
+    fun forSetup(context: ReactApplicationContext,
+                 stripe: Stripe,
+                 publishableKey: String,
+                 stripeAccountId: String?,
+                 promise: Promise,
+                 setupIntentClientSecret: String,
+                 confirmSetupParams: ConfirmSetupIntentParams) {
+      val paymentLauncherFragment = PaymentLauncherFragment(
+        context,
+        stripe,
+        publishableKey,
+        stripeAccountId,
+        promise,
+        setupIntentClientSecret = setupIntentClientSecret,
+        confirmSetupParams = confirmSetupParams
+      )
+      addFragment(paymentLauncherFragment, context, promise)
+    }
+
+    fun forNextAction(context: ReactApplicationContext,
+                      stripe: Stripe,
+                      publishableKey: String,
+                      stripeAccountId: String?,
+                      promise: Promise,
+                      handleNextActionClientSecret: String) {
+      val paymentLauncherFragment = PaymentLauncherFragment(
+        context,
+        stripe,
+        publishableKey,
+        stripeAccountId,
+        promise,
+        handleNextActionClientSecret = handleNextActionClientSecret,
+      )
+      addFragment(paymentLauncherFragment, context, promise)
+    }
+
+    private fun addFragment(fragment: PaymentLauncherFragment, context: ReactApplicationContext, promise: Promise) {
+      (context.currentActivity as? AppCompatActivity)?.let {
+        try {
+          it.supportFragmentManager.beginTransaction()
+            .add(fragment, "payment_launcher_fragment")
+            .commit()
+        } catch (error: IllegalStateException) {
+          promise.resolve(createError(ErrorType.Failed.toString(), error.message))
+        }
+      } ?: run {
+        promise.resolve(createMissingActivityError())
+      }
+    }
+  }
 
   override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?,
                             savedInstanceState: Bundle?): View {
     paymentLauncher = createPaymentLauncher()
+    if (paymentIntentClientSecret != null && confirmPaymentParams != null) {
+      paymentLauncher.confirm(confirmPaymentParams)
+    } else if (setupIntentClientSecret != null && confirmSetupParams != null) {
+      paymentLauncher.confirm(confirmSetupParams)
+    } else if (handleNextActionClientSecret != null) {
+      paymentLauncher.handleNextActionForPaymentIntent(handleNextActionClientSecret)
+    } else {
+      throw Error("TODO")
+    }
     return FrameLayout(requireActivity()).also {
       it.visibility = View.GONE
     }
-  }
-
-  fun handleNextActionForPaymentIntent(clientSecret: String, promise: Promise) {
-    this.clientSecret = clientSecret
-    this.promise = promise
-    paymentLauncher.handleNextActionForPaymentIntent(clientSecret)
-  }
-
-  fun confirm(params: ConfirmPaymentIntentParams, clientSecret: String, promise: Promise) {
-    this.clientSecret = clientSecret
-    this.promise = promise
-    this.isPaymentIntent = true
-    paymentLauncher.confirm(params)
-  }
-
-  fun confirm(params: ConfirmSetupIntentParams, clientSecret: String, promise: Promise) {
-    this.clientSecret = clientSecret
-    this.promise = promise
-    this.isPaymentIntent = false
-    paymentLauncher.confirm(params)
   }
 
   private fun createPaymentLauncher(): PaymentLauncher {
     return PaymentLauncher.create(this, publishableKey, stripeAccountId) { paymentResult ->
       when (paymentResult) {
         is PaymentResult.Completed -> {
-          clientSecret?.let {
-            if (isPaymentIntent) retrievePaymentIntent(it, stripeAccountId)
-            else retrieveSetupIntent(it, stripeAccountId)
-          } ?: run {
-            promise?.resolve(
-              createError(ConfirmPaymentErrorType.Failed.toString(), "Client secret must be set before responding to payment results.")
-            )
-              ?: throw Exception("Client secret must be set before responding to payment results.")
+          if (paymentIntentClientSecret != null) {
+            retrievePaymentIntent(paymentIntentClientSecret, stripeAccountId)
+          } else if (handleNextActionClientSecret != null) {
+            retrievePaymentIntent(handleNextActionClientSecret, stripeAccountId)
+          } else if (setupIntentClientSecret != null) {
+            retrieveSetupIntent(setupIntentClientSecret, stripeAccountId)
+          } else {
+            throw Error("TODO")
           }
         }
         is PaymentResult.Canceled -> {
-          promise?.resolve(createError(ConfirmPaymentErrorType.Canceled.toString(), message = null))
-            ?: throw Exception("No promise is set to handle payment results.")
+          promise.resolve(createError(ConfirmPaymentErrorType.Canceled.toString(), message = null))
+          cleanup()
         }
         is PaymentResult.Failed -> {
-          promise?.resolve(createError(ConfirmPaymentErrorType.Failed.toString(), paymentResult.throwable))
-            ?: throw Exception("No promise is set to handle payment results.")
+          promise.resolve(createError(ConfirmPaymentErrorType.Failed.toString(), paymentResult.throwable))
+          cleanup()
         }
       }
     }
   }
 
+  private fun cleanup() {
+    (context.currentActivity as? AppCompatActivity)?.supportFragmentManager?.beginTransaction()?.remove(this)?.commitAllowingStateLoss()
+  }
+
   private fun retrieveSetupIntent(clientSecret: String, stripeAccountId: String?) {
-    val promise = promise ?: throw Exception("No promise is set to handle payment results.")
     stripe.retrieveSetupIntent(clientSecret, stripeAccountId, object : ApiResultCallback<SetupIntent> {
       override fun onError(e: Exception) {
         promise.resolve(createError(ConfirmSetupIntentErrorType.Failed.toString(), e))
+        cleanup()
       }
 
       override fun onSuccess(result: SetupIntent) {
@@ -113,15 +183,16 @@ class PaymentLauncherFragment(
             promise.resolve(createError(ConfirmSetupIntentErrorType.Unknown.toString(), "unhandled error: ${result.status}"))
           }
         }
+        cleanup()
       }
     })
   }
 
   private fun retrievePaymentIntent(clientSecret: String, stripeAccountId: String?) {
-    val promise = promise ?: throw Exception("No promise is set to handle payment results.")
     stripe.retrievePaymentIntent(clientSecret, stripeAccountId, object : ApiResultCallback<PaymentIntent> {
       override fun onError(e: Exception) {
         promise.resolve(createError(ConfirmPaymentErrorType.Failed.toString(), e))
+        cleanup()
       }
 
       override fun onSuccess(result: PaymentIntent) {
@@ -153,6 +224,7 @@ class PaymentLauncherFragment(
             promise.resolve(createError(ConfirmPaymentErrorType.Unknown.toString(), "unhandled error: ${result.status}"))
           }
         }
+        cleanup()
       }
     })
   }

--- a/android/src/main/java/com/reactnativestripesdk/PaymentLauncherFragment.kt
+++ b/android/src/main/java/com/reactnativestripesdk/PaymentLauncherFragment.kt
@@ -15,21 +15,30 @@ import com.stripe.android.model.*
 import com.stripe.android.payments.paymentlauncher.PaymentLauncher
 import com.stripe.android.payments.paymentlauncher.PaymentResult
 
+/**
+ * Instances of this class should only be initialized with the companion's helper methods.
+ */
 class PaymentLauncherFragment(
   private val context: ReactApplicationContext,
   private val stripe: Stripe,
   private val publishableKey: String,
   private val stripeAccountId: String?,
   private val promise: Promise,
+  // Used when confirming a payment intent
   private val paymentIntentClientSecret: String? = null,
   private val confirmPaymentParams: ConfirmPaymentIntentParams? = null,
+  // Used when confirming a setup intent
   private val setupIntentClientSecret: String? = null,
   private val confirmSetupParams: ConfirmSetupIntentParams? = null,
+  // Used when handling the next action on a payment intent
   private val handleNextActionClientSecret: String? = null,
 ) : Fragment() {
   private lateinit var paymentLauncher: PaymentLauncher
 
   companion object {
+    /**
+     * Helper-constructor used for confirming payment intents
+     */
     fun forPayment(context: ReactApplicationContext,
                    stripe: Stripe,
                    publishableKey: String,
@@ -50,6 +59,9 @@ class PaymentLauncherFragment(
       return paymentLauncherFragment
     }
 
+    /**
+     * Helper-constructor used for confirming setup intents
+     */
     fun forSetup(context: ReactApplicationContext,
                  stripe: Stripe,
                  publishableKey: String,
@@ -70,6 +82,9 @@ class PaymentLauncherFragment(
       return paymentLauncherFragment
     }
 
+    /**
+     * Helper-constructor used for handling the next action on a payment intent
+     */
     fun forNextAction(context: ReactApplicationContext,
                       stripe: Stripe,
                       publishableKey: String,
@@ -113,7 +128,7 @@ class PaymentLauncherFragment(
     } else if (handleNextActionClientSecret != null) {
       paymentLauncher.handleNextActionForPaymentIntent(handleNextActionClientSecret)
     } else {
-      throw Error("TODO")
+      throw Exception("Invalid parameters provided to PaymentLauncher. Ensure that you are providing the correct client secret and setup params (if necessary).")
     }
     return FrameLayout(requireActivity()).also {
       it.visibility = View.GONE
@@ -131,7 +146,7 @@ class PaymentLauncherFragment(
           } else if (setupIntentClientSecret != null) {
             retrieveSetupIntent(setupIntentClientSecret, stripeAccountId)
           } else {
-            throw Error("TODO")
+            throw Exception("Failed to create Payment Launcher. No client secret provided.")
           }
         }
         is PaymentResult.Canceled -> {

--- a/android/src/main/java/com/reactnativestripesdk/PaymentLauncherFragment.kt
+++ b/android/src/main/java/com/reactnativestripesdk/PaymentLauncherFragment.kt
@@ -36,7 +36,7 @@ class PaymentLauncherFragment(
                    stripeAccountId: String?,
                    promise: Promise,
                    paymentIntentClientSecret: String,
-                   confirmPaymentParams: ConfirmPaymentIntentParams) {
+                   confirmPaymentParams: ConfirmPaymentIntentParams): PaymentLauncherFragment {
       val paymentLauncherFragment = PaymentLauncherFragment(
         context,
         stripe,
@@ -47,6 +47,7 @@ class PaymentLauncherFragment(
         confirmPaymentParams = confirmPaymentParams
       )
       addFragment(paymentLauncherFragment, context, promise)
+      return paymentLauncherFragment
     }
 
     fun forSetup(context: ReactApplicationContext,
@@ -55,7 +56,7 @@ class PaymentLauncherFragment(
                  stripeAccountId: String?,
                  promise: Promise,
                  setupIntentClientSecret: String,
-                 confirmSetupParams: ConfirmSetupIntentParams) {
+                 confirmSetupParams: ConfirmSetupIntentParams): PaymentLauncherFragment {
       val paymentLauncherFragment = PaymentLauncherFragment(
         context,
         stripe,
@@ -66,6 +67,7 @@ class PaymentLauncherFragment(
         confirmSetupParams = confirmSetupParams
       )
       addFragment(paymentLauncherFragment, context, promise)
+      return paymentLauncherFragment
     }
 
     fun forNextAction(context: ReactApplicationContext,
@@ -73,7 +75,7 @@ class PaymentLauncherFragment(
                       publishableKey: String,
                       stripeAccountId: String?,
                       promise: Promise,
-                      handleNextActionClientSecret: String) {
+                      handleNextActionClientSecret: String): PaymentLauncherFragment {
       val paymentLauncherFragment = PaymentLauncherFragment(
         context,
         stripe,
@@ -83,6 +85,7 @@ class PaymentLauncherFragment(
         handleNextActionClientSecret = handleNextActionClientSecret,
       )
       addFragment(paymentLauncherFragment, context, promise)
+      return paymentLauncherFragment
     }
 
     private fun addFragment(fragment: PaymentLauncherFragment, context: ReactApplicationContext, promise: Promise) {

--- a/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
+++ b/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
@@ -33,6 +33,7 @@ class StripeSdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJ
 
   private var paymentSheetFragment: PaymentSheetFragment? = null
   private var googlePayFragment: GooglePayFragment? = null
+  private var paymentLauncherFragment: PaymentLauncherFragment? = null
 
   private var confirmPromise: Promise? = null
   private var confirmPaymentClientSecret: String? = null
@@ -43,6 +44,7 @@ class StripeSdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJ
         // BEGIN - Necessary on older versions of React Native (~0.64 and below)
         paymentSheetFragment?.activity?.activityResultRegistry?.dispatchResult(requestCode, resultCode, data)
         googlePayFragment?.activity?.activityResultRegistry?.dispatchResult(requestCode, resultCode, data)
+        paymentLauncherFragment?.activity?.activityResultRegistry?.dispatchResult(requestCode, resultCode, data)
         // END
         try {
           val result = AddPaymentMethodActivityStarter.Result.fromIntent(data)
@@ -152,7 +154,7 @@ class StripeSdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJ
     when (result) {
       is AddPaymentMethodActivityStarter.Result.Success -> {
         if (confirmPaymentClientSecret != null && confirmPromise != null) {
-          PaymentLauncherFragment.forPayment(
+          paymentLauncherFragment = PaymentLauncherFragment.forPayment(
             context = reactApplicationContext,
             stripe,
             publishableKey,
@@ -306,7 +308,7 @@ class StripeSdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJ
 
   @ReactMethod
   fun handleNextAction(paymentIntentClientSecret: String, promise: Promise) {
-    PaymentLauncherFragment.forNextAction(
+    paymentLauncherFragment = PaymentLauncherFragment.forNextAction(
       context = reactApplicationContext,
       stripe,
       publishableKey,
@@ -370,7 +372,7 @@ class StripeSdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJ
         confirmParams.returnUrl = mapToReturnURL(urlScheme)
       }
       confirmParams.shipping = mapToShippingDetails(getMapOrNull(paymentMethodData, "shippingDetails"))
-      PaymentLauncherFragment.forPayment(
+      paymentLauncherFragment = PaymentLauncherFragment.forPayment(
         context = reactApplicationContext,
         stripe,
         publishableKey,
@@ -422,7 +424,7 @@ class StripeSdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJ
       urlScheme?.let {
         confirmParams.returnUrl = mapToReturnURL(urlScheme)
       }
-      PaymentLauncherFragment.forSetup(
+      paymentLauncherFragment = PaymentLauncherFragment.forSetup(
         context = reactApplicationContext,
         stripe,
         publishableKey,

--- a/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
+++ b/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
@@ -31,7 +31,6 @@ class StripeSdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJ
   private var stripeAccountId: String? = null
   private var urlScheme: String? = null
 
-  private lateinit var paymentLauncherFragment: PaymentLauncherFragment
   private var paymentSheetFragment: PaymentSheetFragment? = null
   private var googlePayFragment: GooglePayFragment? = null
 
@@ -44,7 +43,6 @@ class StripeSdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJ
         // BEGIN - Necessary on older versions of React Native (~0.64 and below)
         paymentSheetFragment?.activity?.activityResultRegistry?.dispatchResult(requestCode, resultCode, data)
         googlePayFragment?.activity?.activityResultRegistry?.dispatchResult(requestCode, resultCode, data)
-        paymentLauncherFragment.activity?.activityResultRegistry?.dispatchResult(requestCode, resultCode, data)
         // END
         try {
           val result = AddPaymentMethodActivityStarter.Result.fromIntent(data)
@@ -110,19 +108,7 @@ class StripeSdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJ
     stripe = Stripe(reactApplicationContext, publishableKey, stripeAccountId)
 
     PaymentConfiguration.init(reactApplicationContext, publishableKey, stripeAccountId)
-
-    paymentLauncherFragment = PaymentLauncherFragment(stripe, publishableKey, stripeAccountId)
-    getCurrentActivityOrResolveWithError(promise)?.let {
-      try {
-        it.supportFragmentManager.beginTransaction()
-          .add(paymentLauncherFragment, "payment_launcher_fragment")
-          .commit()
-      } catch (error: IllegalStateException) {
-        promise.resolve(createError(ErrorType.Failed.toString(), error.message))
-      }
-
-      promise.resolve(null)
-    }
+    promise.resolve(null)
   }
 
   @ReactMethod
@@ -166,13 +152,17 @@ class StripeSdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJ
     when (result) {
       is AddPaymentMethodActivityStarter.Result.Success -> {
         if (confirmPaymentClientSecret != null && confirmPromise != null) {
-          paymentLauncherFragment.confirm(
+          PaymentLauncherFragment.forPayment(
+            context = reactApplicationContext,
+            stripe,
+            publishableKey,
+            stripeAccountId,
+            confirmPromise!!,
+            confirmPaymentClientSecret!!,
             ConfirmPaymentIntentParams.createWithPaymentMethodId(
               result.paymentMethod.id!!,
               confirmPaymentClientSecret!!
-            ),
-            confirmPaymentClientSecret!!,
-            confirmPromise!!
+            )
           )
         } else {
           Log.e("StripeReactNative", "FPX payment failed. Promise and/or client secret is not set.")
@@ -316,9 +306,13 @@ class StripeSdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJ
 
   @ReactMethod
   fun handleNextAction(paymentIntentClientSecret: String, promise: Promise) {
-    paymentLauncherFragment.handleNextActionForPaymentIntent(
-      paymentIntentClientSecret,
-      promise
+    PaymentLauncherFragment.forNextAction(
+      context = reactApplicationContext,
+      stripe,
+      publishableKey,
+      stripeAccountId,
+      promise,
+      paymentIntentClientSecret
     )
   }
 
@@ -376,10 +370,14 @@ class StripeSdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJ
         confirmParams.returnUrl = mapToReturnURL(urlScheme)
       }
       confirmParams.shipping = mapToShippingDetails(getMapOrNull(paymentMethodData, "shippingDetails"))
-      paymentLauncherFragment.confirm(
-        confirmParams,
+      PaymentLauncherFragment.forPayment(
+        context = reactApplicationContext,
+        stripe,
+        publishableKey,
+        stripeAccountId,
+        promise,
         paymentIntentClientSecret,
-        promise
+        confirmParams
       )
     } catch (error: PaymentMethodCreateParamsException) {
       promise.resolve(createError(ConfirmPaymentErrorType.Failed.toString(), error))
@@ -424,10 +422,14 @@ class StripeSdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJ
       urlScheme?.let {
         confirmParams.returnUrl = mapToReturnURL(urlScheme)
       }
-      paymentLauncherFragment.confirm(
-        confirmParams,
+      PaymentLauncherFragment.forSetup(
+        context = reactApplicationContext,
+        stripe,
+        publishableKey,
+        stripeAccountId,
+        promise,
         setupIntentClientSecret,
-        promise
+        confirmParams
       )
     } catch (error: PaymentMethodCreateParamsException) {
       promise.resolve(createError(ConfirmPaymentErrorType.Failed.toString(), error))

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -305,7 +305,7 @@ PODS:
     - StripeApplePay (= 22.4.0)
     - StripeCore (= 22.4.0)
     - StripeUICore (= 22.4.0)
-  - stripe-react-native (0.10.0):
+  - stripe-react-native (0.11.0):
     - React-Core
     - Stripe (~> 22.4.0)
     - StripeFinancialConnections (~> 22.4.0)
@@ -487,7 +487,7 @@ SPEC CHECKSUMS:
   RNCPicker: abc646b53a3d28ccfa3232c927a0ca52e0cf024d
   RNScreens: 40a2cb40a02a609938137a1e0acfbf8fc9eebf19
   Stripe: a925dfa9a7e51aa8f782f428abc10cb828b45a85
-  stripe-react-native: e9a9d0a9d26934c31e5af0511d21a73b378948ca
+  stripe-react-native: 20e9f0b042410610ea989becb9a15468f1f9ae86
   StripeApplePay: 369857bafe8baf02e31b47478db1574febd2a2f3
   StripeCore: a94d2823817c97c79fce60884ab9027a2da798c1
   StripeFinancialConnections: 269658b79f639c2d6b7d513235d469418b04c2dd


### PR DESCRIPTION
## Summary

Previously we were instantiating payment launcher on SDK initialization. Now, we init whenever we need, and then tear down the Fragment afterwards

## Motivation

closes https://github.com/stripe/stripe-react-native/issues/930
closes https://github.com/stripe/stripe-react-native/issues/968

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
