### PR TITLE
fix: return card brand as soon as possible in CardField onCardChange callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Breaking changes
+
+### New features
+
+### Fixes
+
+- Fixed an issue on Android where the `brand` field in `CardField`'s `onCardChange` callback wouldn't be set unless the card details were fully complete. [#1012](https://github.com/stripe/stripe-react-native/pull/1012)
+
 ## 0.13.1 - 2022-06-16
 
 ### Breaking changes

--- a/android/src/main/java/com/reactnativestripesdk/CardFieldView.kt
+++ b/android/src/main/java/com/reactnativestripesdk/CardFieldView.kt
@@ -275,6 +275,7 @@ class CardFieldView(context: ThemedReactContext) : FrameLayout(context) {
       cardDetails["validNumber"] = getCardValidationState(CardValidCallback.Fields.Number, cardInputWidgetBinding.cardNumberEditText)
       cardDetails["validCVC"] = getCardValidationState(CardValidCallback.Fields.Cvc, cardInputWidgetBinding.cvcEditText)
       cardDetails["validExpiryDate"] = getCardValidationState(CardValidCallback.Fields.Expiry, cardInputWidgetBinding.expiryDateEditText)
+      cardDetails["brand"] = mapCardBrand(cardInputWidgetBinding.cardNumberEditText.cardBrand)
 
       if (isValid) {
         onValidCardChange()


### PR DESCRIPTION
## Summary

return the card brand as soon as we know it, match iOS

## Motivation
fixes https://github.com/stripe/stripe-react-native/issues/714

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
