### PR TITLE
feat: add `canAddCardToWallet` method for Push Provisioning

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Install Dependencies
         run: yarn bootstrap-no-pods
-        
+
       - name: Setup Java environment
         uses: actions/setup-java@v3
         with:
@@ -67,7 +67,7 @@ jobs:
             sleep 15
             adb shell 'echo "chrome --disable-fre --no-default-browser-check --no-first-run" > /data/local/tmp/chrome-command-line'
             adb shell am set-debug-app --persistent com.android.chrome
-            yarn test:android
+            yarn test:e2e:android
 
       - name: Upload Screenshoots
         uses: actions/upload-artifact@v1
@@ -128,7 +128,7 @@ jobs:
 
       - name: Run Tests
         run: |
-          yarn test:ios
+          yarn test:e2e:ios
 
       - name: Upload Screenshoots
         uses: actions/upload-artifact@v1

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -44,6 +44,8 @@ jobs:
       - name: Install Dependencies
         run: yarn bootstrap
 
+      - name: debug
+        run: xcodebuild -list
+
       - name: Run Tests
-        run: |
-          yarn test:unit:ios
+        run: yarn test:unit:ios

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -44,8 +44,5 @@ jobs:
       - name: Install Dependencies
         run: yarn bootstrap
 
-      - name: debug
-        run: xcodebuild -list
-
       - name: Run Tests
         run: yarn test:unit:ios

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -44,5 +44,63 @@ jobs:
       - name: Install Dependencies
         run: yarn bootstrap
 
-      - name: Run Tests
+      - name: Run tests
         run: yarn test:unit:ios
+
+  test-android:
+    name: unit-test-android
+    runs-on: macos-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - uses: actions/cache@v2
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v2.1.5
+        with:
+          node-version: 14.15.0
+
+      - name: Install React Native CLI
+        run: npm install react-native-cli
+
+      - name: Install Dependencies
+        run: yarn bootstrap-no-pods
+
+      - name: Setup Java environment
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '11'
+
+      - name: Gradle cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-${{ runner.os }}-${{ hashFiles('**/*.gradle*') }}-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}-${{ hashFiles('**/buildSrc/**/*.kt') }}
+
+      - name: Run tests
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 29
+          arch: x86_64
+          profile: Galaxy Nexus
+          target: google_apis
+          force-avd-creation: false
+          disable-animations: true
+          cores: 3
+          ram-size: 8192M
+          script: |
+            yarn test:unit:android

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,49 @@
+name: Unit Tests
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: ['**']
+
+jobs:
+  test-ios:
+    name: unit-test-ios
+    runs-on: macos-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - uses: actions/cache@v2
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - uses: actions/cache@v2
+        with:
+          path: example/ios/Pods
+          key: ${{ runner.os }}-pods-${{ hashFiles('**/Podfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pods-
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v2.1.5
+        with:
+          node-version: 14.15.0
+
+      - name: Install React Native CLI
+        run: npm install react-native-cli
+
+      - name: Install Dependencies
+        run: yarn bootstrap
+
+      - name: Run Tests
+        run: |
+          yarn test:unit:ios

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,8 @@ project.xcworkspace
 local.properties
 android.iml
 *.hprof
+android/build/reports
+example/android/app/build/reports
 
 # Cocoapods
 #

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,7 +95,7 @@ In order to do that, edit .npmrc accordinly to https://raw.githubusercontent.com
 e.g. when you have `71.0.3578` chrome version installed you must specify `2.46` version of chrome-driver.
 
 1. run `yarn run-example-ios` / `yarn run-example-android` to build and open example app.
-2. run `yarn test:ios` / `yarn test:android` to run e2e tests.
+2. run `yarn test:e2e:ios` / `yarn test:e2e:android` to run e2e tests.
 
 ### Scripts
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -34,6 +34,7 @@ android {
     versionCode 1
     versionName "1.0"
     vectorDrawables.useSupportLibrary = true
+    testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
   }
 
   buildTypes {
@@ -146,4 +147,14 @@ dependencies {
 
   // Users need to declare this dependency on their own, otherwise all methods are a no-op
   compileOnly 'com.stripe:stripe-android-issuing-push-provisioning:1.1.0'
+
+  androidTestImplementation "junit:junit:4.13"
+  androidTestImplementation "androidx.test:core:1.4.0"
+  androidTestImplementation 'androidx.test:runner:1.1.0'
+  androidTestImplementation "org.mockito:mockito-core:3.+"
+}
+
+configurations {
+    // We want to include all of our compileOnly libraries in our tests
+    androidTestImplementation.extendsFrom compileOnly
 }

--- a/android/src/androidTest/java/com/reactnativestripesdk/pushprovisioning/PushProvisioningProxyTest.kt
+++ b/android/src/androidTest/java/com/reactnativestripesdk/pushprovisioning/PushProvisioningProxyTest.kt
@@ -1,0 +1,35 @@
+package com.reactnativestripesdk.pushprovisioning
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.facebook.react.bridge.ReactApplicationContext
+import org.junit.Assert.*
+import org.junit.Test
+
+class PushProvisioningProxyTest {
+  private val reactApplicationContext = ReactApplicationContext(
+    ApplicationProvider.getApplicationContext<Context>()
+  )
+
+  @Test
+  fun getApiVersion() {
+    // This value very rarely changes, so the test is hard coded
+    assertEquals(
+      "2019-09-09",
+      PushProvisioningProxy.getApiVersion()
+    )
+  }
+
+  @Test
+  fun isNFCEnabled() {
+    assertEquals(
+      false,
+      PushProvisioningProxy.isNFCEnabled(reactApplicationContext)
+    )
+  }
+
+  @Test
+  fun isTokenInWallet() {
+    assertEquals(TapAndPayProxy.isTokenInWallet({}, "4242"), false)
+  }
+}

--- a/android/src/main/java/com/reactnativestripesdk/Mappers.kt
+++ b/android/src/main/java/com/reactnativestripesdk/Mappers.kt
@@ -14,6 +14,22 @@ internal fun createResult(key: String, value: WritableMap): WritableMap {
   return map
 }
 
+internal fun createCanAddCardResult(canAddCard: Boolean, status: String? = null, token: WritableMap? = null): WritableNativeMap {
+  val result = WritableNativeMap()
+  val details = WritableNativeMap()
+  if (status != null) {
+    result.putBoolean("canAddCard", false)
+    details.putString("status", status)
+  } else {
+    result.putBoolean("canAddCard", canAddCard)
+    if (token != null) {
+      details.putMap("token", token)
+    }
+  }
+  result.putMap("details", details)
+  return result
+}
+
 internal fun mapIntentStatus(status: StripeIntent.Status?): String {
   return when (status) {
     StripeIntent.Status.Succeeded -> "Succeeded"

--- a/android/src/main/java/com/reactnativestripesdk/pushprovisioning/AddToWalletButtonView.kt
+++ b/android/src/main/java/com/reactnativestripesdk/pushprovisioning/AddToWalletButtonView.kt
@@ -17,7 +17,6 @@ import com.facebook.react.bridge.WritableMap
 import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.UIManagerModule
 import com.facebook.react.uimanager.events.EventDispatcher
-import com.reactnativestripesdk.PushProvisioningProxy
 import com.reactnativestripesdk.createError
 
 

--- a/android/src/main/java/com/reactnativestripesdk/pushprovisioning/PushProvisioningProxy.kt
+++ b/android/src/main/java/com/reactnativestripesdk/pushprovisioning/PushProvisioningProxy.kt
@@ -1,13 +1,16 @@
-package com.reactnativestripesdk
+package com.reactnativestripesdk.pushprovisioning
 
 import android.app.Activity
 import android.app.Activity.RESULT_OK
 import android.content.Intent
+import android.content.pm.PackageManager
+import android.nfc.NfcAdapter
 import android.util.Log
-import com.facebook.react.bridge.*
-import com.reactnativestripesdk.pushprovisioning.AddToWalletButtonView
-import com.reactnativestripesdk.pushprovisioning.EphemeralKeyProvider
-import com.reactnativestripesdk.pushprovisioning.TapAndPayProxy
+import com.facebook.react.bridge.BaseActivityEventListener
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReadableMap
+import com.reactnativestripesdk.createError
+import com.reactnativestripesdk.mapError
 import com.stripe.android.pushProvisioning.PushProvisioningActivity
 import com.stripe.android.pushProvisioning.PushProvisioningActivityStarter
 
@@ -24,6 +27,15 @@ object PushProvisioningProxy {
     } catch (e: Exception) {
       Log.e(TAG, "PushProvisioning dependency not found")
       ""
+    }
+  }
+
+  fun isNFCEnabled(context: ReactApplicationContext): Boolean {
+    return if (context.packageManager.hasSystemFeature(PackageManager.FEATURE_NFC)) {
+      val adapter = NfcAdapter.getDefaultAdapter(context)
+      adapter.isEnabled
+    } else {
+      false
     }
   }
 
@@ -57,8 +69,8 @@ object PushProvisioningProxy {
     }
   }
 
-  fun isCardInWallet(activity: Activity, cardLastFour: String, promise: Promise) {
-    TapAndPayProxy.invoke(activity, cardLastFour, promise)
+  fun isCardInWallet(activity: Activity, cardLastFour: String, callback: TokenCheckHandler) {
+    TapAndPayProxy.findExistingToken(activity, cardLastFour, callback)
   }
 
   private fun createActivityEventListener(context: ReactApplicationContext, view: AddToWalletButtonView) {

--- a/android/src/main/java/com/reactnativestripesdk/pushprovisioning/TapAndPayProxy.kt
+++ b/android/src/main/java/com/reactnativestripesdk/pushprovisioning/TapAndPayProxy.kt
@@ -2,54 +2,68 @@ package com.reactnativestripesdk.pushprovisioning
 
 import android.app.Activity
 import android.util.Log
-import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.WritableMap
 import com.facebook.react.bridge.WritableNativeMap
 import com.reactnativestripesdk.createError
 import com.google.android.gms.tasks.Task
 
+typealias TokenCheckHandler = (isCardInWallet: Boolean, token: WritableMap?, error: WritableMap?) -> Unit
+
 object TapAndPayProxy {
   private const val TAG = "StripeTapAndPay"
   private var tapAndPayClient: Any? = null
   const val REQUEST_CODE_TOKENIZE = 90909
 
-  fun invoke(activity: Activity, newCardLastFour: String, promise: Promise) {
-    try {
+  private fun getTapandPayTokens(activity: Activity): Task<List<Any>>? {
+    return try {
       val tapAndPayClass = Class.forName("com.google.android.gms.tapandpay.TapAndPay")
-      val getClientMethod = tapAndPayClass.getMethod("getClient", Activity::class.java)
+      val getClientMethod = tapAndPayClass.getMethod(
+        "getClient",
+        Activity::class.java)
+      val client = getClientMethod.invoke(null, activity)
 
-      tapAndPayClient = getClientMethod.invoke(null, activity).also {
-        val tapAndPayClientClass = Class.forName("com.google.android.gms.tapandpay.TapAndPayClient")
-        val listTokensMethod = tapAndPayClientClass.getMethod("listTokens")
+      val tapAndPayClientClass = Class.forName("com.google.android.gms.tapandpay.TapAndPayClient")
+      val listTokensMethod = tapAndPayClientClass.getMethod("listTokens")
 
-        val tokens = listTokensMethod.invoke(it) as Task<List<Any>>
-        tokens.addOnCompleteListener { task ->
-          if (task.isSuccessful) {
-            for (token in task.result) {
-              try {
-                val getFpanLastFourMethod = Class.forName("com.google.android.gms.tapandpay.issuer.TokenInfo").getMethod("getFpanLastFour")
-                val existingFpanLastFour = getFpanLastFourMethod.invoke(token) as String
-                if (existingFpanLastFour == newCardLastFour) {
-                  promise.resolve(
-                    createResult(
-                      true,
-                      token))
-                  return@addOnCompleteListener
-                }
-              } catch (e: Exception) {
-                Log.e(TAG, "There was a problem finding the class com.google.android.gms.tapandpay.issuer.TokenInfo. Make sure you've included Google's TapAndPay dependency.")
-              }
-            }
-          } else {
-            Log.e(TAG, "Unable to fetch existing tokens from Google TapAndPay.")
-          }
-          promise.resolve(createResult(false))
-        }
-      }
+      listTokensMethod.invoke(client) as Task<List<Any>>
     } catch (e: Exception) {
       Log.e(TAG, "Google TapAndPay dependency not found")
-      promise.resolve(createError("Failed", "Google TapAndPay dependency not found."))
+      null
+    }
+  }
+
+  private fun isTokenInWallet(token: Any, newLastFour: String): Boolean {
+    return try {
+      val getFpanLastFourMethod = Class.forName("com.google.android.gms.tapandpay.issuer.TokenInfo").getMethod("getFpanLastFour")
+      val existingFpanLastFour = getFpanLastFourMethod.invoke(token) as String
+      existingFpanLastFour == newLastFour
+    } catch (e: Exception) {
+      Log.e(TAG, "There was a problem finding the class com.google.android.gms.tapandpay.issuer.TokenInfo. Make sure you've included Google's TapAndPay dependency.")
+      false
+    }
+  }
+
+
+  fun findExistingToken(activity: Activity, newCardLastFour: String, callback: TokenCheckHandler) {
+    val tokens = getTapandPayTokens(activity)
+    if (tokens == null) {
+      callback(false, null, createError("Failed", "Google TapAndPay dependency not found."))
+      return
+    }
+
+    tokens.addOnCompleteListener { task ->
+      if (task.isSuccessful) {
+        for (token in task.result) {
+          if (isTokenInWallet(token, newCardLastFour)) {
+            callback(true,  mapFromTokenInfo(token), null)
+            return@addOnCompleteListener
+          }
+        }
+      } else {
+        Log.e(TAG, "Unable to fetch existing tokens from Google TapAndPay.")
+      }
+      callback(false, null, null)
     }
   }
 
@@ -67,13 +81,6 @@ object TapAndPayProxy {
     } catch (e: Exception) {
       Log.e(TAG, "Google TapAndPay dependency not found.")
     }
-  }
-
-  private fun createResult(cardIsInWallet: Boolean, token: Any? = null): WritableMap {
-    val result = WritableNativeMap()
-    result.putBoolean("isInWallet", cardIsInWallet)
-    result.putMap("token", mapFromTokenInfo(token))
-    return result
   }
 
   private fun mapFromTokenInfo(token: Any?): WritableMap? {

--- a/android/src/main/java/com/reactnativestripesdk/pushprovisioning/TapAndPayProxy.kt
+++ b/android/src/main/java/com/reactnativestripesdk/pushprovisioning/TapAndPayProxy.kt
@@ -33,7 +33,7 @@ object TapAndPayProxy {
     }
   }
 
-  private fun isTokenInWallet(token: Any, newLastFour: String): Boolean {
+  internal fun isTokenInWallet(token: Any, newLastFour: String): Boolean {
     return try {
       val getFpanLastFourMethod = Class.forName("com.google.android.gms.tapandpay.issuer.TokenInfo").getMethod("getFpanLastFour")
       val existingFpanLastFour = getFpanLastFourMethod.invoke(token) as String

--- a/e2e/buyNowPayLater.test.ts
+++ b/e2e/buyNowPayLater.test.ts
@@ -22,7 +22,7 @@ describe('Payment scenarios with redirects', () => {
     $('~payment-screen').waitForDisplayed({ timeout: 30000 });
 
     BasicPaymentScreen.pay({ email: 'test@stripe.com' });
-    BasicPaymentScreen.authorize({ elementType: 'a', pause: 10000 });
+    BasicPaymentScreen.authorize({ pause: 10000 });
     BasicPaymentScreen.checkStatus();
   });
 

--- a/e2e/paymentsWithRedirects.test.ts
+++ b/e2e/paymentsWithRedirects.test.ts
@@ -201,7 +201,7 @@ describe('Payment scenarios with redirects', () => {
     $('~payment-screen').waitForDisplayed({ timeout: 30000 });
 
     BasicPaymentScreen.pay({ email: 'test@stripe.com' });
-    BasicPaymentScreen.authorize({ elementType: 'a' });
+    BasicPaymentScreen.authorize();
     BasicPaymentScreen.checkStatus();
   });
 

--- a/e2e/screenObject/BasicPaymentScreen.ts
+++ b/e2e/screenObject/BasicPaymentScreen.ts
@@ -39,7 +39,7 @@ class BasicPaymentScreen {
     driver.pause(5000);
   }
 
-  authorize({ elementType = 'button', pause = 5000 } = {}) {
+  authorize({ pause = 5000 } = {}) {
     driver.pause(pause);
 
     // We can have multiple webview contexts, so we return all of them and then try going through each one.
@@ -49,9 +49,9 @@ class BasicPaymentScreen {
     for (const context of webviewContexts) {
       try {
         driver.switchContext(context);
-        const button = $(`${elementType}*=Authorize`);
-        if (button.isDisplayed()) {
-          button.click();
+
+        const success = clickAuthorizeButton();
+        if (success) {
           driver.pause(1000);
           break;
         }
@@ -157,6 +157,18 @@ function getNativeContext(): string {
   }
 
   return nativeContext;
+}
+
+function clickAuthorizeButton(): boolean {
+  return ['button', 'a'].some((elementType: string) => {
+    const element = $(`${elementType}*=Authorize`);
+    if (element.isDisplayed()) {
+      element.click();
+      return true;
+    } else {
+      return false;
+    }
+  });
 }
 
 export default new BasicPaymentScreen();

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -20,7 +20,9 @@ target 'StripeSdkExample' do
     :app_path => "#{Pod::Config.instance.installation_root}/.."
   )
 
-  pod 'stripe-react-native', path: '../..'
+  pod 'stripe-react-native',
+      :path => '../..',
+      :testspecs => ['Tests']
 
   # Enables Flipper.
   # Note that if you have use_frameworks! enabled, Flipper will not work and

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -309,6 +309,10 @@ PODS:
     - React-Core
     - Stripe (~> 22.5.1)
     - StripeFinancialConnections (~> 22.5.1)
+  - stripe-react-native/Tests (0.13.1):
+    - React-Core
+    - Stripe (~> 22.5.1)
+    - StripeFinancialConnections (~> 22.5.1)
   - Stripe/Stripe3DS2 (22.5.1):
     - StripeApplePay (= 22.5.1)
     - StripeCore (= 22.5.1)
@@ -362,6 +366,7 @@ DEPENDENCIES:
   - "RNCPicker (from `../node_modules/@react-native-picker/picker`)"
   - RNScreens (from `../node_modules/react-native-screens`)
   - stripe-react-native (from `../..`)
+  - stripe-react-native/Tests (from `../..`)
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
 
 SPEC REPOS:
@@ -487,13 +492,13 @@ SPEC CHECKSUMS:
   RNCPicker: abc646b53a3d28ccfa3232c927a0ca52e0cf024d
   RNScreens: 40a2cb40a02a609938137a1e0acfbf8fc9eebf19
   Stripe: 2b2decd03146e08a350960966d41f3028c2eac29
-  stripe-react-native: 564554ae990c021077813a60417349cc9db3a645
+  stripe-react-native: 9d56a4aefffea73722d2e00ee9f88f42133ffe98
   StripeApplePay: b14f06ac6fc24b56704c1e598149ed0cc45e166f
   StripeCore: 4833738f2ca4336712f279f3c2867a0a7eb67c93
   StripeFinancialConnections: 982115b82af429968d8aa78d329a42ed7ba3feab
   StripeUICore: 08c1efbd7e3c54ee7fa74334a37a1d4c08ba944d
   Yoga: 17cd9a50243093b547c1e539c749928dd68152da
 
-PODFILE CHECKSUM: 89387f6a979368e90b83d6e182d905e7f384066a
+PODFILE CHECKSUM: c4e9b2120821943f7d12dc0f530b092db677b0bd
 
 COCOAPODS: 1.11.3

--- a/example/ios/StripeSdkExample.xcodeproj/project.pbxproj
+++ b/example/ios/StripeSdkExample.xcodeproj/project.pbxproj
@@ -30,7 +30,7 @@
 		247B76C1256C47BD0086EA47 /* StripeSdkExample.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; name = StripeSdkExample.entitlements; path = StripeSdkExample/StripeSdkExample.entitlements; sourceTree = "<group>"; };
 		4D7192F03A36A017E887435B /* Pods-StripeSdkExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-StripeSdkExample.release.xcconfig"; path = "Target Support Files/Pods-StripeSdkExample/Pods-StripeSdkExample.release.xcconfig"; sourceTree = "<group>"; };
 		871719007ECC5EAD276C345C /* Pods-StripeSdkExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-StripeSdkExample.debug.xcconfig"; path = "Target Support Files/Pods-StripeSdkExample/Pods-StripeSdkExample.debug.xcconfig"; sourceTree = "<group>"; };
-		A9E86F3B4D81411588469621 /* Macondo-Regular.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = undefined; includeInIndex = 0; lastKnownFileType = unknown; name = "Macondo-Regular.ttf"; path = "../src/assets/fonts/Macondo-Regular.ttf"; sourceTree = "<group>"; };
+		A9E86F3B4D81411588469621 /* Macondo-Regular.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "Macondo-Regular.ttf"; path = "../src/assets/fonts/Macondo-Regular.ttf"; sourceTree = "<group>"; };
 		BCEA90A70F4BEAD7E9FA28B2 /* libPods-StripeSdkExample.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-StripeSdkExample.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
 		FCD4117C281095E3001354AA /* AppDelegate.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = AppDelegate.mm; path = StripeSdkExample/AppDelegate.mm; sourceTree = "<group>"; };
@@ -120,7 +120,6 @@
 				A9E86F3B4D81411588469621 /* Macondo-Regular.ttf */,
 			);
 			name = Resources;
-			path = "";
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -153,6 +152,7 @@
 		83CBB9F71A601CBA00E9B192 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				LastSwiftUpdateCheck = 1340;
 				LastUpgradeCheck = 1320;
 				ORGANIZATIONNAME = Facebook;
 				TargetAttributes = {

--- a/example/ios/StripeSdkExample.xcodeproj/xcshareddata/xcschemes/StripeSdkExample.xcscheme
+++ b/example/ios/StripeSdkExample.xcodeproj/xcshareddata/xcschemes/StripeSdkExample.xcscheme
@@ -51,6 +51,16 @@
          </BuildableReference>
       </MacroExpansion>
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "87501B78F65E77E2C04C7D908C29DA28"
+               BuildableName = "stripe-react-native-Unit-Tests.xctest"
+               BlueprintName = "stripe-react-native-Unit-Tests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/example/ios/StripeSdkExample.xcworkspace/xcshareddata/xcschemes/UnitTests.xcscheme
+++ b/example/ios/StripeSdkExample.xcworkspace/xcshareddata/xcschemes/UnitTests.xcscheme
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1340"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "87501B78F65E77E2C04C7D908C29DA28"
+               BuildableName = "stripe-react-native-Unit-Tests.xctest"
+               BlueprintName = "stripe-react-native-Unit-Tests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+            <LocationScenarioReference
+               identifier = "com.apple.dt.IDEFoundation.CurrentLocationScenarioIdentifier"
+               referenceType = "1">
+            </LocationScenarioReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/example/src/screens/ApplePayScreen.tsx
+++ b/example/src/screens/ApplePayScreen.tsx
@@ -6,7 +6,7 @@ import {
   ApplePay,
   AddToWalletButton,
   Constants,
-  isCardInWallet,
+  canAddCardToWallet,
 } from '@stripe/stripe-react-native';
 import PaymentScreen from '../components/PaymentScreen';
 import { API_URL } from '../Config';
@@ -16,7 +16,7 @@ const TEST_CARD_ID = 'ic_1KnngYF05jLespP6nGoB1oXn';
 
 export default function ApplePayScreen() {
   const [ephemeralKey, setEphemeralKey] = useState({});
-  const [cardIsInWallet, setCardIsInWallet] = useState(false);
+  const [showAddToWalletButton, setShowAddToWalletButton] = useState(true);
   const [cardDetails, setCardDetails] = useState<any>(null);
 
   useEffect(() => {
@@ -38,14 +38,19 @@ export default function ApplePayScreen() {
     const card = await response.json();
     setCardDetails(card);
 
-    const { isInWallet, error } = await isCardInWallet({
+    const { canAddCard, details, error } = await canAddCardToWallet({
+      primaryAccountIdentifier: card?.wallet?.primary_account_identifier,
       cardLastFour: card.last4,
+      testEnv: true,
     });
 
     if (error) {
       Alert.alert(error.code, error.message);
     } else {
-      setCardIsInWallet(isInWallet ?? false);
+      setShowAddToWalletButton(canAddCard ?? false);
+      if (details?.status) {
+        console.log(`Card status for native wallet: ${details.status}`);
+      }
     }
   };
 
@@ -181,7 +186,7 @@ export default function ApplePayScreen() {
             style={styles.payButton}
           />
 
-          {!cardIsInWallet && (
+          {showAddToWalletButton && (
             <AddToWalletButton
               androidAssetSource={{}}
               testEnv={true}

--- a/ios/StripeSdk.m
+++ b/ios/StripeSdk.m
@@ -122,6 +122,11 @@ RCT_EXTERN_METHOD(
                   rejecter: (RCTPromiseRejectBlock)reject
                   )
 RCT_EXTERN_METHOD(
+                  canAddCardToWallet:(NSDictionary *)params
+                  resolver: (RCTPromiseResolveBlock)resolve
+                  rejecter: (RCTPromiseRejectBlock)reject
+                  )
+RCT_EXTERN_METHOD(
                   isCardInWallet:(NSDictionary *)params
                   resolver: (RCTPromiseResolveBlock)resolve
                   rejecter: (RCTPromiseRejectBlock)reject

--- a/ios/StripeSdk.swift
+++ b/ios/StripeSdk.swift
@@ -1006,12 +1006,12 @@ class StripeSdk: RCTEventEmitter, STPApplePayContextDelegate, STPBankSelectionVi
             resolve(Errors.createError(ErrorType.Failed, "You must provide `cardLastFour`"))
             return
         }
-        let (canAddCard, details) = PushProvisioningUtils.canAddCardToWallet(last4: last4,
+        let (canAddCard, status) = PushProvisioningUtils.canAddCardToWallet(last4: last4,
                                                  primaryAccountIdentifier: params["primaryAccountIdentifier"] as? String ?? "",
                                                  testEnv: params["testEnv"] as? Bool ?? false)
         resolve([
             "canAddCard": canAddCard,
-            "details": details,
+            "details": ["status": status?.rawValue],
         ])
     }
     

--- a/ios/StripeSdk.swift
+++ b/ios/StripeSdk.swift
@@ -995,7 +995,26 @@ class StripeSdk: RCTEventEmitter, STPApplePayContextDelegate, STPBankSelectionVi
             }
         }
     }
-
+    
+    @objc(canAddCardToWallet:resolver:rejecter:)
+    func canAddCardToWallet(
+        params: NSDictionary,
+        resolver resolve: @escaping RCTPromiseResolveBlock,
+        rejecter reject: @escaping RCTPromiseRejectBlock
+    ) -> Void {
+        guard let last4 = params["cardLastFour"] as? String else {
+            resolve(Errors.createError(ErrorType.Failed, "You must provide `cardLastFour`"))
+            return
+        }
+        let (canAddCard, details) = PushProvisioningUtils.canAddCardToWallet(last4: last4,
+                                                 primaryAccountIdentifier: params["primaryAccountIdentifier"] as? String ?? "",
+                                                 testEnv: params["testEnv"] as? Bool ?? false)
+        resolve([
+            "canAddCard": canAddCard,
+            "details": details,
+        ])
+    }
+    
     @objc(isCardInWallet:resolver:rejecter:)
     func isCardInWallet(
         params: NSDictionary,
@@ -1006,15 +1025,7 @@ class StripeSdk: RCTEventEmitter, STPApplePayContextDelegate, STPBankSelectionVi
             resolve(Errors.createError(ErrorType.Failed, "You must provide `cardLastFour`"))
             return
         }
-
-        let existingPass: PKPass? = {
-            if #available(iOS 13.4, *) {
-                return PKPassLibrary().passes(of: PKPassType.secureElement).first(where: {$0.secureElementPass?.primaryAccountNumberSuffix == last4})
-            } else {
-                return PKPassLibrary().passes(of: PKPassType.payment).first(where: {$0.paymentPass?.primaryAccountNumberSuffix == last4})
-            }
-        }()
-        resolve(["isInWallet": existingPass != nil])
+        resolve(["isInWallet": PushProvisioningUtils.passExistsWith(last4: last4)])
     }
 
     func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {

--- a/ios/StripeSdk.xcodeproj/xcshareddata/xcschemes/Tests.xcscheme
+++ b/ios/StripeSdk.xcodeproj/xcshareddata/xcschemes/Tests.xcscheme
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1340"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FC55C2D928620B7D00526360"
+               BuildableName = "Tests.xctest"
+               BlueprintName = "Tests"
+               ReferencedContainer = "container:StripeSdk.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/ios/Tests/PushProvisioningTests.swift
+++ b/ios/Tests/PushProvisioningTests.swift
@@ -1,0 +1,49 @@
+//
+//  Tests.swift
+//  Tests
+//
+//  Created by Charles Cruzan on 6/21/22.
+//  Copyright © 2022 Facebook. All rights reserved.
+//
+
+import XCTest
+@testable import stripe_react_native
+
+class PushProvisioningTests: XCTestCase {
+    func testCanAddCardToWalletInTestMode() throws {
+        let (canAddCard, status) = PushProvisioningUtils.canAddCardToWallet(last4: "4242",
+                                                 primaryAccountIdentifier: "",
+                                                 testEnv: true)
+        XCTAssertEqual(canAddCard, true)
+        XCTAssertEqual(status, nil)
+    }
+
+    func testCanAddCardToWalletInLiveMode() throws {
+        let (canAddCard, status) = PushProvisioningUtils.canAddCardToWallet(last4: "4242",
+                                                 primaryAccountIdentifier: "",
+                                                 testEnv: false)
+        XCTAssertEqual(canAddCard, false)
+        XCTAssertEqual(status, PushProvisioningUtils.AddCardToWalletStatus.MISSING_CONFIGURATION)
+    }
+    
+    func testCanAddPaymentPassInTestMode() throws {
+        XCTAssertEqual(
+            PushProvisioningUtils.canAddPaymentPass(primaryAccountIdentifier: "", isTestMode: true),
+            true
+        )
+    }
+    
+    func testCanAddPaymentPassInLiveMode() throws {
+        XCTAssertEqual(
+            PushProvisioningUtils.canAddPaymentPass(primaryAccountIdentifier: "", isTestMode: false),
+            false
+        )
+    }
+    
+    func testCheckIfPassExists() throws {
+        XCTAssertEqual(
+            PushProvisioningUtils.passExistsWith(last4: "4242"),
+            false
+        )
+    }
+}

--- a/ios/pushprovisioning/AddToWalletButtonView.swift
+++ b/ios/pushprovisioning/AddToWalletButtonView.swift
@@ -33,10 +33,6 @@ class AddToWalletButtonView: UIView {
         }
     }
 
-    func canAddPaymentPass() -> Bool {
-        return self.testEnv ? STPFakeAddPaymentPassViewController.canAddPaymentPass() : PKAddPaymentPassViewController.canAddPaymentPass()
-    }
-
     override func didSetProps(_ changedProps: [String]!) {
         if let addToWalletButton = addToWalletButton {
             addToWalletButton.removeFromSuperview()
@@ -53,7 +49,7 @@ class AddToWalletButtonView: UIView {
     }
 
     @objc func beginPushProvisioning() {
-        if (!canAddPaymentPass()) {
+        if (!PushProvisioningUtils.canAddPaymentPass(primaryAccountIdentifier: cardDetails?["primaryAccountIdentifier"] as? String ?? "", isTestMode: self.testEnv)) {
             onCompleteAction!(
                 Errors.createError(
                     ErrorType.Failed,

--- a/ios/pushprovisioning/PushProvisioningUtils.swift
+++ b/ios/pushprovisioning/PushProvisioningUtils.swift
@@ -1,0 +1,58 @@
+//
+//  PushProvisioningUtils.swift
+//  stripe-react-native
+//
+//  Created by Charles Cruzan on 6/9/22.
+//
+
+import Foundation
+import Stripe
+
+class PushProvisioningUtils {
+    class func canAddCardToWallet(
+        last4: String,
+        primaryAccountIdentifier: String,
+        testEnv: Bool
+    ) -> (canAddCard: Bool, details: NSDictionary) {
+        if (!PKAddPassesViewController.canAddPasses()) {
+            return (false, ["details": ["status": "UNSUPPORTED_DEVICE"]])
+        }
+        
+        let details : NSMutableDictionary = [:]
+        var canAddCard = PushProvisioningUtils.canAddPaymentPass(
+            primaryAccountIdentifier: primaryAccountIdentifier,
+            isTestMode: testEnv)
+        
+        if (!canAddCard) {
+            details["status"] = "MISSING_CONFIGURATION"
+        } else if (PushProvisioningUtils.passExistsWith(last4: last4)) {
+            canAddCard = false
+            details["status"] = "CARD_ALREADY_EXISTS"
+        }
+
+        return (canAddCard, details)
+    }
+    
+    class func canAddPaymentPass(primaryAccountIdentifier: String, isTestMode: Bool) -> Bool {
+        if (isTestMode) {
+            return STPFakeAddPaymentPassViewController.canAddPaymentPass()
+        }
+        
+        if #available(iOS 13.4, *) {
+            return PKPassLibrary().canAddSecureElementPass(primaryAccountIdentifier: primaryAccountIdentifier)
+        } else {
+            return PKAddPaymentPassViewController.canAddPaymentPass()
+        }
+    }
+    
+    class func passExistsWith(last4: String) -> Bool {
+        let existingPass: PKPass? = {
+            if #available(iOS 13.4, *) {
+                return PKPassLibrary().passes(of: PKPassType.secureElement).first(where: {$0.secureElementPass?.primaryAccountNumberSuffix == last4})
+            } else {
+                return PKPassLibrary().passes(of: PKPassType.payment).first(where: {$0.paymentPass?.primaryAccountNumberSuffix == last4})
+            }
+        }()
+        return existingPass != nil
+    }
+}

--- a/ios/pushprovisioning/PushProvisioningUtils.swift
+++ b/ios/pushprovisioning/PushProvisioningUtils.swift
@@ -8,7 +8,7 @@
 import Foundation
 import Stripe
 
-class PushProvisioningUtils {
+internal class PushProvisioningUtils {
     class func canAddCardToWallet(
         last4: String,
         primaryAccountIdentifier: String,

--- a/ios/pushprovisioning/PushProvisioningUtils.swift
+++ b/ios/pushprovisioning/PushProvisioningUtils.swift
@@ -13,24 +13,24 @@ class PushProvisioningUtils {
         last4: String,
         primaryAccountIdentifier: String,
         testEnv: Bool
-    ) -> (canAddCard: Bool, details: NSDictionary) {
+    ) -> (canAddCard: Bool, status: AddCardToWalletStatus?) {
         if (!PKAddPassesViewController.canAddPasses()) {
-            return (false, ["details": ["status": "UNSUPPORTED_DEVICE"]])
+            return (false, AddCardToWalletStatus.UNSUPPORTED_DEVICE)
         }
         
-        let details : NSMutableDictionary = [:]
+        var status : AddCardToWalletStatus? = nil
         var canAddCard = PushProvisioningUtils.canAddPaymentPass(
             primaryAccountIdentifier: primaryAccountIdentifier,
             isTestMode: testEnv)
         
         if (!canAddCard) {
-            details["status"] = "MISSING_CONFIGURATION"
+            status = AddCardToWalletStatus.MISSING_CONFIGURATION
         } else if (PushProvisioningUtils.passExistsWith(last4: last4)) {
             canAddCard = false
-            details["status"] = "CARD_ALREADY_EXISTS"
+            status = AddCardToWalletStatus.CARD_ALREADY_EXISTS
         }
 
-        return (canAddCard, details)
+        return (canAddCard, status)
     }
     
     class func canAddPaymentPass(primaryAccountIdentifier: String, isTestMode: Bool) -> Bool {
@@ -54,5 +54,11 @@ class PushProvisioningUtils {
             }
         }()
         return existingPass != nil
+    }
+    
+    enum AddCardToWalletStatus: String {
+        case UNSUPPORTED_DEVICE
+        case MISSING_CONFIGURATION
+        case CARD_ALREADY_EXISTS
     }
 }

--- a/package.json
+++ b/package.json
@@ -31,8 +31,9 @@
     "docs": "yarn typedoc ./src/index.tsx --out ./docs/api-reference --tsconfig ./tsconfig.json --readme none",
     "run-example-ios": "cd example;ENVFILE=.env.ci react-native run-ios --configuration Release --simulator \"iPhone 13 (15.2)\"",
     "run-example-android": "cd example;ENVFILE=.env.ci react-native run-android --variant=release",
-    "test:ios": "mkdir -p .tmp/screenshots && node ./run-appium-tests.js ios",
-    "test:android": "mkdir -p .tmp/screenshots && node ./run-appium-tests.js android"
+    "test:e2e:ios": "mkdir -p .tmp/screenshots && node ./run-appium-tests.js ios",
+    "test:e2e:android": "mkdir -p .tmp/screenshots && node ./run-appium-tests.js android",
+    "test:unit:ios": "xcodebuild test -workspace example/ios/StripeSdkExample.xcworkspace -destination 'platform=iOS Simulator,name=iPhone 13' -scheme UnitTests"
   },
   "keywords": [
     "react-native",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "run-example-android": "cd example;ENVFILE=.env.ci react-native run-android --variant=release",
     "test:e2e:ios": "mkdir -p .tmp/screenshots && node ./run-appium-tests.js ios",
     "test:e2e:android": "mkdir -p .tmp/screenshots && node ./run-appium-tests.js android",
-    "test:unit:ios": "xcodebuild test -workspace example/ios/StripeSdkExample.xcworkspace -destination 'platform=iOS Simulator,name=iPhone 13' -scheme UnitTests"
+    "test:unit:ios": "xcodebuild test -workspace example/ios/StripeSdkExample.xcworkspace -destination 'platform=iOS Simulator,name=iPhone 13' -scheme UnitTests",
+    "test:unit:android": "cd example/android && ./gradlew connectedAndroidTest"
   },
   "keywords": [
     "react-native",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "test": "jest",
     "typescript": "tsc --noEmit",
-    "lint": "eslint \"**/*.{js,ts,tsx}\" --ignore-pattern \"docs/api-reference/*\" --ignore-pattern example/android/stripe-android",
+    "lint": "eslint \"**/*.{js,ts,tsx}\" --ignore-pattern \"docs/api-reference/*\" --ignore-path .gitignore",
     "prepare": "bob build",
     "release": "./scripts/publish",
     "example": "yarn --cwd example",

--- a/src/NativeStripeSdk.tsx
+++ b/src/NativeStripeSdk.tsx
@@ -25,6 +25,8 @@ import type {
   Token,
   VerifyMicrodepositsParams,
   IsCardInWalletResult,
+  CanAddCardToWalletParams,
+  CanAddCardToWalletResult,
 } from './types';
 
 type NativeStripeSdkType = {
@@ -88,6 +90,9 @@ type NativeStripeSdkType = {
     params: PaymentMethod.CollectBankAccountParams
   ): Promise<ConfirmSetupIntentResult | ConfirmPaymentResult>;
   getConstants(): { API_VERSIONS: { CORE: string; ISSUING: string } };
+  canAddCardToWallet(
+    params: CanAddCardToWalletParams
+  ): Promise<CanAddCardToWalletResult>;
   isCardInWallet(params: {
     cardLastFour: string;
   }): Promise<IsCardInWalletResult>;

--- a/src/components/AddToWalletButton.tsx
+++ b/src/components/AddToWalletButton.tsx
@@ -27,7 +27,7 @@ export interface Props extends AccessibilityProps {
   /** The image asset to use as the Google Pay button. Downloadable from https://developers.google.com/pay/issuers/apis/push-provisioning/android/downloads/flutter/googlepay_flutter_buttons.zip */
   androidAssetSource: ImageSourcePropType;
   testID?: string;
-  /** Only set to `false` when shipping through TestFlight || App Store */
+  /** iOS only. Set this to `true` until shipping through TestFlight || App Store. If true, you must be using live cards, and have the proper iOS entitlement set up. See https://stripe.com/docs/issuing/cards/digital-wallets?platform=react-native#requesting-access-for-ios */
   testEnv?: boolean;
   /** Details of the Issued Card you'd like added to the device's wallet */
   cardDetails: {

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -33,6 +33,8 @@ import {
   CollectBankAccountForPaymentResult,
   CollectBankAccountForSetupResult,
   IsCardInWalletResult,
+  CanAddCardToWalletParams,
+  CanAddCardToWalletResult,
 } from './types';
 
 const APPLE_PAY_NOT_SUPPORTED_MESSAGE =
@@ -557,6 +559,29 @@ export const collectBankAccountForSetup = async (
     }
     return {
       setupIntent: setupIntent!,
+    };
+  } catch (error: any) {
+    return {
+      error: createError(error),
+    };
+  }
+};
+
+export const canAddCardToWallet = async (
+  params: CanAddCardToWalletParams
+): Promise<CanAddCardToWalletResult> => {
+  try {
+    const { canAddCard, details, error } =
+      await NativeStripeSdk.canAddCardToWallet(params);
+
+    if (error) {
+      return {
+        error,
+      };
+    }
+    return {
+      canAddCard: canAddCard as boolean,
+      details: details,
     };
   } catch (error: any) {
     return {

--- a/src/hooks/useStripe.tsx
+++ b/src/hooks/useStripe.tsx
@@ -28,6 +28,8 @@ import type {
   VerifyMicrodepositsForSetupResult,
   CollectBankAccountForSetupResult,
   CollectBankAccountForPaymentResult,
+  CanAddCardToWalletParams,
+  CanAddCardToWalletResult,
 } from '../types';
 import { useCallback, useEffect, useState } from 'react';
 import { isiOS } from '../helpers';
@@ -57,6 +59,7 @@ import {
   collectBankAccountForSetup,
   verifyMicrodepositsForPayment,
   verifyMicrodepositsForSetup,
+  canAddCardToWallet,
 } from '../functions';
 
 /**
@@ -278,6 +281,15 @@ export function useStripe() {
     []
   );
 
+  const _canAddCardToWallet = useCallback(
+    async (
+      params: CanAddCardToWalletParams
+    ): Promise<CanAddCardToWalletResult> => {
+      return canAddCardToWallet(params);
+    },
+    []
+  );
+
   return {
     retrievePaymentIntent: _retrievePaymentIntent,
     retrieveSetupIntent: _retrieveSetupIntent,
@@ -304,5 +316,6 @@ export function useStripe() {
     collectBankAccountForSetup: _collectBankAccountForSetup,
     verifyMicrodepositsForPayment: _verifyMicrodepositsForPayment,
     verifyMicrodepositsForSetup: _verifyMicrodepositsForSetup,
+    canAddCardToWallet: _canAddCardToWallet,
   };
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -295,3 +295,30 @@ export type IsCardInWalletResult =
       token?: undefined;
       error: StripeError<GooglePayError>;
     };
+
+export type CanAddCardToWalletParams = {
+  /** The `primary_account_identifier` value from the issued card. Can be an empty string. */
+  primaryAccountIdentifier: string | null;
+  /** Last 4 digits of the card number. */
+  cardLastFour: string;
+  /** iOS only. Set this to `true` until shipping through TestFlight || App Store. If true, you must be using live cards, and have the proper iOS entitlement set up. See https://stripe.com/docs/issuing/cards/digital-wallets?platform=react-native#requesting-access-for-ios */
+  testEnv?: boolean;
+};
+
+export type CanAddCardToWalletResult =
+  | {
+      canAddCard: boolean;
+      details?: {
+        token?: GooglePayCardToken;
+        status?:
+          | 'MISSING_CONFIGURATION'
+          | 'UNSUPPORTED_DEVICE'
+          | 'CARD_ALREADY_EXISTS';
+      };
+      error?: undefined;
+    }
+  | {
+      canAddCard?: undefined;
+      details?: undefined;
+      error: StripeError<GooglePayError>;
+    };

--- a/stripe-react-native.podspec
+++ b/stripe-react-native.podspec
@@ -15,6 +15,11 @@ Pod::Spec.new do |s|
   s.source       = { git: 'https://github.com/stripe/stripe-react-native.git', tag: s.version.to_s }
 
   s.source_files = 'ios/**/*.{h,m,mm,swift}'
+  s.exclude_files = 'ios/Tests/'
+
+  s.test_spec 'Tests' do |test_spec|
+    test_spec.source_files = 'ios/Tests/**/*.{m,swift}'
+  end
 
   s.dependency 'React-Core'
   s.dependency 'Stripe', stripe_version


### PR DESCRIPTION
## Summary

Adds a method to check if a particular card can be provisioned with the current app on this particular device.

## Motivation

It's useful to ensure that a card can be added _before_ showing the AddToWallet component. A card can be added if:
- the device supports paying with native wallet cards in the first place
- the app can provision cards
- the card in question hasn't already been added

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [x] I added automated tests

## Documentation

Select one: 
- [x] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
