### PR TITLE
Upgrade stripe-android to 20.5.+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 - Fixed cases where Android apps would crash with the error: `Unable to instantiate fragment com.reactnativestripesdk.PaymentLauncherFragment`. [#965](https://github.com/stripe/stripe-react-native/pull/965)
 - Fixed `appearance.shapes.shadow.offset` and `appearance.primaryButton.shapes.shadow.offset` not applying the y-coordinate in the correct direction. [#962](https://github.com/stripe/stripe-react-native/pull/962)
+- Fixed a bug where `handleNextAction` wouldn't resolve on Android when using 3DS2. [#966](https://github.com/stripe/stripe-react-native/pull/966)
+- Fixed a bug where the wrong CVC icon was show in the `CardForm` component on Android. [#966](https://github.com/stripe/stripe-react-native/pull/966)
 
 ## 0.11.0
 

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,2 +1,2 @@
 StripeSdk_kotlinVersion=1.6.10
-StripeSdk_stripeVersion=20.4.+
+StripeSdk_stripeVersion=20.5.+

--- a/android/src/main/java/com/reactnativestripesdk/CardFormViewManager.kt
+++ b/android/src/main/java/com/reactnativestripesdk/CardFormViewManager.kt
@@ -38,7 +38,7 @@ class CardFormViewManager : SimpleViewManager<CardFormView>() {
 
    @ReactProp(name = "placeholders")
    fun setPlaceHolders(view: CardFormView, placeholders: ReadableMap) {
-     view.setPlaceHolders(placeholders);
+     view.setPlaceHolders(placeholders)
    }
 
   @ReactProp(name = "autofocus")

--- a/android/src/main/java/com/reactnativestripesdk/PaymentSheetFragment.kt
+++ b/android/src/main/java/com/reactnativestripesdk/PaymentSheetFragment.kt
@@ -1,7 +1,6 @@
 package com.reactnativestripesdk
 
 import android.content.Context
-import android.content.res.ColorStateList
 import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.graphics.Color


### PR DESCRIPTION
## Summary

Upgrade from 20.4 to 20.5. This will pick up any version up to but not including 20.6

## Motivation

fixes in changelog

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
