### PR TITLE
fix: postal code inputs no longer accept characters that are never present in postal codes

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,3 +2,7 @@ lib/typescript/example
 **/__tests__
 **/__fixtures__
 **/__mocks__
+
+/android/src/androidTest/
+/android/src/test/
+/android/build/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@
 
 ### Fixes
 
+- Fixed behavior of `CardField` and `CardForm` on Android to match that on iOS; postal code input no longer accepts characters that are never present in postal codes (anything besides 0-9, a-z, A-Z, hyphens, and whitespace). [#1027](https://github.com/stripe/stripe-react-native/pull/1027).
+
 ## 0.14.0 - 2022-06-30
 
 ### Breaking changes

--- a/android/src/main/java/com/reactnativestripesdk/AuBECSDebitFormView.kt
+++ b/android/src/main/java/com/reactnativestripesdk/AuBECSDebitFormView.kt
@@ -10,6 +10,8 @@ import com.facebook.react.uimanager.events.EventDispatcher
 import com.google.android.material.shape.CornerFamily
 import com.google.android.material.shape.MaterialShapeDrawable
 import com.google.android.material.shape.ShapeAppearanceModel
+import com.reactnativestripesdk.utils.getIntOrNull
+import com.reactnativestripesdk.utils.getValOr
 import com.stripe.android.databinding.BecsDebitWidgetBinding
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.view.BecsDebitWidget

--- a/android/src/main/java/com/reactnativestripesdk/CardFieldView.kt
+++ b/android/src/main/java/com/reactnativestripesdk/CardFieldView.kt
@@ -16,6 +16,8 @@ import com.facebook.react.uimanager.events.EventDispatcher
 import com.google.android.material.shape.CornerFamily
 import com.google.android.material.shape.MaterialShapeDrawable
 import com.google.android.material.shape.ShapeAppearanceModel
+import com.reactnativestripesdk.utils.*
+import com.reactnativestripesdk.utils.mapCardBrand
 import com.stripe.android.core.model.CountryCode
 import com.stripe.android.core.model.CountryUtils
 import com.stripe.android.databinding.CardInputWidgetBinding
@@ -25,7 +27,6 @@ import com.stripe.android.view.CardInputListener
 import com.stripe.android.view.CardInputWidget
 import com.stripe.android.view.CardValidCallback
 import com.stripe.android.view.StripeEditText
-import java.lang.Exception
 
 class CardFieldView(context: ThemedReactContext) : FrameLayout(context) {
   private var mCardWidget: CardInputWidget = CardInputWidget(context)
@@ -205,12 +206,13 @@ class CardFieldView(context: ThemedReactContext) : FrameLayout(context) {
    * We can reliable assume that setPostalCodeEnabled is called before
    * setCountryCode because of the order of the props in CardField.tsx
    */
-  fun setCountryCode(countryCode: String?) {
+  fun setCountryCode(countryString: String?) {
     if (mCardWidget.postalCodeEnabled) {
       val doesCountryUsePostalCode = CountryUtils.doesCountryUsePostalCode(
-        CountryCode.create(value = countryCode ?: LocaleListCompat.getAdjustedDefault()[0].country)
+        CountryCode.create(value = countryString ?: LocaleListCompat.getAdjustedDefault()[0].country)
       )
       mCardWidget.postalCodeRequired = doesCountryUsePostalCode
+      setPostalCodeFilter()
     }
   }
 
@@ -334,6 +336,13 @@ class CardFieldView(context: ThemedReactContext) : FrameLayout(context) {
         }
       }
     })
+  }
+
+  private fun setPostalCodeFilter() {
+    cardInputWidgetBinding.postalCodeEditText.filters = arrayOf(
+      *cardInputWidgetBinding.postalCodeEditText.filters,
+      PostalCodeUtilities.createPostalCodeInputFilter()
+    )
   }
 
   override fun requestLayout() {

--- a/android/src/main/java/com/reactnativestripesdk/CardFieldView.kt
+++ b/android/src/main/java/com/reactnativestripesdk/CardFieldView.kt
@@ -347,9 +347,9 @@ class CardFieldView(context: ThemedReactContext) : FrameLayout(context) {
   private fun createPostalCodeInputFilter(countryCode: CountryCode): InputFilter {
     return InputFilter { charSequence, start, end, _, _, _ ->
       for (i in start until end) {
-        if (countryCode == CountryCode.US && !PostalCodeUtilities.isValidUsPostalCodeCharacter(charSequence[i])) {
-          return@InputFilter ""
-        } else if (!PostalCodeUtilities.isValidGlobalPostalCodeCharacter(charSequence[i])) {
+        val isValidCharacter = (countryCode == CountryCode.US && PostalCodeUtilities.isValidUsPostalCodeCharacter(charSequence[i])) ||
+          (countryCode != CountryCode.US && PostalCodeUtilities.isValidGlobalPostalCodeCharacter(charSequence[i]))
+        if (!isValidCharacter) {
           return@InputFilter ""
         }
       }

--- a/android/src/main/java/com/reactnativestripesdk/CardFormView.kt
+++ b/android/src/main/java/com/reactnativestripesdk/CardFormView.kt
@@ -14,6 +14,8 @@ import com.facebook.react.uimanager.events.EventDispatcher
 import com.google.android.material.shape.CornerFamily
 import com.google.android.material.shape.MaterialShapeDrawable
 import com.google.android.material.shape.ShapeAppearanceModel
+import com.reactnativestripesdk.utils.*
+import com.reactnativestripesdk.utils.mapCardBrand
 import com.stripe.android.core.model.CountryCode
 import com.stripe.android.databinding.CardMultilineWidgetBinding
 import com.stripe.android.databinding.StripeCardFormViewBinding
@@ -38,6 +40,7 @@ class CardFormView(context: ThemedReactContext) : FrameLayout(context) {
 
     addView(cardForm)
     setListeners()
+    setPostalCodeFilter()
 
     viewTreeObserver.addOnGlobalLayoutListener { requestLayout() }
   }
@@ -252,6 +255,13 @@ class CardFormView(context: ThemedReactContext) : FrameLayout(context) {
       currentFocusedField = if (hasFocus) CardInputListener.FocusField.PostalCode.toString() else  null
       onChangeFocus()
     }
+  }
+
+  private fun setPostalCodeFilter() {
+    multilineWidgetBinding.etPostalCode.filters = arrayOf(
+      *multilineWidgetBinding.etPostalCode.filters,
+      PostalCodeUtilities.createPostalCodeInputFilter()
+    )
   }
 
   override fun requestLayout() {

--- a/android/src/main/java/com/reactnativestripesdk/CardFormView.kt
+++ b/android/src/main/java/com/reactnativestripesdk/CardFormView.kt
@@ -272,6 +272,7 @@ class CardFormView(context: ThemedReactContext) : FrameLayout(context) {
   private fun createPostalCodeInputFilter(): InputFilter {
     return InputFilter { charSequence, start, end, _, _, _ ->
       if (cardFormViewBinding.countryLayout.getSelectedCountryCode() == CountryCode.US) {
+        // Rely on CardFormView's built-in US postal code filter
         return@InputFilter null
       }
 

--- a/android/src/main/java/com/reactnativestripesdk/CollectBankAccountLauncherFragment.kt
+++ b/android/src/main/java/com/reactnativestripesdk/CollectBankAccountLauncherFragment.kt
@@ -9,6 +9,11 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
+import com.reactnativestripesdk.utils.*
+import com.reactnativestripesdk.utils.createError
+import com.reactnativestripesdk.utils.createResult
+import com.reactnativestripesdk.utils.mapFromPaymentIntentResult
+import com.reactnativestripesdk.utils.mapFromSetupIntentResult
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.SetupIntent
 import com.stripe.android.model.StripeIntent

--- a/android/src/main/java/com/reactnativestripesdk/GooglePayFragment.kt
+++ b/android/src/main/java/com/reactnativestripesdk/GooglePayFragment.kt
@@ -8,6 +8,10 @@ import android.widget.FrameLayout
 import androidx.fragment.app.Fragment
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.WritableNativeMap
+import com.reactnativestripesdk.utils.GooglePayErrorType
+import com.reactnativestripesdk.utils.createError
+import com.reactnativestripesdk.utils.createResult
+import com.reactnativestripesdk.utils.mapFromPaymentMethod
 import com.stripe.android.googlepaylauncher.GooglePayEnvironment
 import com.stripe.android.googlepaylauncher.GooglePayLauncher
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher

--- a/android/src/main/java/com/reactnativestripesdk/PaymentLauncherFragment.kt
+++ b/android/src/main/java/com/reactnativestripesdk/PaymentLauncherFragment.kt
@@ -9,6 +9,9 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
+import com.reactnativestripesdk.utils.*
+import com.reactnativestripesdk.utils.createError
+import com.reactnativestripesdk.utils.createMissingActivityError
 import com.stripe.android.ApiResultCallback
 import com.stripe.android.Stripe
 import com.stripe.android.model.*

--- a/android/src/main/java/com/reactnativestripesdk/PaymentMethodCreateParamsFactory.kt
+++ b/android/src/main/java/com/reactnativestripesdk/PaymentMethodCreateParamsFactory.kt
@@ -1,6 +1,10 @@
 package com.reactnativestripesdk
 
 import com.facebook.react.bridge.ReadableMap
+import com.reactnativestripesdk.utils.*
+import com.reactnativestripesdk.utils.mapToBillingDetails
+import com.reactnativestripesdk.utils.mapToUSBankAccountHolderType
+import com.reactnativestripesdk.utils.mapToUSBankAccountType
 import com.stripe.android.model.*
 
 class PaymentMethodCreateParamsFactory(

--- a/android/src/main/java/com/reactnativestripesdk/PaymentSheetAppearance.kt
+++ b/android/src/main/java/com/reactnativestripesdk/PaymentSheetAppearance.kt
@@ -2,6 +2,7 @@ package com.reactnativestripesdk
 
 import android.graphics.Color
 import android.os.Bundle
+import com.reactnativestripesdk.utils.PaymentSheetAppearanceException
 import com.stripe.android.paymentsheet.PaymentSheet
 
 fun PaymentSheetFragment.buildPaymentSheetAppearance(userParams: Bundle?): PaymentSheet.Appearance {

--- a/android/src/main/java/com/reactnativestripesdk/PaymentSheetFragment.kt
+++ b/android/src/main/java/com/reactnativestripesdk/PaymentSheetFragment.kt
@@ -18,6 +18,9 @@ import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.WritableMap
 import com.facebook.react.bridge.WritableNativeMap
+import com.reactnativestripesdk.utils.*
+import com.reactnativestripesdk.utils.createError
+import com.reactnativestripesdk.utils.createResult
 import com.stripe.android.paymentsheet.PaymentOptionCallback
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetResult

--- a/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
+++ b/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
@@ -8,6 +8,9 @@ import androidx.appcompat.app.AppCompatActivity
 import com.facebook.react.bridge.*
 import com.facebook.react.module.annotations.ReactModule
 import com.reactnativestripesdk.pushprovisioning.PushProvisioningProxy
+import com.reactnativestripesdk.utils.*
+import com.reactnativestripesdk.utils.createError
+import com.reactnativestripesdk.utils.createMissingActivityError
 import com.stripe.android.*
 import com.stripe.android.core.ApiVersion
 import com.stripe.android.core.AppInfo

--- a/android/src/main/java/com/reactnativestripesdk/pushprovisioning/AddToWalletButtonView.kt
+++ b/android/src/main/java/com/reactnativestripesdk/pushprovisioning/AddToWalletButtonView.kt
@@ -17,7 +17,7 @@ import com.facebook.react.bridge.WritableMap
 import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.UIManagerModule
 import com.facebook.react.uimanager.events.EventDispatcher
-import com.reactnativestripesdk.createError
+import com.reactnativestripesdk.utils.createError
 
 
 class AddToWalletButtonView(private val context: ThemedReactContext, private val requestManager: RequestManager) : AppCompatImageView(context) {

--- a/android/src/main/java/com/reactnativestripesdk/pushprovisioning/PushProvisioningProxy.kt
+++ b/android/src/main/java/com/reactnativestripesdk/pushprovisioning/PushProvisioningProxy.kt
@@ -9,8 +9,8 @@ import android.util.Log
 import com.facebook.react.bridge.BaseActivityEventListener
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReadableMap
-import com.reactnativestripesdk.createError
-import com.reactnativestripesdk.mapError
+import com.reactnativestripesdk.utils.createError
+import com.reactnativestripesdk.utils.mapError
 import com.stripe.android.pushProvisioning.PushProvisioningActivity
 import com.stripe.android.pushProvisioning.PushProvisioningActivityStarter
 

--- a/android/src/main/java/com/reactnativestripesdk/pushprovisioning/TapAndPayProxy.kt
+++ b/android/src/main/java/com/reactnativestripesdk/pushprovisioning/TapAndPayProxy.kt
@@ -5,7 +5,7 @@ import android.util.Log
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.WritableMap
 import com.facebook.react.bridge.WritableNativeMap
-import com.reactnativestripesdk.createError
+import com.reactnativestripesdk.utils.createError
 import com.google.android.gms.tasks.Task
 
 typealias TokenCheckHandler = (isCardInWallet: Boolean, token: WritableMap?, error: WritableMap?) -> Unit

--- a/android/src/main/java/com/reactnativestripesdk/utils/Errors.kt
+++ b/android/src/main/java/com/reactnativestripesdk/utils/Errors.kt
@@ -1,4 +1,4 @@
-package com.reactnativestripesdk
+package com.reactnativestripesdk.utils
 
 import com.facebook.react.bridge.WritableMap
 import com.facebook.react.bridge.WritableNativeMap

--- a/android/src/main/java/com/reactnativestripesdk/utils/Extensions.kt
+++ b/android/src/main/java/com/reactnativestripesdk/utils/Extensions.kt
@@ -1,4 +1,4 @@
-package com.reactnativestripesdk
+package com.reactnativestripesdk.utils
 
 import android.content.Context
 import android.view.View

--- a/android/src/main/java/com/reactnativestripesdk/utils/Mappers.kt
+++ b/android/src/main/java/com/reactnativestripesdk/utils/Mappers.kt
@@ -1,4 +1,4 @@
-package com.reactnativestripesdk
+package com.reactnativestripesdk.utils
 
 import android.os.Bundle
 import android.util.Log

--- a/android/src/main/java/com/reactnativestripesdk/utils/PostalCodeUtilities.kt
+++ b/android/src/main/java/com/reactnativestripesdk/utils/PostalCodeUtilities.kt
@@ -1,0 +1,27 @@
+package com.reactnativestripesdk.utils
+
+import android.text.InputFilter
+
+class PostalCodeUtilities {
+
+  companion object {
+
+    fun createPostalCodeInputFilter(): InputFilter {
+      return InputFilter { charSequence, start, end, _, _, _ ->
+        for (i in start until end) {
+          if (!isValidPostalCodeCharacter(charSequence[i])) {
+            return@InputFilter ""
+          }
+        }
+        return@InputFilter null
+      }
+    }
+
+    private fun isValidPostalCodeCharacter(c: Char): Boolean {
+      return Character.isLetterOrDigit(c)
+        || c.isWhitespace()
+        || c == '-'
+    }
+  }
+
+}

--- a/android/src/main/java/com/reactnativestripesdk/utils/PostalCodeUtilities.kt
+++ b/android/src/main/java/com/reactnativestripesdk/utils/PostalCodeUtilities.kt
@@ -1,27 +1,18 @@
 package com.reactnativestripesdk.utils
 
-import android.text.InputFilter
-
 class PostalCodeUtilities {
 
   companion object {
-
-    fun createPostalCodeInputFilter(): InputFilter {
-      return InputFilter { charSequence, start, end, _, _, _ ->
-        for (i in start until end) {
-          if (!isValidPostalCodeCharacter(charSequence[i])) {
-            return@InputFilter ""
-          }
-        }
-        return@InputFilter null
-      }
-    }
-
-    private fun isValidPostalCodeCharacter(c: Char): Boolean {
+    internal fun isValidGlobalPostalCodeCharacter(c: Char): Boolean {
       return Character.isLetterOrDigit(c)
         || c.isWhitespace()
         || c == '-'
     }
-  }
 
+    internal fun isValidUsPostalCodeCharacter(c: Char): Boolean {
+      return Character.isDigit(c)
+        || c.isWhitespace()
+        || c == '-'
+    }
+  }
 }


### PR DESCRIPTION
## Summary

Adds InputFilters to postal code edit texts for CardForm and CardField.

https://en.wikipedia.org/wiki/Postal_code#Character_sets

Also created a utils/ directory in the android source in this PR just to clean up a bit as we go

## Motivation

fixes a bug, makes behavior consistent with iOS

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
