### PR TITLE
chore: bump stripe-ios to 22.5

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -300,27 +300,27 @@ PODS:
   - RNScreens (3.13.1):
     - React-Core
     - React-RCTImage
-  - Stripe (22.4.0):
-    - Stripe/Stripe3DS2 (= 22.4.0)
-    - StripeApplePay (= 22.4.0)
-    - StripeCore (= 22.4.0)
-    - StripeUICore (= 22.4.0)
-  - stripe-react-native (0.12.0):
+  - Stripe (22.5.1):
+    - Stripe/Stripe3DS2 (= 22.5.1)
+    - StripeApplePay (= 22.5.1)
+    - StripeCore (= 22.5.1)
+    - StripeUICore (= 22.5.1)
+  - stripe-react-native (0.13.1):
     - React-Core
-    - Stripe (~> 22.4.0)
-    - StripeFinancialConnections (~> 22.4.0)
-  - Stripe/Stripe3DS2 (22.4.0):
-    - StripeApplePay (= 22.4.0)
-    - StripeCore (= 22.4.0)
-    - StripeUICore (= 22.4.0)
-  - StripeApplePay (22.4.0):
-    - StripeCore (= 22.4.0)
-  - StripeCore (22.4.0)
-  - StripeFinancialConnections (22.4.0):
-    - StripeCore (= 22.4.0)
-    - StripeUICore (= 22.4.0)
-  - StripeUICore (22.4.0):
-    - StripeCore (= 22.4.0)
+    - Stripe (~> 22.5.1)
+    - StripeFinancialConnections (~> 22.5.1)
+  - Stripe/Stripe3DS2 (22.5.1):
+    - StripeApplePay (= 22.5.1)
+    - StripeCore (= 22.5.1)
+    - StripeUICore (= 22.5.1)
+  - StripeApplePay (22.5.1):
+    - StripeCore (= 22.5.1)
+  - StripeCore (22.5.1)
+  - StripeFinancialConnections (22.5.1):
+    - StripeCore (= 22.5.1)
+    - StripeUICore (= 22.5.1)
+  - StripeUICore (22.5.1):
+    - StripeCore (= 22.5.1)
   - Yoga (1.14.0)
 
 DEPENDENCIES:
@@ -486,12 +486,12 @@ SPEC CHECKSUMS:
   RNCMaskedView: c298b644a10c0c142055b3ae24d83879ecb13ccd
   RNCPicker: abc646b53a3d28ccfa3232c927a0ca52e0cf024d
   RNScreens: 40a2cb40a02a609938137a1e0acfbf8fc9eebf19
-  Stripe: a925dfa9a7e51aa8f782f428abc10cb828b45a85
-  stripe-react-native: 5ba7374969691d6371065bb66a9f3a5cdbf1d8e1
-  StripeApplePay: 369857bafe8baf02e31b47478db1574febd2a2f3
-  StripeCore: a94d2823817c97c79fce60884ab9027a2da798c1
-  StripeFinancialConnections: 269658b79f639c2d6b7d513235d469418b04c2dd
-  StripeUICore: a8e24a6c91a5c99075c7a490d45695fb912876e8
+  Stripe: 2b2decd03146e08a350960966d41f3028c2eac29
+  stripe-react-native: 564554ae990c021077813a60417349cc9db3a645
+  StripeApplePay: b14f06ac6fc24b56704c1e598149ed0cc45e166f
+  StripeCore: 4833738f2ca4336712f279f3c2867a0a7eb67c93
+  StripeFinancialConnections: 982115b82af429968d8aa78d329a42ed7ba3feab
+  StripeUICore: 08c1efbd7e3c54ee7fa74334a37a1d4c08ba944d
   Yoga: 17cd9a50243093b547c1e539c749928dd68152da
 
 PODFILE CHECKSUM: 89387f6a979368e90b83d6e182d905e7f384066a

--- a/stripe-react-native.podspec
+++ b/stripe-react-native.podspec
@@ -1,7 +1,7 @@
 require 'json'
 
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
-stripe_version = '~> 22.4.0'
+stripe_version = '~> 22.5.1'
 
 Pod::Spec.new do |s|
   s.name         = 'stripe-react-native'


### PR DESCRIPTION
## Summary
bump stripe-ios dependency
## Motivation
fixes https://github.com/stripe/stripe-react-native/issues/1010
