### PR TITLE
fix: make lastPaymentError and lastSetupError consistent across platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Fixes
 
 - Resolve with an Error (of type `Canceled`) if no payment option is selected in the Payment Sheet custom flow (i.e., the `x` button is clicked to close the Payment Sheet). [#975](https://github.com/stripe/stripe-react-native/pull/975)
+- Make `SetupIntent.lastSetupError` and `PaymentIntent.lastPaymentError` object shape consistent on iOS and Android.[#990](https://github.com/stripe/stripe-react-native/pull/990)
 
 ## 0.12.0
 

--- a/android/src/main/java/com/reactnativestripesdk/Mappers.kt
+++ b/android/src/main/java/com/reactnativestripesdk/Mappers.kt
@@ -402,14 +402,13 @@ internal fun mapFromPaymentIntentResult(paymentIntent: PaymentIntent): WritableM
 
   paymentIntent.lastPaymentError?.let {
     val paymentError: WritableMap = WritableNativeMap()
-
-    paymentIntent.lastPaymentError?.paymentMethod?.let { paymentMethod ->
-      paymentError.putMap("paymentMethod", mapFromPaymentMethod(paymentMethod))
-    }
-
     paymentError.putString("code", it.code)
     paymentError.putString("message", it.message)
     paymentError.putString("type", mapFromPaymentIntentLastErrorType(it.type))
+    paymentError.putString("declineCode", it.declineCode)
+    paymentIntent.lastPaymentError?.paymentMethod?.let { paymentMethod ->
+      paymentError.putMap("paymentMethod", mapFromPaymentMethod(paymentMethod))
+    }
 
     map.putMap("lastPaymentError", paymentError)
   }
@@ -775,11 +774,10 @@ internal fun mapFromSetupIntentResult(setupIntent: SetupIntent): WritableMap {
     setupError.putString("code", it.code)
     setupError.putString("message", it.message)
     setupError.putString("type", mapFromSetupIntentLastErrorType(it.type))
-
+    setupError.putString("declineCode", it.declineCode)
     setupIntent.lastSetupError?.paymentMethod?.let { paymentMethod ->
       setupError.putMap("paymentMethod", mapFromPaymentMethod(paymentMethod))
     }
-
     map.putMap("lastSetupError", setupError)
   }
 

--- a/ios/Mappers.swift
+++ b/ios/Mappers.swift
@@ -721,7 +721,7 @@ class Mappers {
         if let lastSetupError = setupIntent.lastSetupError {
             let setupError: NSMutableDictionary = [
                 "code": lastSetupError.code ?? NSNull(),
-                "message": lastSetupError.description,
+                "message": lastSetupError.message ?? NSNull(),
                 "type": mapFromSetupIntentLastPaymentErrorType(lastSetupError.type) ?? NSNull(),
                 "declineCode": lastSetupError.declineCode ?? NSNull(),
                 "paymentMethod": mapFromPaymentMethod(lastSetupError.paymentMethod) ?? NSNull()


### PR DESCRIPTION
## Summary

added `declineCode` to object on android, and used the `message` instead of `description` on iOS for the `message` field.

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
