### PR TITLE
feat,fix: CardForm country input defaults to current region on Android, add option to override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,6 @@
 
 ### Fixes
 
-- `CardForm`'s country input on Android will now match the behavior of iOS- defaulting to the current locale of the device (user setting). [#974](https://github.com/stripe/stripe-react-native/pull/974)
-
 ## 0.12.0
 
 ### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+### Breaking changes
+
+### New features
+
+- Added a `defaultValues` prop to the `CardForm` component. Currently only accepts `countryCode`, and is Android-only. [#974](https://github.com/stripe/stripe-react-native/pull/974)
+
+### Fixes
+
+- `CardForm`'s country input on Android will now match the behavior of iOS- defaulting to the current locale of the device (user setting). [#974](https://github.com/stripe/stripe-react-native/pull/974)
+
 ## 0.12.0
 
 ### Breaking changes

--- a/android/src/main/java/com/reactnativestripesdk/CardFormView.kt
+++ b/android/src/main/java/com/reactnativestripesdk/CardFormView.kt
@@ -14,6 +14,7 @@ import com.facebook.react.uimanager.events.EventDispatcher
 import com.google.android.material.shape.CornerFamily
 import com.google.android.material.shape.MaterialShapeDrawable
 import com.google.android.material.shape.ShapeAppearanceModel
+import com.stripe.android.core.model.CountryCode
 import com.stripe.android.databinding.CardMultilineWidgetBinding
 import com.stripe.android.databinding.StripeCardFormViewBinding
 import com.stripe.android.model.Address
@@ -46,6 +47,19 @@ class CardFormView(context: ThemedReactContext) : FrameLayout(context) {
 
     cardFormViewBinding.cardMultilineWidget.postalCodeRequired = false
     cardFormViewBinding.postalCodeContainer.visibility = visibility
+  }
+
+  fun setDefaultValues(defaults: ReadableMap) {
+    val defaultLocale = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+      if (context.resources.configuration.locales.isEmpty) "US"
+      else context.resources.configuration.locales[0].country
+    } else {
+      context.resources.configuration.locale.country
+    }
+    val countryCode =  defaults.getString("countryCode") ?: defaultLocale
+
+    cardFormViewBinding.countryLayout.setSelectedCountryCode(CountryCode(countryCode))
+    cardFormViewBinding.countryLayout.updateUiForCountryEntered(CountryCode(countryCode))
   }
 
   fun setPlaceHolders(value: ReadableMap) {

--- a/android/src/main/java/com/reactnativestripesdk/CardFormView.kt
+++ b/android/src/main/java/com/reactnativestripesdk/CardFormView.kt
@@ -50,16 +50,10 @@ class CardFormView(context: ThemedReactContext) : FrameLayout(context) {
   }
 
   fun setDefaultValues(defaults: ReadableMap) {
-    val defaultLocale = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-      if (context.resources.configuration.locales.isEmpty) "US"
-      else context.resources.configuration.locales[0].country
-    } else {
-      context.resources.configuration.locale.country
+    defaults.getString("countryCode")?.let {
+      cardFormViewBinding.countryLayout.setSelectedCountryCode(CountryCode(it))
+      cardFormViewBinding.countryLayout.updateUiForCountryEntered(CountryCode(it))
     }
-    val countryCode =  defaults.getString("countryCode") ?: defaultLocale
-
-    cardFormViewBinding.countryLayout.setSelectedCountryCode(CountryCode(countryCode))
-    cardFormViewBinding.countryLayout.updateUiForCountryEntered(CountryCode(countryCode))
   }
 
   fun setPlaceHolders(value: ReadableMap) {

--- a/android/src/main/java/com/reactnativestripesdk/CardFormViewManager.kt
+++ b/android/src/main/java/com/reactnativestripesdk/CardFormViewManager.kt
@@ -51,6 +51,11 @@ class CardFormViewManager : SimpleViewManager<CardFormView>() {
     view.setCardStyle(cardStyle)
   }
 
+  @ReactProp(name = "defaultValues")
+  fun setDefaultValues(view: CardFormView, defaults: ReadableMap) {
+    view.setDefaultValues(defaults)
+  }
+
   override fun createViewInstance(reactContext: ThemedReactContext): CardFormView {
     val stripeSdkModule: StripeSdkModule? = reactContext.getNativeModule(StripeSdkModule::class.java)
     val view = CardFormView(reactContext)

--- a/example/src/screens/MultilineWebhookPaymentScreen.tsx
+++ b/example/src/screens/MultilineWebhookPaymentScreen.tsx
@@ -103,6 +103,9 @@ export default function MultilineWebhookPaymentScreen() {
           console.log(cardDetails);
           setComplete(cardDetails.complete);
         }}
+        defaultValues={{
+          countryCode: 'US',
+        }}
       />
       <View style={styles.row}>
         <Switch

--- a/src/components/CardForm.tsx
+++ b/src/components/CardForm.tsx
@@ -42,6 +42,8 @@ export interface Props extends AccessibilityProps {
 
   /** Android only */
   placeholders?: CardFormView.Placeholders;
+  /** Android only */
+  defaultValues?: CardFormView.DefaultValues;
   // onBlur?(): void;
   // onFocus?(focusedField: CardFormView.FieldNames | null): void;
   onFormComplete?(card: CardFormView.Details): void;
@@ -81,6 +83,7 @@ export const CardForm = forwardRef<CardFormView.Methods, Props>(
       // onFocus,
       // onBlur,
       placeholders,
+      defaultValues,
       ...props
     },
     ref
@@ -184,6 +187,9 @@ export const CardForm = forwardRef<CardFormView.Methods, Props>(
           expiration: placeholders?.expiration,
           cvc: placeholders?.cvc,
           postalCode: placeholders?.postalCode,
+        }}
+        defaultValues={{
+          ...(defaultValues ?? {}),
         }}
         onFocusChange={onFocusHandler}
         // postalCodeEnabled={postalCodeEnabled}

--- a/src/types/components/CardFormView.ts
+++ b/src/types/components/CardFormView.ts
@@ -44,6 +44,11 @@ export interface Placeholders {
   postalCode?: string;
 }
 
+export type DefaultValues = {
+  /** The 2-letter country code for the country selected by default on Android. If this is null, it is set by the device's configured region in the Settings app. */
+  countryCode?: string;
+};
+
 /**
  * @ignore
  */
@@ -54,6 +59,8 @@ export interface NativeProps {
   cardStyle?: Styles;
   /** Android only */
   placeholders?: Placeholders;
+  /** Android only */
+  defaultValues?: DefaultValues;
   // postalCodeEnabled: boolean;
   onFocusChange(
     event: NativeSyntheticEvent<{ focusedField: FieldName | null }>


### PR DESCRIPTION
## Summary

`CardForm`'s country input on Android will now match the behavior of iOS- defaulting to the current locale of the device (user setting). This PR also adds new functionality- the option to override that input on Android (iOS doesn't expose this)

## Motivation
closes https://github.com/stripe/stripe-react-native/issues/695

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one: 
- [x] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
