### PR TITLE
[skip actions] resolve with an error if merchantDisplayName isn't provided

### DIFF
--- a/android/src/main/java/com/reactnativestripesdk/PaymentSheetFragment.kt
+++ b/android/src/main/java/com/reactnativestripesdk/PaymentSheetFragment.kt
@@ -49,6 +49,10 @@ class PaymentSheetFragment(
   override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
     super.onViewCreated(view, savedInstanceState)
     val merchantDisplayName = arguments?.getString("merchantDisplayName").orEmpty()
+    if (merchantDisplayName.isEmpty()) {
+      initPromise.resolve(createError(ErrorType.Failed.toString(), "merchantDisplayName cannot be empty or null."))
+      return
+    }
     val customerId = arguments?.getString("customerId").orEmpty()
     val customerEphemeralKeySecret = arguments?.getString("customerEphemeralKeySecret").orEmpty()
     val countryCode = arguments?.getString("merchantCountryCode").orEmpty()

--- a/src/types/PaymentSheet.ts
+++ b/src/types/PaymentSheet.ts
@@ -3,10 +3,11 @@ import type { BillingDetails } from './Common';
 export type SetupParams = ClientSecretParams &
   GooglePayParams &
   ApplePayParams & {
+    /** Your customer-facing business name. On Android, this is required and cannot be an empty string. */
+    merchantDisplayName: string;
     customerId?: string;
     customerEphemeralKeySecret?: string;
     customFlow?: boolean;
-    merchantDisplayName?: string;
     style?: 'alwaysLight' | 'alwaysDark' | 'automatic';
     returnURL?: string;
     defaultBillingDetails?: BillingDetails;


### PR DESCRIPTION


## Summary

`stripe-android` will crash if you pass an empty string to the PaymentSheet.Configuration and then attempt to present the payment sheet, so let's catch that and resolve during the initialization step with an error.


## Motivation

closes https://github.com/stripe/stripe-react-native/issues/980

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one: 
- [x] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
