### PR TITLE
fix: don't aggressively remove payment sheet fragment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Fix build errors on Xcode 14 beta 1 by upgrading `stripe-ios` to `~>22.5.1`. [#1011](https://github.com/stripe/stripe-react-native/pull/1011)
 - Fixed an issue on Android where the `brand` field in `CardField`'s `onCardChange` callback wouldn't be set unless the card details were fully complete. [#1012](https://github.com/stripe/stripe-react-native/pull/1012)
 - Fixed an issue where Payment Sheet would cause crashes on Android if `merchantDisplayName` wasn't provided. [#1015](https://github.com/stripe/stripe-react-native/pull/1015)
+- Fixed a bug on Android where a crash could occur if the PaymentSheet was canceled and opened again. [#1014](https://github.com/stripe/stripe-react-native/pull/1014)
 
 ## 0.13.1 - 2022-06-16
 

--- a/android/src/main/java/com/reactnativestripesdk/PaymentSheetFragment.kt
+++ b/android/src/main/java/com/reactnativestripesdk/PaymentSheetFragment.kt
@@ -102,9 +102,10 @@ class PaymentSheetFragment(
           confirmPromise?.resolve(WritableNativeMap()) ?: run {
             presentPromise?.resolve(WritableNativeMap())
           }
+          // Remove the fragment now, we can be sure it won't be needed again if an intent is successful
+          (context.currentActivity as? AppCompatActivity)?.supportFragmentManager?.beginTransaction()?.remove(this)?.commitAllowingStateLoss()
         }
       }
-      (context.currentActivity as? AppCompatActivity)?.supportFragmentManager?.beginTransaction()?.remove(this)?.commitAllowingStateLoss()
     }
 
     var defaultBillingDetails: PaymentSheet.BillingDetails? = null

--- a/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
+++ b/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
@@ -118,6 +118,10 @@ class StripeSdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJ
   @ReactMethod
   fun initPaymentSheet(params: ReadableMap, promise: Promise) {
     getCurrentActivityOrResolveWithError(promise)?.let { activity ->
+      paymentSheetFragment?.let {
+        // If a payment sheet was already initialized, we want to remove its fragment first
+        activity.supportFragmentManager.beginTransaction().remove(it).commitAllowingStateLoss()
+      }
       paymentSheetFragment = PaymentSheetFragment(reactApplicationContext, promise).also {
         val bundle = toBundleObject(params)
         it.arguments = bundle


### PR DESCRIPTION
## Summary

Previously we would remove the payment sheet fragment after the result callback completed. But if customers cancel and then launch the same payment sheet again, this would cause an issue. Now, if the payment succeeds, we know we can remove the fragment. Otherwise, we don't remove it until a new payment sheet is being initialized (there are never two payment sheets initialized at once)

## Motivation
fixes https://github.com/stripe/stripe-react-native/issues/999

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
