### PR TITLE
fix: support all payment methods in `createPaymentMethod` on Android

### DIFF
--- a/android/src/main/java/com/reactnativestripesdk/PaymentMethodCreateParamsFactory.kt
+++ b/android/src/main/java/com/reactnativestripesdk/PaymentMethodCreateParamsFactory.kt
@@ -153,7 +153,27 @@ class PaymentMethodCreateParamsFactory(
 
   @Throws(PaymentMethodCreateParamsException::class)
   private fun createAuBecsDebitParams(): PaymentMethodCreateParams {
+    val formDetails = getMapOrNull(paymentMethodData, "formDetails") ?: run {
+      throw PaymentMethodCreateParamsException("You must provide form details")
+    }
 
+    val bsbNumber = getValOr(formDetails, "bsbNumber") as String
+    val accountNumber = getValOr(formDetails, "accountNumber") as String
+    val name = getValOr(formDetails, "name") as String
+    val email = getValOr(formDetails, "email") as String
+
+    val billingDetails = PaymentMethod.BillingDetails.Builder()
+      .setName(name)
+      .setEmail(email)
+      .build()
+
+    return PaymentMethodCreateParams.create(
+      auBecsDebit = PaymentMethodCreateParams.AuBecsDebit(
+        bsbNumber = bsbNumber,
+        accountNumber = accountNumber
+      ),
+      billingDetails = billingDetails
+    )
   }
 
   @Throws(PaymentMethodCreateParamsException::class)
@@ -459,27 +479,7 @@ class PaymentMethodCreateParamsFactory(
 
   @Throws(PaymentMethodCreateParamsException::class)
   private fun createAuBecsDebitPaymentConfirmParams(): ConfirmPaymentIntentParams {
-    val formDetails = getMapOrNull(paymentMethodData, "formDetails") ?: run {
-      throw PaymentMethodCreateParamsException("You must provide form details")
-    }
-
-    val bsbNumber = getValOr(formDetails, "bsbNumber") as String
-    val accountNumber = getValOr(formDetails, "accountNumber") as String
-    val name = getValOr(formDetails, "name") as String
-    val email = getValOr(formDetails, "email") as String
-
-    val billingDetails = PaymentMethod.BillingDetails.Builder()
-      .setName(name)
-      .setEmail(email)
-      .build()
-
-    val params = PaymentMethodCreateParams.create(
-      auBecsDebit = PaymentMethodCreateParams.AuBecsDebit(
-        bsbNumber = bsbNumber,
-        accountNumber = accountNumber
-      ),
-      billingDetails = billingDetails
-    )
+    val params = createAuBecsDebitParams()
 
     return ConfirmPaymentIntentParams
       .createWithPaymentMethodCreateParams(
@@ -491,27 +491,7 @@ class PaymentMethodCreateParamsFactory(
 
   @Throws(PaymentMethodCreateParamsException::class)
   private fun createAuBecsDebitPaymentSetupParams(): ConfirmSetupIntentParams {
-    val formDetails = getMapOrNull(paymentMethodData, "formDetails") ?: run {
-      throw PaymentMethodCreateParamsException("You must provide form details")
-    }
-
-    val bsbNumber = getValOr(formDetails, "bsbNumber") as String
-    val accountNumber = getValOr(formDetails, "accountNumber") as String
-    val name = getValOr(formDetails, "name") as String
-    val email = getValOr(formDetails, "email") as String
-
-    val billingDetails = PaymentMethod.BillingDetails.Builder()
-      .setName(name)
-      .setEmail(email)
-      .build()
-
-    val params = PaymentMethodCreateParams.create(
-      auBecsDebit = PaymentMethodCreateParams.AuBecsDebit(
-        bsbNumber = bsbNumber,
-        accountNumber = accountNumber
-      ),
-      billingDetails = billingDetails
-    )
+    val params = createAuBecsDebitParams()
 
     return ConfirmSetupIntentParams
       .create(

--- a/android/src/main/java/com/reactnativestripesdk/PaymentMethodCreateParamsFactory.kt
+++ b/android/src/main/java/com/reactnativestripesdk/PaymentMethodCreateParamsFactory.kt
@@ -193,26 +193,43 @@ class PaymentMethodCreateParamsFactory(
   }
 
   @Throws(PaymentMethodCreateParamsException::class)
-  fun createConfirmParams(clientSecret: String, paymentMethodType: PaymentMethod.Type): ConfirmStripeIntentParams {
+  fun createParams(clientSecret: String, paymentMethodType: PaymentMethod.Type, isPaymentIntent: Boolean): ConfirmStripeIntentParams {
     try {
       return when (paymentMethodType) {
-        PaymentMethod.Type.Card -> createCardStripeIntentParams(clientSecret, true)
-        PaymentMethod.Type.Ideal -> createIDEALStripeIntentParams(clientSecret, true)
-        PaymentMethod.Type.Alipay -> createAlipayPaymentConfirmParams(clientSecret)
-        PaymentMethod.Type.Sofort -> createSofortPaymentConfirmParams(clientSecret)
-        PaymentMethod.Type.Bancontact -> createBancontactPaymentConfirmParams(clientSecret)
-        PaymentMethod.Type.SepaDebit -> createSepaPaymentConfirmParams(clientSecret)
-        PaymentMethod.Type.Oxxo -> createOXXOPaymentConfirmParams(clientSecret)
-        PaymentMethod.Type.Giropay -> createGiropayPaymentConfirmParams(clientSecret)
-        PaymentMethod.Type.Eps -> createEPSPaymentConfirmParams(clientSecret)
-        PaymentMethod.Type.GrabPay -> createGrabPayPaymentConfirmParams(clientSecret)
-        PaymentMethod.Type.P24 -> createP24PaymentConfirmParams(clientSecret)
-        PaymentMethod.Type.Fpx -> createFpxPaymentConfirmParams(clientSecret)
-        PaymentMethod.Type.AfterpayClearpay -> createAfterpayClearpayPaymentConfirmParams(clientSecret)
-        PaymentMethod.Type.AuBecsDebit -> createAuBecsDebitPaymentConfirmParams(clientSecret)
-        PaymentMethod.Type.Klarna -> createKlarnaPaymentConfirmParams(clientSecret)
-        PaymentMethod.Type.USBankAccount -> createUSBankAccountPaymentConfirmParams(clientSecret)
-        PaymentMethod.Type.PayPal -> createPayPalPaymentConfirmParams(clientSecret)
+        PaymentMethod.Type.Card -> createCardStripeIntentParams(clientSecret, isPaymentIntent)
+        PaymentMethod.Type.USBankAccount -> createUSBankAccountStripeIntentParams(clientSecret, isPaymentIntent)
+        PaymentMethod.Type.PayPal -> createPayPalStripeIntentParams(clientSecret, isPaymentIntent)
+
+        PaymentMethod.Type.Ideal,
+        PaymentMethod.Type.Alipay,
+        PaymentMethod.Type.Sofort,
+        PaymentMethod.Type.Bancontact,
+        PaymentMethod.Type.SepaDebit,
+        PaymentMethod.Type.Oxxo,
+        PaymentMethod.Type.Giropay,
+        PaymentMethod.Type.Eps,
+        PaymentMethod.Type.GrabPay,
+        PaymentMethod.Type.P24,
+        PaymentMethod.Type.Fpx,
+        PaymentMethod.Type.AfterpayClearpay,
+        PaymentMethod.Type.AuBecsDebit,
+        PaymentMethod.Type.Klarna -> {
+          val params = createPaymentMethodParams(paymentMethodType)
+
+          return if (isPaymentIntent) {
+            ConfirmPaymentIntentParams
+              .createWithPaymentMethodCreateParams(
+                paymentMethodCreateParams = params,
+                clientSecret = clientSecret,
+                setupFutureUsage = mapToPaymentIntentFutureUsage(getValOr(options, "setupFutureUsage")),
+              )
+          } else {
+            ConfirmSetupIntentParams.create(
+              paymentMethodCreateParams = params,
+              clientSecret = clientSecret,
+            )
+          }
+        }
         else -> {
           throw Exception("This paymentMethodType is not supported yet")
         }
@@ -221,58 +238,6 @@ class PaymentMethodCreateParamsFactory(
       throw error
     }
   }
-
-  @Throws(PaymentMethodCreateParamsException::class)
-  fun createSetupParams(clientSecret: String, paymentMethodType: PaymentMethod.Type): ConfirmStripeIntentParams {
-    try {
-      return when (paymentMethodType) {
-        PaymentMethod.Type.Card -> createCardStripeIntentParams(clientSecret, false)
-        PaymentMethod.Type.Ideal -> createIDEALStripeIntentParams(clientSecret, false)
-        PaymentMethod.Type.Sofort -> createSofortPaymentSetupParams(clientSecret)
-        PaymentMethod.Type.Bancontact -> createBancontactPaymentSetupParams(clientSecret)
-        PaymentMethod.Type.SepaDebit -> createSepaPaymentSetupParams(clientSecret)
-        PaymentMethod.Type.AuBecsDebit -> createAuBecsDebitPaymentSetupParams(clientSecret)
-        PaymentMethod.Type.USBankAccount -> createUSBankAccountPaymentSetupParams(clientSecret)
-        PaymentMethod.Type.PayPal -> createPayPalPaymentSetupParams()
-        else -> {
-          throw Exception("This paymentMethodType is not supported yet")
-        }
-      }
-    } catch (error: PaymentMethodCreateParamsException) {
-      throw error
-    }
-  }
-
-  @Throws(PaymentMethodCreateParamsException::class)
-  private fun createIDEALStripeIntentParams(clientSecret: String, isPaymentIntent: Boolean): ConfirmStripeIntentParams {
-    val createParams = createIDEALParams()
-
-    return if (isPaymentIntent) {
-      ConfirmPaymentIntentParams
-        .createWithPaymentMethodCreateParams(
-          paymentMethodCreateParams = createParams,
-          clientSecret = clientSecret,
-          setupFutureUsage = mapToPaymentIntentFutureUsage(getValOr(options, "setupFutureUsage")),
-        )
-    } else {
-      return ConfirmSetupIntentParams.create(
-        paymentMethodCreateParams = createParams,
-        clientSecret = clientSecret,
-      )
-    }
-  }
-
-  @Throws(PaymentMethodCreateParamsException::class)
-  private fun createP24PaymentConfirmParams(clientSecret: String): ConfirmPaymentIntentParams {
-    val params = createP24Params()
-
-    return ConfirmPaymentIntentParams
-      .createWithPaymentMethodCreateParams(
-        paymentMethodCreateParams = params,
-        clientSecret = clientSecret,
-        setupFutureUsage = mapToPaymentIntentFutureUsage(getValOr(options, "setupFutureUsage")),
-      )
- }
 
   @Throws(PaymentMethodCreateParamsException::class)
   private fun createCardPaymentMethodParams(): PaymentMethodCreateParams {
@@ -333,232 +298,46 @@ class PaymentMethodCreateParamsFactory(
   }
 
   @Throws(PaymentMethodCreateParamsException::class)
-  private fun createSepaPaymentSetupParams(clientSecret: String): ConfirmSetupIntentParams {
-    val params = createSepaParams()
-
-    return ConfirmSetupIntentParams.create(
-      paymentMethodCreateParams = params,
-      clientSecret = clientSecret
-    )
-  }
-
-  @Throws(PaymentMethodCreateParamsException::class)
-  private fun createAlipayPaymentConfirmParams(clientSecret: String): ConfirmPaymentIntentParams {
-    return ConfirmPaymentIntentParams.createWithPaymentMethodCreateParams(createAlipayParams(), clientSecret)
-  }
-
-  @Throws(PaymentMethodCreateParamsException::class)
-  private fun createSofortPaymentConfirmParams(clientSecret: String): ConfirmPaymentIntentParams {
-    val params = createSofortParams()
-
-    return ConfirmPaymentIntentParams
-      .createWithPaymentMethodCreateParams(
-        paymentMethodCreateParams = params,
-        clientSecret = clientSecret,
-        setupFutureUsage = mapToPaymentIntentFutureUsage(getValOr(options, "setupFutureUsage")),
-      )
-  }
-
-  @Throws(PaymentMethodCreateParamsException::class)
-  private fun createSofortPaymentSetupParams(clientSecret: String): ConfirmSetupIntentParams {
-    val params = createSofortParams()
-
-    return ConfirmSetupIntentParams.create(
-      paymentMethodCreateParams = params,
-      clientSecret = clientSecret,
-    )
-  }
-
-  @Throws(PaymentMethodCreateParamsException::class)
-  private fun createGrabPayPaymentConfirmParams(clientSecret: String): ConfirmPaymentIntentParams {
-    val params = createGrabPayParams()
-
-    return ConfirmPaymentIntentParams
-      .createWithPaymentMethodCreateParams(
-        paymentMethodCreateParams = params,
-        clientSecret = clientSecret,
-        setupFutureUsage = mapToPaymentIntentFutureUsage(getValOr(options, "setupFutureUsage")),
-      )
-  }
-
-  @Throws(PaymentMethodCreateParamsException::class)
-  private fun createBancontactPaymentConfirmParams(clientSecret: String): ConfirmPaymentIntentParams {
-    val params = createBancontactParams()
-
-    return ConfirmPaymentIntentParams
-      .createWithPaymentMethodCreateParams(
-        paymentMethodCreateParams = params,
-        clientSecret = clientSecret,
-        setupFutureUsage = mapToPaymentIntentFutureUsage(getValOr(options, "setupFutureUsage")),
-      )
-  }
-
-  private fun createBancontactPaymentSetupParams(clientSecret: String): ConfirmSetupIntentParams {
-    val params = createBancontactParams()
-
-    return ConfirmSetupIntentParams
-      .create(
-        paymentMethodCreateParams = params,
-        clientSecret = clientSecret,
-      )
-  }
-
-  @Throws(PaymentMethodCreateParamsException::class)
-  private fun createOXXOPaymentConfirmParams(clientSecret: String): ConfirmPaymentIntentParams {
-    val params = createOXXOParams()
-
-    return ConfirmPaymentIntentParams
-      .createWithPaymentMethodCreateParams(
-        paymentMethodCreateParams = params,
-        clientSecret = clientSecret,
-        setupFutureUsage = mapToPaymentIntentFutureUsage(getValOr(options, "setupFutureUsage"))
-      )
-  }
-
-  @Throws(PaymentMethodCreateParamsException::class)
-  private fun createEPSPaymentConfirmParams(clientSecret: String): ConfirmPaymentIntentParams {
-    val params = createEPSParams()
-
-    return ConfirmPaymentIntentParams
-      .createWithPaymentMethodCreateParams(
-        paymentMethodCreateParams = params,
-        clientSecret = clientSecret,
-        setupFutureUsage = mapToPaymentIntentFutureUsage(getValOr(options, "setupFutureUsage"))
-      )
-  }
-
-  @Throws(PaymentMethodCreateParamsException::class)
-  private fun createGiropayPaymentConfirmParams(clientSecret: String): ConfirmPaymentIntentParams {
-    val params = createGiropayParams()
-
-    return ConfirmPaymentIntentParams
-      .createWithPaymentMethodCreateParams(
-        paymentMethodCreateParams = params,
-        clientSecret = clientSecret,
-        setupFutureUsage = mapToPaymentIntentFutureUsage(getValOr(options, "setupFutureUsage"))
-      )
-  }
-
-  @Throws(PaymentMethodCreateParamsException::class)
-  private fun createSepaPaymentConfirmParams(clientSecret: String): ConfirmPaymentIntentParams {
-    val params = createSepaParams()
-
-    return ConfirmPaymentIntentParams
-      .createWithPaymentMethodCreateParams(
-        paymentMethodCreateParams = params,
-        clientSecret = clientSecret,
-        setupFutureUsage = mapToPaymentIntentFutureUsage(getValOr(options, "setupFutureUsage"))
-      )
-  }
-
-  @Throws(PaymentMethodCreateParamsException::class)
-  private fun createFpxPaymentConfirmParams(clientSecret: String): ConfirmPaymentIntentParams {
-    val params = createFpxParams()
-
-    return ConfirmPaymentIntentParams
-      .createWithPaymentMethodCreateParams(
-        paymentMethodCreateParams = params,
-        clientSecret = clientSecret,
-        setupFutureUsage = mapToPaymentIntentFutureUsage(getValOr(options, "setupFutureUsage"))
-      )
-  }
-
-  @Throws(PaymentMethodCreateParamsException::class)
-  private fun createAfterpayClearpayPaymentConfirmParams(clientSecret: String): ConfirmPaymentIntentParams {
-    val params = createAfterpayClearpayParams()
-
-    return ConfirmPaymentIntentParams
-      .createWithPaymentMethodCreateParams(
-        paymentMethodCreateParams = params,
-        clientSecret = clientSecret,
-        setupFutureUsage = mapToPaymentIntentFutureUsage(getValOr(options, "setupFutureUsage"))
-      )
-  }
-
-  @Throws(PaymentMethodCreateParamsException::class)
-  private fun createAuBecsDebitPaymentConfirmParams(clientSecret: String): ConfirmPaymentIntentParams {
-    val params = createAuBecsDebitParams()
-
-    return ConfirmPaymentIntentParams
-      .createWithPaymentMethodCreateParams(
-        paymentMethodCreateParams = params,
-        clientSecret = clientSecret,
-        setupFutureUsage = mapToPaymentIntentFutureUsage(getValOr(options, "setupFutureUsage"))
-      )
-  }
-
-  @Throws(PaymentMethodCreateParamsException::class)
-  private fun createAuBecsDebitPaymentSetupParams(clientSecret: String): ConfirmSetupIntentParams {
-    val params = createAuBecsDebitParams()
-
-    return ConfirmSetupIntentParams
-      .create(
-        paymentMethodCreateParams = params,
-        clientSecret = clientSecret,
-      )
-  }
-
-  @Throws(PaymentMethodCreateParamsException::class)
-  private fun createUSBankAccountPaymentSetupParams(clientSecret: String): ConfirmSetupIntentParams {
+  private fun createUSBankAccountStripeIntentParams(clientSecret: String, isPaymentIntent: Boolean): ConfirmStripeIntentParams {
     // If payment method data is supplied, assume they are passing in the bank details manually
     paymentMethodData?.let {
       if (billingDetailsParams?.name.isNullOrBlank()) {
         throw PaymentMethodCreateParamsException("When creating a US bank account payment method, you must provide the following billing details: name")
       }
-      return ConfirmSetupIntentParams.create(
-        paymentMethodCreateParams = createUSBankAccountParams(paymentMethodData),
-        clientSecret = clientSecret,
-      )
-    } ?: run {
-      // Payment method is assumed to be already attached through via collectBankAccount
-      return ConfirmSetupIntentParams.create(
-        clientSecret = clientSecret,
-        paymentMethodType = PaymentMethod.Type.USBankAccount
-      )
-    }
-  }
-
-  @Throws(PaymentMethodCreateParamsException::class)
-  private fun createPayPalPaymentSetupParams(): ConfirmSetupIntentParams {
-    throw PaymentMethodCreateParamsException("PayPal is not yet supported through SetupIntents.")
-  }
-
-  @Throws(PaymentMethodCreateParamsException::class)
-  private fun createKlarnaPaymentConfirmParams(clientSecret: String): ConfirmPaymentIntentParams {
-    val params = createKlarnaParams()
-
-    return ConfirmPaymentIntentParams
-      .createWithPaymentMethodCreateParams(
-        paymentMethodCreateParams = params,
-        clientSecret = clientSecret,
-        setupFutureUsage = mapToPaymentIntentFutureUsage(getValOr(options, "setupFutureUsage"))
-      )
-  }
-
-  @Throws(PaymentMethodCreateParamsException::class)
-  private fun createUSBankAccountPaymentConfirmParams(clientSecret: String): ConfirmPaymentIntentParams {
-    // If payment method data is supplied, assume they are passing in the bank details manually
-    paymentMethodData?.let {
-      if (billingDetailsParams?.name.isNullOrBlank()) {
-        throw PaymentMethodCreateParamsException("When creating a US bank account payment method, you must provide the following billing details: name")
+      return if (isPaymentIntent) {
+        ConfirmPaymentIntentParams.createWithPaymentMethodCreateParams(
+          paymentMethodCreateParams = createUSBankAccountParams(paymentMethodData),
+          clientSecret,
+          setupFutureUsage = mapToPaymentIntentFutureUsage(getValOr(options, "setupFutureUsage"))
+        )
+      } else {
+        ConfirmSetupIntentParams.create(
+          paymentMethodCreateParams = createUSBankAccountParams(paymentMethodData),
+          clientSecret = clientSecret,
+        )
       }
-
-      return ConfirmPaymentIntentParams.createWithPaymentMethodCreateParams(
-        paymentMethodCreateParams = createUSBankAccountParams(paymentMethodData),
-        clientSecret,
-        setupFutureUsage = mapToPaymentIntentFutureUsage(getValOr(options, "setupFutureUsage"))
-      )
     } ?: run {
       // Payment method is assumed to be already attached through via collectBankAccount
-      return ConfirmPaymentIntentParams.create(
-        clientSecret = clientSecret,
-        paymentMethodType = PaymentMethod.Type.USBankAccount
-      )
+      return if (isPaymentIntent) {
+        ConfirmPaymentIntentParams.create(
+          clientSecret = clientSecret,
+          paymentMethodType = PaymentMethod.Type.USBankAccount
+        )
+      } else {
+        ConfirmSetupIntentParams.create(
+          clientSecret = clientSecret,
+          paymentMethodType = PaymentMethod.Type.USBankAccount
+        )
+      }
     }
   }
 
   @Throws(PaymentMethodCreateParamsException::class)
-  private fun createPayPalPaymentConfirmParams(clientSecret: String): ConfirmPaymentIntentParams {
+  private fun createPayPalStripeIntentParams(clientSecret: String, isPaymentIntent: Boolean): ConfirmStripeIntentParams {
+    if (!isPaymentIntent) {
+      throw PaymentMethodCreateParamsException("PayPal is not yet supported through SetupIntents.")
+    }
+
     val params = createPayPalParams()
 
     return ConfirmPaymentIntentParams.createWithPaymentMethodCreateParams(

--- a/android/src/main/java/com/reactnativestripesdk/PaymentMethodCreateParamsFactory.kt
+++ b/android/src/main/java/com/reactnativestripesdk/PaymentMethodCreateParamsFactory.kt
@@ -94,7 +94,11 @@ class PaymentMethodCreateParamsFactory(
 
   @Throws(PaymentMethodCreateParamsException::class)
   private fun createOXXOParams(): PaymentMethodCreateParams {
+    billingDetailsParams?.let {
+      return PaymentMethodCreateParams.createOxxo(it)
+    }
 
+    throw PaymentMethodCreateParamsException("You must provide billing details")
   }
 
   @Throws(PaymentMethodCreateParamsException::class)
@@ -368,18 +372,14 @@ class PaymentMethodCreateParamsFactory(
 
   @Throws(PaymentMethodCreateParamsException::class)
   private fun createOXXOPaymentConfirmParams(): ConfirmPaymentIntentParams {
-    billingDetailsParams?.let {
-      val params = PaymentMethodCreateParams.createOxxo(it)
+    val params = createOXXOParams()
 
-      return ConfirmPaymentIntentParams
-        .createWithPaymentMethodCreateParams(
-          paymentMethodCreateParams = params,
-          clientSecret = clientSecret,
-          setupFutureUsage = mapToPaymentIntentFutureUsage(getValOr(options, "setupFutureUsage"))
-        )
-    }
-
-    throw PaymentMethodCreateParamsException("You must provide billing details")
+    return ConfirmPaymentIntentParams
+      .createWithPaymentMethodCreateParams(
+        paymentMethodCreateParams = params,
+        clientSecret = clientSecret,
+        setupFutureUsage = mapToPaymentIntentFutureUsage(getValOr(options, "setupFutureUsage"))
+      )
   }
 
   @Throws(PaymentMethodCreateParamsException::class)

--- a/android/src/main/java/com/reactnativestripesdk/PaymentMethodCreateParamsFactory.kt
+++ b/android/src/main/java/com/reactnativestripesdk/PaymentMethodCreateParamsFactory.kt
@@ -4,7 +4,6 @@ import com.facebook.react.bridge.ReadableMap
 import com.stripe.android.model.*
 
 class PaymentMethodCreateParamsFactory(
-  private val clientSecret: String,
   private val paymentMethodData: ReadableMap?,
   private val options: ReadableMap,
   private val cardFieldView: CardFieldView?,
@@ -194,26 +193,26 @@ class PaymentMethodCreateParamsFactory(
   }
 
   @Throws(PaymentMethodCreateParamsException::class)
-  fun createConfirmParams(paymentMethodType: PaymentMethod.Type): ConfirmPaymentIntentParams {
+  fun createConfirmParams(clientSecret: String, paymentMethodType: PaymentMethod.Type): ConfirmPaymentIntentParams {
     try {
       return when (paymentMethodType) {
-        PaymentMethod.Type.Card -> createCardPaymentConfirmParams()
-        PaymentMethod.Type.Ideal -> createIDEALPaymentConfirmParams()
-        PaymentMethod.Type.Alipay -> createAlipayPaymentConfirmParams()
-        PaymentMethod.Type.Sofort -> createSofortPaymentConfirmParams()
-        PaymentMethod.Type.Bancontact -> createBancontactPaymentConfirmParams()
-        PaymentMethod.Type.SepaDebit -> createSepaPaymentConfirmParams()
-        PaymentMethod.Type.Oxxo -> createOXXOPaymentConfirmParams()
-        PaymentMethod.Type.Giropay -> createGiropayPaymentConfirmParams()
-        PaymentMethod.Type.Eps -> createEPSPaymentConfirmParams()
-        PaymentMethod.Type.GrabPay -> createGrabPayPaymentConfirmParams()
-        PaymentMethod.Type.P24 -> createP24PaymentConfirmParams()
-        PaymentMethod.Type.Fpx -> createFpxPaymentConfirmParams()
-        PaymentMethod.Type.AfterpayClearpay -> createAfterpayClearpayPaymentConfirmParams()
-        PaymentMethod.Type.AuBecsDebit -> createAuBecsDebitPaymentConfirmParams()
-        PaymentMethod.Type.Klarna -> createKlarnaPaymentConfirmParams()
-        PaymentMethod.Type.USBankAccount -> createUSBankAccountPaymentConfirmParams()
-        PaymentMethod.Type.PayPal -> createPayPalPaymentConfirmParams()
+        PaymentMethod.Type.Card -> createCardPaymentConfirmParams(clientSecret)
+        PaymentMethod.Type.Ideal -> createIDEALPaymentConfirmParams(clientSecret)
+        PaymentMethod.Type.Alipay -> createAlipayPaymentConfirmParams(clientSecret)
+        PaymentMethod.Type.Sofort -> createSofortPaymentConfirmParams(clientSecret)
+        PaymentMethod.Type.Bancontact -> createBancontactPaymentConfirmParams(clientSecret)
+        PaymentMethod.Type.SepaDebit -> createSepaPaymentConfirmParams(clientSecret)
+        PaymentMethod.Type.Oxxo -> createOXXOPaymentConfirmParams(clientSecret)
+        PaymentMethod.Type.Giropay -> createGiropayPaymentConfirmParams(clientSecret)
+        PaymentMethod.Type.Eps -> createEPSPaymentConfirmParams(clientSecret)
+        PaymentMethod.Type.GrabPay -> createGrabPayPaymentConfirmParams(clientSecret)
+        PaymentMethod.Type.P24 -> createP24PaymentConfirmParams(clientSecret)
+        PaymentMethod.Type.Fpx -> createFpxPaymentConfirmParams(clientSecret)
+        PaymentMethod.Type.AfterpayClearpay -> createAfterpayClearpayPaymentConfirmParams(clientSecret)
+        PaymentMethod.Type.AuBecsDebit -> createAuBecsDebitPaymentConfirmParams(clientSecret)
+        PaymentMethod.Type.Klarna -> createKlarnaPaymentConfirmParams(clientSecret)
+        PaymentMethod.Type.USBankAccount -> createUSBankAccountPaymentConfirmParams(clientSecret)
+        PaymentMethod.Type.PayPal -> createPayPalPaymentConfirmParams(clientSecret)
         else -> {
           throw Exception("This paymentMethodType is not supported yet")
         }
@@ -224,16 +223,16 @@ class PaymentMethodCreateParamsFactory(
   }
 
   @Throws(PaymentMethodCreateParamsException::class)
-  fun createSetupParams(paymentMethodType: PaymentMethod.Type): ConfirmSetupIntentParams {
+  fun createSetupParams(clientSecret: String, paymentMethodType: PaymentMethod.Type): ConfirmSetupIntentParams {
     try {
       return when (paymentMethodType) {
-        PaymentMethod.Type.Card -> createCardPaymentSetupParams()
-        PaymentMethod.Type.Ideal -> createIDEALPaymentSetupParams()
-        PaymentMethod.Type.Sofort -> createSofortPaymentSetupParams()
-        PaymentMethod.Type.Bancontact -> createBancontactPaymentSetupParams()
-        PaymentMethod.Type.SepaDebit -> createSepaPaymentSetupParams()
-        PaymentMethod.Type.AuBecsDebit -> createAuBecsDebitPaymentSetupParams()
-        PaymentMethod.Type.USBankAccount -> createUSBankAccountPaymentSetupParams()
+        PaymentMethod.Type.Card -> createCardPaymentSetupParams(clientSecret)
+        PaymentMethod.Type.Ideal -> createIDEALPaymentSetupParams(clientSecret)
+        PaymentMethod.Type.Sofort -> createSofortPaymentSetupParams(clientSecret)
+        PaymentMethod.Type.Bancontact -> createBancontactPaymentSetupParams(clientSecret)
+        PaymentMethod.Type.SepaDebit -> createSepaPaymentSetupParams(clientSecret)
+        PaymentMethod.Type.AuBecsDebit -> createAuBecsDebitPaymentSetupParams(clientSecret)
+        PaymentMethod.Type.USBankAccount -> createUSBankAccountPaymentSetupParams(clientSecret)
         PaymentMethod.Type.PayPal -> createPayPalPaymentSetupParams()
         else -> {
           throw Exception("This paymentMethodType is not supported yet")
@@ -245,7 +244,7 @@ class PaymentMethodCreateParamsFactory(
   }
 
   @Throws(PaymentMethodCreateParamsException::class)
-  private fun createIDEALPaymentConfirmParams(): ConfirmPaymentIntentParams {
+  private fun createIDEALPaymentConfirmParams(clientSecret: String): ConfirmPaymentIntentParams {
     val createParams = createIDEALParams()
 
     return ConfirmPaymentIntentParams
@@ -257,7 +256,7 @@ class PaymentMethodCreateParamsFactory(
   }
 
   @Throws(PaymentMethodCreateParamsException::class)
-  private fun createP24PaymentConfirmParams(): ConfirmPaymentIntentParams {
+  private fun createP24PaymentConfirmParams(clientSecret: String): ConfirmPaymentIntentParams {
     val params = createP24Params()
 
     return ConfirmPaymentIntentParams
@@ -288,7 +287,7 @@ class PaymentMethodCreateParamsFactory(
   }
 
   @Throws(PaymentMethodCreateParamsException::class)
-  private fun createCardPaymentConfirmParams(): ConfirmPaymentIntentParams {
+  private fun createCardPaymentConfirmParams(clientSecret: String): ConfirmPaymentIntentParams {
     val paymentMethodId = getValOr(paymentMethodData, "paymentMethodId", null)
     val paymentMethodCreateParams = createCardParams()
 
@@ -316,7 +315,7 @@ class PaymentMethodCreateParamsFactory(
   }
 
   @Throws(PaymentMethodCreateParamsException::class)
-  private fun createIDEALPaymentSetupParams(): ConfirmSetupIntentParams {
+  private fun createIDEALPaymentSetupParams(clientSecret: String): ConfirmSetupIntentParams {
     val createParams = createIDEALParams()
 
     return ConfirmSetupIntentParams.create(
@@ -326,7 +325,7 @@ class PaymentMethodCreateParamsFactory(
   }
 
   @Throws(PaymentMethodCreateParamsException::class)
-  private fun createSepaPaymentSetupParams(): ConfirmSetupIntentParams {
+  private fun createSepaPaymentSetupParams(clientSecret: String): ConfirmSetupIntentParams {
     val params = createSepaParams()
 
     return ConfirmSetupIntentParams.create(
@@ -336,7 +335,7 @@ class PaymentMethodCreateParamsFactory(
   }
 
   @Throws(PaymentMethodCreateParamsException::class)
-  private fun createCardPaymentSetupParams(): ConfirmSetupIntentParams {
+  private fun createCardPaymentSetupParams(clientSecret: String): ConfirmSetupIntentParams {
     val paymentMethodId = getValOr(paymentMethodData, "paymentMethodId", null)
     val paymentMethodCreateParams = createCardParams()
 
@@ -352,12 +351,12 @@ class PaymentMethodCreateParamsFactory(
   }
 
   @Throws(PaymentMethodCreateParamsException::class)
-  private fun createAlipayPaymentConfirmParams(): ConfirmPaymentIntentParams {
+  private fun createAlipayPaymentConfirmParams(clientSecret: String): ConfirmPaymentIntentParams {
     return ConfirmPaymentIntentParams.createWithPaymentMethodCreateParams(createAlipayParams(), clientSecret)
   }
 
   @Throws(PaymentMethodCreateParamsException::class)
-  private fun createSofortPaymentConfirmParams(): ConfirmPaymentIntentParams {
+  private fun createSofortPaymentConfirmParams(clientSecret: String): ConfirmPaymentIntentParams {
     val params = createSofortParams()
 
     return ConfirmPaymentIntentParams
@@ -369,7 +368,7 @@ class PaymentMethodCreateParamsFactory(
   }
 
   @Throws(PaymentMethodCreateParamsException::class)
-  private fun createSofortPaymentSetupParams(): ConfirmSetupIntentParams {
+  private fun createSofortPaymentSetupParams(clientSecret: String): ConfirmSetupIntentParams {
     val params = createSofortParams()
 
     return ConfirmSetupIntentParams.create(
@@ -379,7 +378,7 @@ class PaymentMethodCreateParamsFactory(
   }
 
   @Throws(PaymentMethodCreateParamsException::class)
-  private fun createGrabPayPaymentConfirmParams(): ConfirmPaymentIntentParams {
+  private fun createGrabPayPaymentConfirmParams(clientSecret: String): ConfirmPaymentIntentParams {
     val params = createGrabPayParams()
 
     return ConfirmPaymentIntentParams
@@ -391,7 +390,7 @@ class PaymentMethodCreateParamsFactory(
   }
 
   @Throws(PaymentMethodCreateParamsException::class)
-  private fun createBancontactPaymentConfirmParams(): ConfirmPaymentIntentParams {
+  private fun createBancontactPaymentConfirmParams(clientSecret: String): ConfirmPaymentIntentParams {
     val params = createBancontactParams()
 
     return ConfirmPaymentIntentParams
@@ -402,7 +401,7 @@ class PaymentMethodCreateParamsFactory(
       )
   }
 
-  private fun createBancontactPaymentSetupParams(): ConfirmSetupIntentParams {
+  private fun createBancontactPaymentSetupParams(clientSecret: String): ConfirmSetupIntentParams {
     val params = createBancontactParams()
 
     return ConfirmSetupIntentParams
@@ -413,7 +412,7 @@ class PaymentMethodCreateParamsFactory(
   }
 
   @Throws(PaymentMethodCreateParamsException::class)
-  private fun createOXXOPaymentConfirmParams(): ConfirmPaymentIntentParams {
+  private fun createOXXOPaymentConfirmParams(clientSecret: String): ConfirmPaymentIntentParams {
     val params = createOXXOParams()
 
     return ConfirmPaymentIntentParams
@@ -425,7 +424,7 @@ class PaymentMethodCreateParamsFactory(
   }
 
   @Throws(PaymentMethodCreateParamsException::class)
-  private fun createEPSPaymentConfirmParams(): ConfirmPaymentIntentParams {
+  private fun createEPSPaymentConfirmParams(clientSecret: String): ConfirmPaymentIntentParams {
     val params = createEPSParams()
 
     return ConfirmPaymentIntentParams
@@ -437,7 +436,7 @@ class PaymentMethodCreateParamsFactory(
   }
 
   @Throws(PaymentMethodCreateParamsException::class)
-  private fun createGiropayPaymentConfirmParams(): ConfirmPaymentIntentParams {
+  private fun createGiropayPaymentConfirmParams(clientSecret: String): ConfirmPaymentIntentParams {
     val params = createGiropayParams()
 
     return ConfirmPaymentIntentParams
@@ -449,7 +448,7 @@ class PaymentMethodCreateParamsFactory(
   }
 
   @Throws(PaymentMethodCreateParamsException::class)
-  private fun createSepaPaymentConfirmParams(): ConfirmPaymentIntentParams {
+  private fun createSepaPaymentConfirmParams(clientSecret: String): ConfirmPaymentIntentParams {
     val params = createSepaParams()
 
     return ConfirmPaymentIntentParams
@@ -461,7 +460,7 @@ class PaymentMethodCreateParamsFactory(
   }
 
   @Throws(PaymentMethodCreateParamsException::class)
-  private fun createFpxPaymentConfirmParams(): ConfirmPaymentIntentParams {
+  private fun createFpxPaymentConfirmParams(clientSecret: String): ConfirmPaymentIntentParams {
     val params = createFpxParams()
 
     return ConfirmPaymentIntentParams
@@ -473,7 +472,7 @@ class PaymentMethodCreateParamsFactory(
   }
 
   @Throws(PaymentMethodCreateParamsException::class)
-  private fun createAfterpayClearpayPaymentConfirmParams(): ConfirmPaymentIntentParams {
+  private fun createAfterpayClearpayPaymentConfirmParams(clientSecret: String): ConfirmPaymentIntentParams {
     val params = createAfterpayClearpayParams()
 
     return ConfirmPaymentIntentParams
@@ -485,7 +484,7 @@ class PaymentMethodCreateParamsFactory(
   }
 
   @Throws(PaymentMethodCreateParamsException::class)
-  private fun createAuBecsDebitPaymentConfirmParams(): ConfirmPaymentIntentParams {
+  private fun createAuBecsDebitPaymentConfirmParams(clientSecret: String): ConfirmPaymentIntentParams {
     val params = createAuBecsDebitParams()
 
     return ConfirmPaymentIntentParams
@@ -497,7 +496,7 @@ class PaymentMethodCreateParamsFactory(
   }
 
   @Throws(PaymentMethodCreateParamsException::class)
-  private fun createAuBecsDebitPaymentSetupParams(): ConfirmSetupIntentParams {
+  private fun createAuBecsDebitPaymentSetupParams(clientSecret: String): ConfirmSetupIntentParams {
     val params = createAuBecsDebitParams()
 
     return ConfirmSetupIntentParams
@@ -508,7 +507,7 @@ class PaymentMethodCreateParamsFactory(
   }
 
   @Throws(PaymentMethodCreateParamsException::class)
-  private fun createUSBankAccountPaymentSetupParams(): ConfirmSetupIntentParams {
+  private fun createUSBankAccountPaymentSetupParams(clientSecret: String): ConfirmSetupIntentParams {
     // If payment method data is supplied, assume they are passing in the bank details manually
     paymentMethodData?.let {
       if (billingDetailsParams?.name.isNullOrBlank()) {
@@ -533,7 +532,7 @@ class PaymentMethodCreateParamsFactory(
   }
 
   @Throws(PaymentMethodCreateParamsException::class)
-  private fun createKlarnaPaymentConfirmParams(): ConfirmPaymentIntentParams {
+  private fun createKlarnaPaymentConfirmParams(clientSecret: String): ConfirmPaymentIntentParams {
     val params = createKlarnaParams()
 
     return ConfirmPaymentIntentParams
@@ -545,7 +544,7 @@ class PaymentMethodCreateParamsFactory(
   }
 
   @Throws(PaymentMethodCreateParamsException::class)
-  private fun createUSBankAccountPaymentConfirmParams(): ConfirmPaymentIntentParams {
+  private fun createUSBankAccountPaymentConfirmParams(clientSecret: String): ConfirmPaymentIntentParams {
     // If payment method data is supplied, assume they are passing in the bank details manually
     paymentMethodData?.let {
       if (billingDetailsParams?.name.isNullOrBlank()) {
@@ -567,7 +566,7 @@ class PaymentMethodCreateParamsFactory(
   }
 
   @Throws(PaymentMethodCreateParamsException::class)
-  private fun createPayPalPaymentConfirmParams(): ConfirmPaymentIntentParams {
+  private fun createPayPalPaymentConfirmParams(clientSecret: String): ConfirmPaymentIntentParams {
     val params = createPayPalParams()
 
     return ConfirmPaymentIntentParams.createWithPaymentMethodCreateParams(

--- a/android/src/main/java/com/reactnativestripesdk/PaymentMethodCreateParamsFactory.kt
+++ b/android/src/main/java/com/reactnativestripesdk/PaymentMethodCreateParamsFactory.kt
@@ -121,7 +121,8 @@ class PaymentMethodCreateParamsFactory(
 
   @Throws(PaymentMethodCreateParamsException::class)
   private fun createGrabPayParams(): PaymentMethodCreateParams {
-
+    val billingDetails = billingDetailsParams ?: PaymentMethod.BillingDetails()
+    return PaymentMethodCreateParams.createGrabPay(billingDetails)
   }
 
   @Throws(PaymentMethodCreateParamsException::class)
@@ -345,8 +346,7 @@ class PaymentMethodCreateParamsFactory(
 
   @Throws(PaymentMethodCreateParamsException::class)
   private fun createGrabPayPaymentConfirmParams(): ConfirmPaymentIntentParams {
-    val billingDetails = billingDetailsParams ?: PaymentMethod.BillingDetails()
-    val params = PaymentMethodCreateParams.createGrabPay(billingDetails)
+    val params = createGrabPayParams()
 
     return ConfirmPaymentIntentParams
       .createWithPaymentMethodCreateParams(

--- a/android/src/main/java/com/reactnativestripesdk/PaymentMethodCreateParamsFactory.kt
+++ b/android/src/main/java/com/reactnativestripesdk/PaymentMethodCreateParamsFactory.kt
@@ -43,6 +43,81 @@ class PaymentMethodCreateParamsFactory(
   }
 
   @Throws(PaymentMethodCreateParamsException::class)
+  private fun createIDEALParams(): PaymentMethodCreateParams {
+
+  }
+
+  @Throws(PaymentMethodCreateParamsException::class)
+  private fun createAlipayParams(): PaymentMethodCreateParams {
+
+  }
+
+  @Throws(PaymentMethodCreateParamsException::class)
+  private fun createSofortParams(): PaymentMethodCreateParams {
+
+  }
+
+  @Throws(PaymentMethodCreateParamsException::class)
+  private fun createBancontactParams(): PaymentMethodCreateParams {
+
+  }
+
+  @Throws(PaymentMethodCreateParamsException::class)
+  private fun createSepaParams(): PaymentMethodCreateParams {
+
+  }
+
+  @Throws(PaymentMethodCreateParamsException::class)
+  private fun createOXXOParams(): PaymentMethodCreateParams {
+
+  }
+
+  @Throws(PaymentMethodCreateParamsException::class)
+  private fun createGiropayParams(): PaymentMethodCreateParams {
+
+  }
+
+  @Throws(PaymentMethodCreateParamsException::class)
+  private fun createEPSParams(): PaymentMethodCreateParams {
+
+  }
+
+  @Throws(PaymentMethodCreateParamsException::class)
+  private fun createGrabPayParams(): PaymentMethodCreateParams {
+
+  }
+
+  @Throws(PaymentMethodCreateParamsException::class)
+  private fun createP24Params(): PaymentMethodCreateParams {
+
+  }
+
+  @Throws(PaymentMethodCreateParamsException::class)
+  private fun createFpxParams(): PaymentMethodCreateParams {
+
+  }
+
+  @Throws(PaymentMethodCreateParamsException::class)
+  private fun createAfterpayClearpayParams(): PaymentMethodCreateParams {
+
+  }
+
+  @Throws(PaymentMethodCreateParamsException::class)
+  private fun createAuBecsDebitParams(): PaymentMethodCreateParams {
+
+  }
+
+  @Throws(PaymentMethodCreateParamsException::class)
+  private fun createKlarnaParams(): PaymentMethodCreateParams {
+
+  }
+
+  @Throws(PaymentMethodCreateParamsException::class)
+  private fun createPayPalParams(): PaymentMethodCreateParams {
+
+  }
+
+  @Throws(PaymentMethodCreateParamsException::class)
   fun createConfirmParams(paymentMethodType: PaymentMethod.Type): ConfirmPaymentIntentParams {
     try {
       return when (paymentMethodType) {

--- a/android/src/main/java/com/reactnativestripesdk/PaymentMethodCreateParamsFactory.kt
+++ b/android/src/main/java/com/reactnativestripesdk/PaymentMethodCreateParamsFactory.kt
@@ -144,7 +144,11 @@ class PaymentMethodCreateParamsFactory(
 
   @Throws(PaymentMethodCreateParamsException::class)
   private fun createAfterpayClearpayParams(): PaymentMethodCreateParams {
+    billingDetailsParams?.let {
+      return PaymentMethodCreateParams.createAfterpayClearpay(it)
+    }
 
+    throw PaymentMethodCreateParamsException("You must provide billing details")
   }
 
   @Throws(PaymentMethodCreateParamsException::class)
@@ -443,18 +447,14 @@ class PaymentMethodCreateParamsFactory(
 
   @Throws(PaymentMethodCreateParamsException::class)
   private fun createAfterpayClearpayPaymentConfirmParams(): ConfirmPaymentIntentParams {
-    billingDetailsParams?.let {
-      val params = PaymentMethodCreateParams.createAfterpayClearpay(it)
+    val params = createAfterpayClearpayParams()
 
-      return ConfirmPaymentIntentParams
-        .createWithPaymentMethodCreateParams(
-          paymentMethodCreateParams = params,
-          clientSecret = clientSecret,
-          setupFutureUsage = mapToPaymentIntentFutureUsage(getValOr(options, "setupFutureUsage"))
-        )
-    }
-
-    throw PaymentMethodCreateParamsException("You must provide billing details")
+    return ConfirmPaymentIntentParams
+      .createWithPaymentMethodCreateParams(
+        paymentMethodCreateParams = params,
+        clientSecret = clientSecret,
+        setupFutureUsage = mapToPaymentIntentFutureUsage(getValOr(options, "setupFutureUsage"))
+      )
   }
 
   @Throws(PaymentMethodCreateParamsException::class)

--- a/android/src/main/java/com/reactnativestripesdk/PaymentMethodCreateParamsFactory.kt
+++ b/android/src/main/java/com/reactnativestripesdk/PaymentMethodCreateParamsFactory.kt
@@ -178,7 +178,14 @@ class PaymentMethodCreateParamsFactory(
 
   @Throws(PaymentMethodCreateParamsException::class)
   private fun createKlarnaParams(): PaymentMethodCreateParams {
+    if (billingDetailsParams == null ||
+      billingDetailsParams.address?.country.isNullOrBlank() ||
+      billingDetailsParams.email.isNullOrBlank()
+    ) {
+      throw PaymentMethodCreateParamsException("Klarna requires that you provide the following billing details: email, country")
+    }
 
+    return PaymentMethodCreateParams.createKlarna(billingDetailsParams)
   }
 
   @Throws(PaymentMethodCreateParamsException::class)
@@ -527,14 +534,7 @@ class PaymentMethodCreateParamsFactory(
 
   @Throws(PaymentMethodCreateParamsException::class)
   private fun createKlarnaPaymentConfirmParams(): ConfirmPaymentIntentParams {
-    if (billingDetailsParams == null ||
-      billingDetailsParams.address?.country.isNullOrBlank() ||
-      billingDetailsParams.email.isNullOrBlank()
-    ) {
-      throw PaymentMethodCreateParamsException("Klarna requires that you provide the following billing details: email, country")
-    }
-
-    val params = PaymentMethodCreateParams.createKlarna(billingDetailsParams)
+    val params = createKlarnaParams()
 
     return ConfirmPaymentIntentParams
       .createWithPaymentMethodCreateParams(

--- a/android/src/main/java/com/reactnativestripesdk/PaymentMethodCreateParamsFactory.kt
+++ b/android/src/main/java/com/reactnativestripesdk/PaymentMethodCreateParamsFactory.kt
@@ -261,8 +261,6 @@ class PaymentMethodCreateParamsFactory(
   @Throws(PaymentMethodCreateParamsException::class)
   private fun createCardStripeIntentParams(clientSecret: String, isPaymentIntent: Boolean): ConfirmStripeIntentParams {
     val paymentMethodId = getValOr(paymentMethodData, "paymentMethodId", null)
-    val paymentMethodCreateParams = createCardPaymentMethodParams()
-
     val setupFutureUsage = mapToPaymentIntentFutureUsage(getValOr(options, "setupFutureUsage"))
 
     if (paymentMethodId != null) {
@@ -283,6 +281,7 @@ class PaymentMethodCreateParamsFactory(
             clientSecret)
         )
     } else {
+      val paymentMethodCreateParams = createCardPaymentMethodParams()
       return (
         if (isPaymentIntent)
           ConfirmPaymentIntentParams

--- a/android/src/main/java/com/reactnativestripesdk/PaymentMethodCreateParamsFactory.kt
+++ b/android/src/main/java/com/reactnativestripesdk/PaymentMethodCreateParamsFactory.kt
@@ -197,7 +197,7 @@ class PaymentMethodCreateParamsFactory(
     try {
       return when (paymentMethodType) {
         PaymentMethod.Type.Card -> createCardStripeIntentParams(clientSecret, true)
-        PaymentMethod.Type.Ideal -> createIDEALPaymentConfirmParams(clientSecret)
+        PaymentMethod.Type.Ideal -> createIDEALStripeIntentParams(clientSecret, true)
         PaymentMethod.Type.Alipay -> createAlipayPaymentConfirmParams(clientSecret)
         PaymentMethod.Type.Sofort -> createSofortPaymentConfirmParams(clientSecret)
         PaymentMethod.Type.Bancontact -> createBancontactPaymentConfirmParams(clientSecret)
@@ -227,7 +227,7 @@ class PaymentMethodCreateParamsFactory(
     try {
       return when (paymentMethodType) {
         PaymentMethod.Type.Card -> createCardStripeIntentParams(clientSecret, false)
-        PaymentMethod.Type.Ideal -> createIDEALPaymentSetupParams(clientSecret)
+        PaymentMethod.Type.Ideal -> createIDEALStripeIntentParams(clientSecret, false)
         PaymentMethod.Type.Sofort -> createSofortPaymentSetupParams(clientSecret)
         PaymentMethod.Type.Bancontact -> createBancontactPaymentSetupParams(clientSecret)
         PaymentMethod.Type.SepaDebit -> createSepaPaymentSetupParams(clientSecret)
@@ -244,15 +244,22 @@ class PaymentMethodCreateParamsFactory(
   }
 
   @Throws(PaymentMethodCreateParamsException::class)
-  private fun createIDEALPaymentConfirmParams(clientSecret: String): ConfirmPaymentIntentParams {
+  private fun createIDEALStripeIntentParams(clientSecret: String, isPaymentIntent: Boolean): ConfirmStripeIntentParams {
     val createParams = createIDEALParams()
 
-    return ConfirmPaymentIntentParams
-      .createWithPaymentMethodCreateParams(
+    return if (isPaymentIntent) {
+      ConfirmPaymentIntentParams
+        .createWithPaymentMethodCreateParams(
+          paymentMethodCreateParams = createParams,
+          clientSecret = clientSecret,
+          setupFutureUsage = mapToPaymentIntentFutureUsage(getValOr(options, "setupFutureUsage")),
+        )
+    } else {
+      return ConfirmSetupIntentParams.create(
         paymentMethodCreateParams = createParams,
         clientSecret = clientSecret,
-        setupFutureUsage = mapToPaymentIntentFutureUsage(getValOr(options, "setupFutureUsage")),
       )
+    }
   }
 
   @Throws(PaymentMethodCreateParamsException::class)
@@ -323,16 +330,6 @@ class PaymentMethodCreateParamsFactory(
             .create(paymentMethodCreateParams, clientSecret)
         )
     }
-  }
-
-  @Throws(PaymentMethodCreateParamsException::class)
-  private fun createIDEALPaymentSetupParams(clientSecret: String): ConfirmSetupIntentParams {
-    val createParams = createIDEALParams()
-
-    return ConfirmSetupIntentParams.create(
-      paymentMethodCreateParams = createParams,
-      clientSecret = clientSecret,
-    )
   }
 
   @Throws(PaymentMethodCreateParamsException::class)

--- a/android/src/main/java/com/reactnativestripesdk/PaymentMethodCreateParamsFactory.kt
+++ b/android/src/main/java/com/reactnativestripesdk/PaymentMethodCreateParamsFactory.kt
@@ -112,7 +112,11 @@ class PaymentMethodCreateParamsFactory(
 
   @Throws(PaymentMethodCreateParamsException::class)
   private fun createEPSParams(): PaymentMethodCreateParams {
+    billingDetailsParams?.let {
+      return PaymentMethodCreateParams.createEps(it)
+    }
 
+    throw PaymentMethodCreateParamsException("You must provide billing details")
   }
 
   @Throws(PaymentMethodCreateParamsException::class)
@@ -388,18 +392,14 @@ class PaymentMethodCreateParamsFactory(
 
   @Throws(PaymentMethodCreateParamsException::class)
   private fun createEPSPaymentConfirmParams(): ConfirmPaymentIntentParams {
-    billingDetailsParams?.let {
-      val params = PaymentMethodCreateParams.createEps(it)
+    val params = createEPSParams()
 
-      return ConfirmPaymentIntentParams
-        .createWithPaymentMethodCreateParams(
-          paymentMethodCreateParams = params,
-          clientSecret = clientSecret,
-          setupFutureUsage = mapToPaymentIntentFutureUsage(getValOr(options, "setupFutureUsage"))
-        )
-    }
-
-    throw PaymentMethodCreateParamsException("You must provide billing details")
+    return ConfirmPaymentIntentParams
+      .createWithPaymentMethodCreateParams(
+        paymentMethodCreateParams = params,
+        clientSecret = clientSecret,
+        setupFutureUsage = mapToPaymentIntentFutureUsage(getValOr(options, "setupFutureUsage"))
+      )
   }
 
   @Throws(PaymentMethodCreateParamsException::class)

--- a/android/src/main/java/com/reactnativestripesdk/PaymentMethodCreateParamsFactory.kt
+++ b/android/src/main/java/com/reactnativestripesdk/PaymentMethodCreateParamsFactory.kt
@@ -136,7 +136,10 @@ class PaymentMethodCreateParamsFactory(
 
   @Throws(PaymentMethodCreateParamsException::class)
   private fun createFpxParams(): PaymentMethodCreateParams {
-
+    val bank = getBooleanOrFalse(paymentMethodData, "testOfflineBank").let { "test_offline_bank" }
+    return PaymentMethodCreateParams.create(
+      PaymentMethodCreateParams.Fpx(bank)
+    )
   }
 
   @Throws(PaymentMethodCreateParamsException::class)
@@ -428,10 +431,7 @@ class PaymentMethodCreateParamsFactory(
 
   @Throws(PaymentMethodCreateParamsException::class)
   private fun createFpxPaymentConfirmParams(): ConfirmPaymentIntentParams {
-    val bank = getBooleanOrFalse(paymentMethodData, "testOfflineBank").let { "test_offline_bank" }
-    val params = PaymentMethodCreateParams.create(
-      PaymentMethodCreateParams.Fpx(bank)
-    )
+    val params = createFpxParams()
 
     return ConfirmPaymentIntentParams
       .createWithPaymentMethodCreateParams(

--- a/android/src/main/java/com/reactnativestripesdk/PaymentMethodCreateParamsFactory.kt
+++ b/android/src/main/java/com/reactnativestripesdk/PaymentMethodCreateParamsFactory.kt
@@ -103,7 +103,11 @@ class PaymentMethodCreateParamsFactory(
 
   @Throws(PaymentMethodCreateParamsException::class)
   private fun createGiropayParams(): PaymentMethodCreateParams {
+    billingDetailsParams?.let {
+      return PaymentMethodCreateParams.createGiropay(it)
+    }
 
+    throw PaymentMethodCreateParamsException("You must provide billing details")
   }
 
   @Throws(PaymentMethodCreateParamsException::class)
@@ -400,18 +404,14 @@ class PaymentMethodCreateParamsFactory(
 
   @Throws(PaymentMethodCreateParamsException::class)
   private fun createGiropayPaymentConfirmParams(): ConfirmPaymentIntentParams {
-    billingDetailsParams?.let {
-      val params = PaymentMethodCreateParams.createGiropay(it)
+    val params = createGiropayParams()
 
-      return ConfirmPaymentIntentParams
-        .createWithPaymentMethodCreateParams(
-          paymentMethodCreateParams = params,
-          clientSecret = clientSecret,
-          setupFutureUsage = mapToPaymentIntentFutureUsage(getValOr(options, "setupFutureUsage"))
-        )
-    }
-
-    throw PaymentMethodCreateParamsException("You must provide billing details")
+    return ConfirmPaymentIntentParams
+      .createWithPaymentMethodCreateParams(
+        paymentMethodCreateParams = params,
+        clientSecret = clientSecret,
+        setupFutureUsage = mapToPaymentIntentFutureUsage(getValOr(options, "setupFutureUsage"))
+      )
   }
 
   @Throws(PaymentMethodCreateParamsException::class)

--- a/android/src/main/java/com/reactnativestripesdk/PaymentMethodCreateParamsFactory.kt
+++ b/android/src/main/java/com/reactnativestripesdk/PaymentMethodCreateParamsFactory.kt
@@ -31,7 +31,7 @@ class PaymentMethodCreateParamsFactory(
         PaymentMethod.Type.AfterpayClearpay -> createAfterpayClearpayParams()
         PaymentMethod.Type.AuBecsDebit -> createAuBecsDebitParams()
         PaymentMethod.Type.Klarna -> createKlarnaParams()
-        PaymentMethod.Type.USBankAccount -> createUSBankAccountParams()
+        PaymentMethod.Type.USBankAccount -> createUSBankAccountParams(paymentMethodData)
         PaymentMethod.Type.PayPal -> createPayPalParams()
         else -> {
           throw Exception("This paymentMethodType is not supported yet")
@@ -577,7 +577,7 @@ class PaymentMethodCreateParamsFactory(
   }
 
   @Throws(PaymentMethodCreateParamsException::class)
-  private fun createUSBankAccountParams(params: ReadableMap): PaymentMethodCreateParams {
+  private fun createUSBankAccountParams(params: ReadableMap?): PaymentMethodCreateParams {
     val accountNumber = getValOr(params, "accountNumber", null)
     val routingNumber = getValOr(params, "routingNumber", null)
 

--- a/android/src/main/java/com/reactnativestripesdk/PaymentMethodCreateParamsFactory.kt
+++ b/android/src/main/java/com/reactnativestripesdk/PaymentMethodCreateParamsFactory.kt
@@ -190,7 +190,7 @@ class PaymentMethodCreateParamsFactory(
 
   @Throws(PaymentMethodCreateParamsException::class)
   private fun createPayPalParams(): PaymentMethodCreateParams {
-
+    return PaymentMethodCreateParams.createPayPal(null)
   }
 
   @Throws(PaymentMethodCreateParamsException::class)
@@ -568,8 +568,10 @@ class PaymentMethodCreateParamsFactory(
 
   @Throws(PaymentMethodCreateParamsException::class)
   private fun createPayPalPaymentConfirmParams(): ConfirmPaymentIntentParams {
+    val params = createPayPalParams()
+
     return ConfirmPaymentIntentParams.createWithPaymentMethodCreateParams(
-      paymentMethodCreateParams = PaymentMethodCreateParams.createPayPal(null),
+      paymentMethodCreateParams = params,
       clientSecret = clientSecret,
     )
   }

--- a/android/src/main/java/com/reactnativestripesdk/PaymentMethodCreateParamsFactory.kt
+++ b/android/src/main/java/com/reactnativestripesdk/PaymentMethodCreateParamsFactory.kt
@@ -241,21 +241,18 @@ class PaymentMethodCreateParamsFactory(
 
   @Throws(PaymentMethodCreateParamsException::class)
   private fun createCardPaymentMethodParams(): PaymentMethodCreateParams {
-    val paymentMethodId = getValOr(paymentMethodData, "paymentMethodId", null)
     val token = getValOr(paymentMethodData, "token", null)
+    var cardParams = cardFieldView?.cardParams ?: cardFormView?.cardParams
 
-    val cardParams = cardFieldView?.cardParams ?: cardFormView?.cardParams
+    if (token != null) {
+      cardParams = PaymentMethodCreateParams.Card.create(token)
+    }
 
-    if (cardParams == null && paymentMethodId == null && token == null) {
+    if (cardParams == null) {
       throw PaymentMethodCreateParamsException("Card details not complete")
     }
 
-    var card = cardParams
-    if (token != null) {
-      card = PaymentMethodCreateParams.Card.create(token)
-    }
-
-    return PaymentMethodCreateParams.create(card!!, billingDetailsParams)
+    return PaymentMethodCreateParams.create(cardParams, billingDetailsParams)
   }
 
   @Throws(PaymentMethodCreateParamsException::class)

--- a/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
+++ b/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
@@ -390,7 +390,7 @@ class StripeSdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJ
     val factory = PaymentMethodCreateParamsFactory(paymentMethodData, options, cardFieldView, cardFormView)
 
     try {
-      val confirmParams = factory.createConfirmParams(paymentIntentClientSecret, paymentMethodType) as ConfirmPaymentIntentParams
+      val confirmParams = factory.createParams(paymentIntentClientSecret, paymentMethodType, isPaymentIntent = true) as ConfirmPaymentIntentParams
       urlScheme?.let {
         confirmParams.returnUrl = mapToReturnURL(urlScheme)
       }
@@ -443,7 +443,7 @@ class StripeSdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJ
     val factory = PaymentMethodCreateParamsFactory(getMapOrNull(params, "paymentMethodData"), options, cardFieldView, cardFormView)
 
     try {
-      val confirmParams = factory.createSetupParams(setupIntentClientSecret, paymentMethodType) as ConfirmSetupIntentParams
+      val confirmParams = factory.createParams(setupIntentClientSecret, paymentMethodType, isPaymentIntent = false) as ConfirmSetupIntentParams
       urlScheme?.let {
         confirmParams.returnUrl = mapToReturnURL(urlScheme)
       }

--- a/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
+++ b/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
@@ -390,7 +390,7 @@ class StripeSdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJ
     val factory = PaymentMethodCreateParamsFactory(paymentMethodData, options, cardFieldView, cardFormView)
 
     try {
-      val confirmParams = factory.createConfirmParams(paymentIntentClientSecret, paymentMethodType)
+      val confirmParams = factory.createConfirmParams(paymentIntentClientSecret, paymentMethodType) as ConfirmPaymentIntentParams
       urlScheme?.let {
         confirmParams.returnUrl = mapToReturnURL(urlScheme)
       }
@@ -443,7 +443,7 @@ class StripeSdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJ
     val factory = PaymentMethodCreateParamsFactory(getMapOrNull(params, "paymentMethodData"), options, cardFieldView, cardFormView)
 
     try {
-      val confirmParams = factory.createSetupParams(setupIntentClientSecret, paymentMethodType)
+      val confirmParams = factory.createSetupParams(setupIntentClientSecret, paymentMethodType) as ConfirmSetupIntentParams
       urlScheme?.let {
         confirmParams.returnUrl = mapToReturnURL(urlScheme)
       }

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -305,11 +305,11 @@ PODS:
     - StripeApplePay (= 22.5.1)
     - StripeCore (= 22.5.1)
     - StripeUICore (= 22.5.1)
-  - stripe-react-native (0.13.1):
+  - stripe-react-native (0.14.0):
     - React-Core
     - Stripe (~> 22.5.1)
     - StripeFinancialConnections (~> 22.5.1)
-  - stripe-react-native/Tests (0.13.1):
+  - stripe-react-native/Tests (0.14.0):
     - React-Core
     - Stripe (~> 22.5.1)
     - StripeFinancialConnections (~> 22.5.1)
@@ -492,7 +492,7 @@ SPEC CHECKSUMS:
   RNCPicker: abc646b53a3d28ccfa3232c927a0ca52e0cf024d
   RNScreens: 40a2cb40a02a609938137a1e0acfbf8fc9eebf19
   Stripe: 2b2decd03146e08a350960966d41f3028c2eac29
-  stripe-react-native: 9d56a4aefffea73722d2e00ee9f88f42133ffe98
+  stripe-react-native: c90947c1f02761d11622dcb3cd3bd8683916b36b
   StripeApplePay: b14f06ac6fc24b56704c1e598149ed0cc45e166f
   StripeCore: 4833738f2ca4336712f279f3c2867a0a7eb67c93
   StripeFinancialConnections: 982115b82af429968d8aa78d329a42ed7ba3feab


### PR DESCRIPTION
## Summary

Added support for all the payment methods we currently support via other functions (like `confirmPayment`) to be supported via the `createPaymentMethod` function. 

## Motivation

closes https://github.com/stripe/stripe-react-native/issues/642
Cleans up a lot of the logic in `[PaymentMethodCreateParamsFactory.kt](https://github.com/stripe/stripe-react-native/pull/987/files#diff-9eb0ba7715e0870bce660045f3334fdf6e7b14a32606b63229033597ce125e35)` so that it's simpler, shorter, and more extensible.

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
