### PR TITLE
fix: Make CardField postal code behavior consistent on iOS and Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,12 @@
 ### New features
 
 - Added a `defaultValues` prop to the `CardForm` component. Currently only accepts `countryCode`, and is Android-only. [#974](https://github.com/stripe/stripe-react-native/pull/974)
+- Added the `countryCode` prop to the `CardField` component. [#989](https://github.com/stripe/stripe-react-native/pull/989)
 
 ### Fixes
 
 - Resolve with an Error (of type `Canceled`) if no payment option is selected in the Payment Sheet custom flow (i.e., the `x` button is clicked to close the Payment Sheet). [#975](https://github.com/stripe/stripe-react-native/pull/975)
+- Fixed an issue on Android where the `complete` field in the `onCardChange` callback would incorrectly be set to `true` even if the postal code wasn't filled out. [#989](https://github.com/stripe/stripe-react-native/pull/989)
 
 ## 0.12.0
 

--- a/android/src/main/java/com/reactnativestripesdk/CardFieldView.kt
+++ b/android/src/main/java/com/reactnativestripesdk/CardFieldView.kt
@@ -33,6 +33,7 @@ class CardFieldView(context: ThemedReactContext) : FrameLayout(context) {
   private var mEventDispatcher: EventDispatcher? = context.getNativeModule(UIManagerModule::class.java)?.eventDispatcher
   private var dangerouslyGetFullCardDetails: Boolean = false
   private var currentFocusedField: String? = null
+  private var isCardValid = false
 
   init {
     cardInputWidgetBinding.container.isFocusable = true
@@ -224,7 +225,7 @@ class CardFieldView(context: ThemedReactContext) : FrameLayout(context) {
 
   private fun sendCardDetailsEvent() {
     mEventDispatcher?.dispatchEvent(
-      CardChangedEvent(id, cardDetails, mCardWidget.postalCodeEnabled, cardParams != null, dangerouslyGetFullCardDetails))
+      CardChangedEvent(id, cardDetails, mCardWidget.postalCodeEnabled, isCardValid, dangerouslyGetFullCardDetails))
   }
 
   private fun setListeners() {
@@ -246,6 +247,7 @@ class CardFieldView(context: ThemedReactContext) : FrameLayout(context) {
     }
 
     mCardWidget.setCardValidCallback { isValid, invalidFields ->
+      isCardValid = isValid
       fun getCardValidationState(field: CardValidCallback.Fields, editTextField: StripeEditText): String {
         if (invalidFields.contains(field)) {
           return if (editTextField.shouldShowError) "Invalid"
@@ -263,6 +265,7 @@ class CardFieldView(context: ThemedReactContext) : FrameLayout(context) {
       } else {
         cardParams = null
         cardAddress = null
+        sendCardDetailsEvent()
       }
     }
 
@@ -284,8 +287,6 @@ class CardFieldView(context: ThemedReactContext) : FrameLayout(context) {
         if (splitText.size == 2) {
           cardDetails["expiryYear"] = var1.toString().split("/")[1].toIntOrNull()
         }
-
-        sendCardDetailsEvent()
       }
     })
 
@@ -294,7 +295,6 @@ class CardFieldView(context: ThemedReactContext) : FrameLayout(context) {
       override fun afterTextChanged(p0: Editable?) {}
       override fun onTextChanged(var1: CharSequence?, var2: Int, var3: Int, var4: Int) {
         cardDetails["postalCode"] = var1.toString()
-        sendCardDetailsEvent()
       }
     })
 
@@ -305,7 +305,6 @@ class CardFieldView(context: ThemedReactContext) : FrameLayout(context) {
         if (dangerouslyGetFullCardDetails) {
           cardDetails["number"] = var1.toString().replace(" ", "")
         }
-        sendCardDetailsEvent()
       }
     })
 
@@ -316,7 +315,6 @@ class CardFieldView(context: ThemedReactContext) : FrameLayout(context) {
         if (dangerouslyGetFullCardDetails) {
           cardDetails["cvc"] = var1.toString()
         }
-        sendCardDetailsEvent()
       }
     })
   }

--- a/android/src/main/java/com/reactnativestripesdk/CardFieldView.kt
+++ b/android/src/main/java/com/reactnativestripesdk/CardFieldView.kt
@@ -15,6 +15,8 @@ import com.facebook.react.uimanager.events.EventDispatcher
 import com.google.android.material.shape.CornerFamily
 import com.google.android.material.shape.MaterialShapeDrawable
 import com.google.android.material.shape.ShapeAppearanceModel
+import com.stripe.android.core.model.CountryCode
+import com.stripe.android.core.model.CountryUtils
 import com.stripe.android.databinding.CardInputWidgetBinding
 import com.stripe.android.model.Address
 import com.stripe.android.model.PaymentMethodCreateParams
@@ -196,6 +198,19 @@ class CardFieldView(context: ThemedReactContext) : FrameLayout(context) {
 
   fun setPostalCodeEnabled(isEnabled: Boolean) {
     mCardWidget.postalCodeEnabled = isEnabled
+  }
+
+  fun setCountryCode(countryCode: String?) {
+    val defaultLocale = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+      if (context.resources.configuration.locales.isEmpty) "US"
+      else context.resources.configuration.locales[0].country
+    } else {
+      context.resources.configuration.locale.country
+    }
+
+    val doesCountryUsePostalCode = CountryUtils.doesCountryUsePostalCode(CountryCode.create(value = countryCode ?: defaultLocale))
+    mCardWidget.postalCodeRequired = doesCountryUsePostalCode
+    mCardWidget.postalCodeEnabled = doesCountryUsePostalCode
   }
 
   fun getValue(): MutableMap<String, Any?> {

--- a/android/src/main/java/com/reactnativestripesdk/CardFieldView.kt
+++ b/android/src/main/java/com/reactnativestripesdk/CardFieldView.kt
@@ -8,6 +8,7 @@ import android.text.Editable
 import android.text.TextWatcher
 import android.util.Log
 import android.widget.FrameLayout
+import androidx.core.os.LocaleListCompat
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.UIManagerModule
@@ -201,14 +202,9 @@ class CardFieldView(context: ThemedReactContext) : FrameLayout(context) {
   }
 
   fun setCountryCode(countryCode: String?) {
-    val defaultLocale = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-      if (context.resources.configuration.locales.isEmpty) "US"
-      else context.resources.configuration.locales[0].country
-    } else {
-      context.resources.configuration.locale.country
-    }
-
-    val doesCountryUsePostalCode = CountryUtils.doesCountryUsePostalCode(CountryCode.create(value = countryCode ?: defaultLocale))
+    val doesCountryUsePostalCode = CountryUtils.doesCountryUsePostalCode(
+      CountryCode.create(value = countryCode ?: LocaleListCompat.getAdjustedDefault()[0].country)
+    )
     mCardWidget.postalCodeRequired = doesCountryUsePostalCode
     mCardWidget.postalCodeEnabled = doesCountryUsePostalCode
   }

--- a/android/src/main/java/com/reactnativestripesdk/CardFieldViewManager.kt
+++ b/android/src/main/java/com/reactnativestripesdk/CardFieldViewManager.kt
@@ -51,6 +51,11 @@ class CardFieldViewManager : SimpleViewManager<CardFieldView>() {
     view.setPlaceHolders(placeholders)
   }
 
+  @ReactProp(name = "countryCode")
+  fun setPlaceHolders(view: CardFieldView, countryCode: String?) {
+    view.setCountryCode(countryCode)
+  }
+
   override fun createViewInstance(reactContext: ThemedReactContext): CardFieldView {
     val stripeSdkModule: StripeSdkModule? = reactContext.getNativeModule(StripeSdkModule::class.java)
     val view = CardFieldView(reactContext)

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -305,7 +305,7 @@ PODS:
     - StripeApplePay (= 22.4.0)
     - StripeCore (= 22.4.0)
     - StripeUICore (= 22.4.0)
-  - stripe-react-native (0.11.0):
+  - stripe-react-native (0.12.0):
     - React-Core
     - Stripe (~> 22.4.0)
     - StripeFinancialConnections (~> 22.4.0)
@@ -487,7 +487,7 @@ SPEC CHECKSUMS:
   RNCPicker: abc646b53a3d28ccfa3232c927a0ca52e0cf024d
   RNScreens: 40a2cb40a02a609938137a1e0acfbf8fc9eebf19
   Stripe: a925dfa9a7e51aa8f782f428abc10cb828b45a85
-  stripe-react-native: 20e9f0b042410610ea989becb9a15468f1f9ae86
+  stripe-react-native: 5ba7374969691d6371065bb66a9f3a5cdbf1d8e1
   StripeApplePay: 369857bafe8baf02e31b47478db1574febd2a2f3
   StripeCore: a94d2823817c97c79fce60884ab9027a2da798c1
   StripeFinancialConnections: 269658b79f639c2d6b7d513235d469418b04c2dd

--- a/ios/CardFieldManager.m
+++ b/ios/CardFieldManager.m
@@ -4,6 +4,7 @@
 
 @interface RCT_EXTERN_MODULE(CardFieldManager, RCTViewManager)
 RCT_EXPORT_VIEW_PROPERTY(postalCodeEnabled, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(countryCode, NSString)
 RCT_EXPORT_VIEW_PROPERTY(onCardChange, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onFocusChange, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(cardStyle, NSDictionary)

--- a/ios/CardFieldView.swift
+++ b/ios/CardFieldView.swift
@@ -18,6 +18,12 @@ class CardFieldView: UIView, STPPaymentCardTextFieldDelegate {
         }
     }
     
+    @objc var countryCode: String? {
+        didSet {
+            cardField.countryCode = countryCode
+        }
+    }
+    
     @objc var placeholders: NSDictionary = NSDictionary() {
         didSet {
             if let numberPlaceholder = placeholders["number"] as? String {

--- a/src/components/CardField.tsx
+++ b/src/components/CardField.tsx
@@ -30,7 +30,10 @@ const CardFieldNative =
  */
 export interface Props extends AccessibilityProps {
   style?: StyleProp<ViewStyle>;
+  /** Controls if a postal code entry field can be displayed to the user. Defaults to false. If true, the type of code entry shown is controlled by the set countryCode prop. Some country codes may result in no postal code entry being shown if those countries do not commonly use postal codes. If false, no postal code entry will ever be displayed. */
   postalCodeEnabled?: boolean;
+  /** Controls the postal code entry shown (if the postalCodeEnabled prop is set to true). */
+  countryCode?: string;
   cardStyle?: CardFieldInput.Styles;
   placeholders?: CardFieldInput.Placeholders;
   autofocus?: boolean;

--- a/src/components/CardField.tsx
+++ b/src/components/CardField.tsx
@@ -32,7 +32,7 @@ export interface Props extends AccessibilityProps {
   style?: StyleProp<ViewStyle>;
   /** Controls if a postal code entry field can be displayed to the user. Defaults to false. If true, the type of code entry shown is controlled by the set countryCode prop. Some country codes may result in no postal code entry being shown if those countries do not commonly use postal codes. If false, no postal code entry will ever be displayed. */
   postalCodeEnabled?: boolean;
-  /** Controls the postal code entry shown (if the postalCodeEnabled prop is set to true). */
+  /** Controls the postal code entry shown (if the postalCodeEnabled prop is set to true). Defaults to the device's default locale. */
   countryCode?: string;
   cardStyle?: CardFieldInput.Styles;
   placeholders?: CardFieldInput.Placeholders;
@@ -77,6 +77,7 @@ export const CardField = forwardRef<CardFieldInput.Methods, Props>(
       cardStyle,
       placeholders,
       postalCodeEnabled,
+      countryCode,
       ...props
     },
     ref
@@ -178,6 +179,7 @@ export const CardField = forwardRef<CardFieldInput.Methods, Props>(
         onCardChange={onCardChangeHandler}
         onFocusChange={onFocusHandler}
         postalCodeEnabled={postalCodeEnabled ?? true}
+        countryCode={countryCode ?? null}
         cardStyle={{
           backgroundColor: cardStyle?.backgroundColor,
           borderColor: cardStyle?.borderColor,

--- a/src/types/components/CardFieldInput.ts
+++ b/src/types/components/CardFieldInput.ts
@@ -59,6 +59,7 @@ export interface NativeProps {
   value?: Partial<Details>;
   postalCodeEnabled?: boolean;
   autofocus?: boolean;
+  countryCode: string | null;
   onCardChange(event: NativeSyntheticEvent<Details>): void;
   onFocusChange(
     event: NativeSyntheticEvent<{ focusedField: FieldName | null }>


### PR DESCRIPTION
## Summary & Motivation

previously, the `complete` field in the `onCardChange` callback would incorrectly be set to `true` if the postal code wasn't filled out on Android (not ios). This fixes that, and also implements the same behavior as ios- if the user's current device locale is a country/region without postal codes, the postal code entry isn't shown or required. 

Users can also override the country code by passing the `countryCode` prop

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one: 
- [x] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
