### PR TITLE
fix: Never show postal code input in `CardField` if `postalCodeEnabled=false` (regardless of `countryCode`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Fixes
 
-- Never show postal code input in `CardField` if `postalCodeEnabled=false` (regardless of `countryCode`).
+- Never show postal code input in `CardField` if `postalCodeEnabled=false` (regardless of `countryCode`). [#996](https://github.com/stripe/stripe-react-native/pull/996)
 
 ## 0.13.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Breaking changes
+
+### New features
+
+### Fixes
+
+- Never show postal code input in `CardField` if `postalCodeEnabled=false` (regardless of `countryCode`).
+
 ## 0.13.0
 
 ### Breaking changes

--- a/android/src/main/java/com/reactnativestripesdk/CardFieldView.kt
+++ b/android/src/main/java/com/reactnativestripesdk/CardFieldView.kt
@@ -201,12 +201,17 @@ class CardFieldView(context: ThemedReactContext) : FrameLayout(context) {
     mCardWidget.postalCodeEnabled = isEnabled
   }
 
+  /**
+   * We can reliable assume that setPostalCodeEnabled is called before
+   * setCountryCode because of the order of the props in CardField.tsx
+   */
   fun setCountryCode(countryCode: String?) {
-    val doesCountryUsePostalCode = CountryUtils.doesCountryUsePostalCode(
-      CountryCode.create(value = countryCode ?: LocaleListCompat.getAdjustedDefault()[0].country)
-    )
-    mCardWidget.postalCodeRequired = doesCountryUsePostalCode
-    mCardWidget.postalCodeEnabled = doesCountryUsePostalCode
+    if (mCardWidget.postalCodeEnabled) {
+      val doesCountryUsePostalCode = CountryUtils.doesCountryUsePostalCode(
+        CountryCode.create(value = countryCode ?: LocaleListCompat.getAdjustedDefault()[0].country)
+      )
+      mCardWidget.postalCodeRequired = doesCountryUsePostalCode
+    }
   }
 
   fun getValue(): MutableMap<String, Any?> {

--- a/android/src/main/java/com/reactnativestripesdk/CardFieldViewManager.kt
+++ b/android/src/main/java/com/reactnativestripesdk/CardFieldViewManager.kt
@@ -46,14 +46,14 @@ class CardFieldViewManager : SimpleViewManager<CardFieldView>() {
     view.setCardStyle(cardStyle)
   }
 
+  @ReactProp(name = "countryCode")
+  fun setCountryCode(view: CardFieldView, countryCode: String?) {
+    view.setCountryCode(countryCode)
+  }
+
   @ReactProp(name = "placeholders")
   fun setPlaceHolders(view: CardFieldView, placeholders: ReadableMap) {
     view.setPlaceHolders(placeholders)
-  }
-
-  @ReactProp(name = "countryCode")
-  fun setPlaceHolders(view: CardFieldView, countryCode: String?) {
-    view.setCountryCode(countryCode)
   }
 
   override fun createViewInstance(reactContext: ThemedReactContext): CardFieldView {


### PR DESCRIPTION
## Summary

Previously we'd show the postal code if the `countryCode` was set to a country that does require postal codes, even if `postalCodeEnabled` was false.

## Motivation
fix small bug intro'd in 0.13.0

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
