### PR TITLE
fix: resolve with Error.Canceled if no payment option is selected in Payment Sheet custom flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Breaking changes
+
+### New features
+
+### Fixes
+
+- Resolve with an Error (of type `Canceled`) if no payment option is selected in the Payment Sheet custom flow (i.e., the `x` button is clicked to close the Payment Sheet). [#975](https://github.com/stripe/stripe-react-native/pull/975)
+
 ## 0.12.0
 
 ### Breaking changes

--- a/android/src/main/java/com/reactnativestripesdk/PaymentSheetFragment.kt
+++ b/android/src/main/java/com/reactnativestripesdk/PaymentSheetFragment.kt
@@ -74,14 +74,15 @@ class PaymentSheetFragment(
         option.putString("label", paymentOption.label)
         option.putString("image", imageString)
         presentPromise?.resolve(createResult("paymentOption", option))
+      } else {
+        presentPromise?.resolve(createError(PaymentSheetErrorType.Canceled.toString(), "The payment option selection flow has been canceled"))
       }
-      presentPromise?.resolve(WritableNativeMap())
     }
 
     val paymentResultCallback = PaymentSheetResultCallback { paymentResult ->
       when (paymentResult) {
         is PaymentSheetResult.Canceled -> {
-          val message = "The payment has been canceled"
+          val message = "The payment flow has been canceled"
           confirmPromise?.resolve(createError(PaymentSheetErrorType.Canceled.toString(), message))
             ?: run {
               presentPromise?.resolve(createError(PaymentSheetErrorType.Canceled.toString(), message))

--- a/ios/StripeSdk.swift
+++ b/ios/StripeSdk.swift
@@ -204,7 +204,7 @@ class StripeSdk: RCTEventEmitter, STPApplePayContextDelegate, STPBankSelectionVi
                         resolve([])
                         self.paymentSheetFlowController = nil
                     case .canceled:
-                        resolve(Errors.createError(ErrorType.Canceled, "The payment has been canceled"))
+                        resolve(Errors.createError(ErrorType.Canceled, "The payment flow has been canceled"))
                     case .failed(let error):
                         resolve(Errors.createError(ErrorType.Failed, error.localizedDescription))
                     }
@@ -232,7 +232,7 @@ class StripeSdk: RCTEventEmitter, STPApplePayContextDelegate, STPBankSelectionVi
                         ]
                         resolve(Mappers.createResult("paymentOption", option))
                     } else {
-                        resolve(Mappers.createResult("paymentOption", nil))
+                        resolve(Errors.createError(ErrorType.Canceled, "The payment option selection flow has been canceled"))
                     }
                 }
             } else if let paymentSheet = self.paymentSheet {

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -406,7 +406,7 @@ export const presentPaymentSheet =
         };
       }
       return {
-        paymentOption: paymentOption,
+        paymentOption: paymentOption!,
       };
     } catch (error: any) {
       return {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -140,11 +140,7 @@ export type InitPaymentSheetResult =
 
 export type PresentPaymentSheetResult =
   | {
-      paymentOption?: undefined;
-      error?: undefined;
-    }
-  | {
-      paymentOption?: PaymentSheet.PaymentOption;
+      paymentOption: PaymentSheet.PaymentOption;
       error?: undefined;
     }
   | {


### PR DESCRIPTION

## Summary

previously we'd return with a null error, and a null payment option is the flow was cancelled. this isn't necessarily bad, but it doesn't match the behavior of the non-custom flow, or any of our other flows.

Now, we resolve with an error.code == Canceled

## Motivation
closes https://github.com/stripe/stripe-react-native/issues/723
## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
