### PR TITLE
feat: add payment method: affirm

### DIFF
--- a/android/src/main/java/com/reactnativestripesdk/utils/Mappers.kt
+++ b/android/src/main/java/com/reactnativestripesdk/utils/Mappers.kt
@@ -124,6 +124,7 @@ internal fun mapPaymentMethodType(type: PaymentMethod.Type?): String {
     PaymentMethod.Type.Klarna -> "Klarna"
     PaymentMethod.Type.USBankAccount -> "USBankAccount"
     PaymentMethod.Type.PayPal -> "PayPal"
+    PaymentMethod.Type.Affirm -> "Affirm"
     else -> "Unknown"
   }
 }
@@ -152,6 +153,7 @@ internal fun mapToPaymentMethodType(type: String?): PaymentMethod.Type? {
     "Klarna" -> PaymentMethod.Type.Klarna
     "USBankAccount" -> PaymentMethod.Type.USBankAccount
     "PayPal" -> PaymentMethod.Type.PayPal
+    "Affirm" -> PaymentMethod.Type.Affirm
     else -> null
   }
 }

--- a/docs/accept-a-payment-multiline-card.md
+++ b/docs/accept-a-payment-multiline-card.md
@@ -85,7 +85,7 @@ function PaymentScreen() {
       },
       body: JSON.stringify({
         currency: 'usd',
-        items: [{ id: 'id' }],
+        items: ['id-1'],
       }),
     });
     const { clientSecret } = await response.json();

--- a/docs/wechat-pay.md
+++ b/docs/wechat-pay.md
@@ -135,7 +135,7 @@ function PaymentScreen() {
       },
       body: JSON.stringify({
         currency: 'usd',
-        items: [{ id: 'id' }],
+        items: ['id-1'],
       }),
     });
     const { clientSecret } = await response.json();

--- a/e2e/buyNowPayLater.test.ts
+++ b/e2e/buyNowPayLater.test.ts
@@ -26,6 +26,19 @@ describe('Payment scenarios with redirects', () => {
     BasicPaymentScreen.checkStatus();
   });
 
+  it('Affirm payment scenario', function () {
+    this.retries(3);
+
+    homeScreen.goTo('Buy now pay later');
+    homeScreen.goTo('Affirm');
+
+    $('~payment-screen').waitForDisplayed({ timeout: 30000 });
+
+    BasicPaymentScreen.pay({ email: 'test@stripe.com' });
+    BasicPaymentScreen.authorize({ pause: 10000 });
+    BasicPaymentScreen.checkStatus();
+  });
+
   it('Opens Klarna webview', function () {
     this.retries(3);
 

--- a/e2e/screenObject/HomeScreen.ts
+++ b/e2e/screenObject/HomeScreen.ts
@@ -37,6 +37,7 @@ const SCREENS = <const>[
   'WeChat Pay',
   'ACH payment',
   'ACH setup',
+  'Affirm',
 ];
 
 class HomeScreen {

--- a/example/server/index.ts
+++ b/example/server/index.ts
@@ -32,15 +32,20 @@ app.use(
 );
 
 // tslint:disable-next-line: interface-name
-interface Order {
-  items: object[];
-}
+const itemIdToPrice: { [id: string]: number } = {
+  'id-1': 1400,
+  'id-2': 2000,
+  'id-3': 3000,
+  'id-4': 4000,
+  'id-5': 5000,
+};
 
-const calculateOrderAmount = (_order?: Order): number => {
-  // Replace this constant with a calculation of the order's amount.
-  // Calculate the order total on the server to prevent
-  // people from directly manipulating the amount on the client.
-  return 1400;
+const calculateOrderAmount = (itemIds: string[] = ['id-1']): number => {
+  const total = itemIds
+    .map((id) => itemIdToPrice[id])
+    .reduce((prev, curr) => prev + curr, 0);
+
+  return total;
 };
 
 function getKeys(payment_method?: string) {
@@ -97,7 +102,7 @@ app.post(
       client = 'ios',
     }: {
       email: string;
-      items: Order;
+      items: string[];
       currency: string;
       payment_method_types: string[];
       request_three_d_secure: 'any' | 'automatic';
@@ -159,7 +164,7 @@ app.post(
       request_three_d_secure,
       email,
     }: {
-      items: Order;
+      items: string[];
       currency: string;
       request_three_d_secure: 'any' | 'automatic';
       email: string;
@@ -235,7 +240,7 @@ app.post(
       paymentMethodId?: string;
       paymentIntentId?: string;
       cvcToken?: string;
-      items: Order;
+      items: string[];
       currency: string;
       useStripeSdk: boolean;
       email?: string;

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -38,6 +38,7 @@ import GooglePayScreen from './screens/GooglePayScreen';
 import ACHPaymentScreen from './screens/ACHPaymentScreen';
 import ACHSetupScreen from './screens/ACHSetupScreen';
 import PayPalScreen from './screens/PayPalScreen';
+import AffirmScreen from './screens/AffirmScreen';
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
 
@@ -77,6 +78,7 @@ export type RootStackParamList = {
   ACHPaymentScreen: undefined;
   ACHSetupScreen: undefined;
   PayPalScreen: undefined;
+  AffirmScreen: undefined;
 };
 
 declare global {
@@ -218,6 +220,7 @@ export default function App() {
           <Stack.Screen name="ACHPaymentScreen" component={ACHPaymentScreen} />
           <Stack.Screen name="ACHSetupScreen" component={ACHSetupScreen} />
           <Stack.Screen name="PayPalScreen" component={PayPalScreen} />
+          <Stack.Screen name="AffirmScreen" component={AffirmScreen} />
         </Stack.Navigator>
       </NavigationContainer>
     </>

--- a/example/src/screens/ACHPaymentScreen.tsx
+++ b/example/src/screens/ACHPaymentScreen.tsx
@@ -32,7 +32,7 @@ export default function ACHPaymentScreen() {
       body: JSON.stringify({
         email: email,
         currency: 'usd',
-        items: [{ id: 'id' }],
+        items: ['id-1'],
         payment_method_types: ['us_bank_account'],
       }),
     });

--- a/example/src/screens/AffirmScreen.tsx
+++ b/example/src/screens/AffirmScreen.tsx
@@ -1,0 +1,121 @@
+import type { PaymentMethod } from '@stripe/stripe-react-native';
+import React, { useState } from 'react';
+import { Alert, TextInput, StyleSheet } from 'react-native';
+import {
+  useConfirmPayment,
+  createPaymentMethod,
+} from '@stripe/stripe-react-native';
+import Button from '../components/Button';
+import PaymentScreen from '../components/PaymentScreen';
+import { API_URL } from '../Config';
+import { colors } from '../colors';
+
+export default function AffirmScreen() {
+  const [email, setEmail] = useState('');
+  const { confirmPayment, loading } = useConfirmPayment();
+
+  const fetchPaymentIntentClientSecret = async () => {
+    const response = await fetch(`${API_URL}/create-payment-intent`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        email,
+        currency: 'usd',
+        items: ['id-5'],
+        payment_method_types: ['affirm'],
+      }),
+    });
+    const { clientSecret, error } = await response.json();
+
+    return { clientSecret, error };
+  };
+
+  const handlePayPress = async () => {
+    const { clientSecret, error: clientSecretError } =
+      await fetchPaymentIntentClientSecret();
+
+    if (clientSecretError) {
+      Alert.alert(`Error`, clientSecretError);
+      return;
+    }
+
+    const shippingDetails: PaymentMethod.ShippingDetails = {
+      address: {
+        city: 'Houston',
+        country: 'US',
+        line1: '1459 Circle Drive',
+        postalCode: '77063',
+        state: 'Texas',
+      },
+      name: 'John Doe',
+    };
+
+    console.log('hi');
+    const { error, paymentIntent } = await confirmPayment(clientSecret, {
+      paymentMethodType: 'Affirm',
+      paymentMethodData: {
+        shippingDetails,
+      },
+    });
+
+    if (error) {
+      Alert.alert(`Error code: ${error.code}`, error.message);
+      console.log('Payment confirmation error', error.message);
+    } else if (paymentIntent) {
+      Alert.alert(
+        'Success',
+        `The payment was confirmed successfully! currency: ${paymentIntent.currency}`
+      );
+    }
+  };
+
+  const handleCreatePaymentMethodPress = async () => {
+    const { paymentMethod, error } = await createPaymentMethod({
+      paymentMethodType: 'Affirm',
+    });
+
+    if (error) {
+      Alert.alert(`Error code: ${error.code}`, error.message);
+      return;
+    } else {
+      Alert.alert('Success', `Payment method id: ${paymentMethod?.id}`);
+    }
+  };
+
+  return (
+    <PaymentScreen>
+      <TextInput
+        autoCapitalize="none"
+        placeholder="E-mail"
+        keyboardType="email-address"
+        onChange={(value) => setEmail(value.nativeEvent.text)}
+        style={styles.input}
+      />
+      <Button
+        variant="primary"
+        onPress={handlePayPress}
+        title="Pay"
+        accessibilityLabel="Pay"
+        loading={loading}
+      />
+      <Button
+        variant="primary"
+        onPress={handleCreatePaymentMethodPress}
+        title="Create payment method"
+        accessibilityLabel="Create payment method"
+        loading={loading}
+      />
+    </PaymentScreen>
+  );
+}
+
+const styles = StyleSheet.create({
+  input: {
+    height: 44,
+    borderBottomColor: colors.slate,
+    borderBottomWidth: 1.5,
+    marginBottom: 20,
+  },
+});

--- a/example/src/screens/AfterpayClearpayPaymentScreen.tsx
+++ b/example/src/screens/AfterpayClearpayPaymentScreen.tsx
@@ -23,7 +23,7 @@ export default function AfterpayClearpayPaymentScreen() {
       body: JSON.stringify({
         email,
         currency: 'usd',
-        items: [{ id: 'id' }],
+        items: ['id-1'],
         payment_method_types: ['afterpay_clearpay'],
       }),
     });

--- a/example/src/screens/AlipayPaymentScreen.tsx
+++ b/example/src/screens/AlipayPaymentScreen.tsx
@@ -19,7 +19,7 @@ export default function AlipayPaymentScreen() {
       body: JSON.stringify({
         email,
         currency: 'usd',
-        items: [{ id: 'id' }],
+        items: ['id-1'],
         payment_method_types: ['alipay'],
       }),
     });

--- a/example/src/screens/AuBECSDebitPaymentScreen.tsx
+++ b/example/src/screens/AuBECSDebitPaymentScreen.tsx
@@ -24,7 +24,7 @@ export default function AuBECSDebitPaymentScreen() {
       body: JSON.stringify({
         email: formDetails?.email,
         currency: 'aud',
-        items: [{ id: 'id' }],
+        items: ['id-1'],
         payment_method_types: ['au_becs_debit'],
       }),
     });

--- a/example/src/screens/BancontactPaymentScreen.tsx
+++ b/example/src/screens/BancontactPaymentScreen.tsx
@@ -21,7 +21,7 @@ export default function BancontactPaymentScreen() {
       body: JSON.stringify({
         email,
         currency: 'eur',
-        items: [{ id: 'id' }],
+        items: ['id-1'],
         request_three_d_secure: 'any',
         payment_method_types: ['bancontact'],
       }),

--- a/example/src/screens/CVCReCollectionScreen.tsx
+++ b/example/src/screens/CVCReCollectionScreen.tsx
@@ -23,7 +23,7 @@ export default function CVCReCollectionScreen() {
         },
         body: JSON.stringify({
           currency: 'usd',
-          items: [{ id: 'id' }],
+          items: ['id-1'],
           request_three_d_secure: 'any',
           // e-mail of the customer which has set up payment method
           email,
@@ -39,7 +39,7 @@ export default function CVCReCollectionScreen() {
     useStripeSdk: boolean;
     cvcToken: string;
     currency: string;
-    items: { id: string }[];
+    items: string[];
     email: string;
   }) => {
     const response = await fetch(`${API_URL}/pay-without-webhooks`, {
@@ -106,7 +106,7 @@ export default function CVCReCollectionScreen() {
       const paymentIntent = await callNoWebhookPayEndpoint({
         useStripeSdk: true,
         currency: 'usd',
-        items: [{ id: 'id' }],
+        items: ['id-1'],
         cvcToken: tokenId,
         email,
       });

--- a/example/src/screens/EPSPaymentScreen.tsx
+++ b/example/src/screens/EPSPaymentScreen.tsx
@@ -20,7 +20,7 @@ export default function EPSPaymentScreen() {
       body: JSON.stringify({
         email,
         currency: 'eur',
-        items: [{ id: 'id' }],
+        items: ['id-1'],
         payment_method_types: ['eps'],
       }),
     });

--- a/example/src/screens/FPXPaymentScreen.tsx
+++ b/example/src/screens/FPXPaymentScreen.tsx
@@ -19,7 +19,7 @@ export default function FPXPaymentScreen() {
       body: JSON.stringify({
         email,
         currency: 'myr',
-        items: [{ id: 'id' }],
+        items: ['id-1'],
         request_three_d_secure: 'any',
         payment_method_types: ['fpx'],
       }),

--- a/example/src/screens/GiropayPaymentScreen.tsx
+++ b/example/src/screens/GiropayPaymentScreen.tsx
@@ -20,7 +20,7 @@ export default function GiropayPaymentScreen() {
       body: JSON.stringify({
         email,
         currency: 'eur',
-        items: [{ id: 'id' }],
+        items: ['id-1'],
         payment_method_types: ['giropay'],
       }),
     });

--- a/example/src/screens/GooglePayScreen.tsx
+++ b/example/src/screens/GooglePayScreen.tsx
@@ -78,7 +78,7 @@ export default function GooglePayScreen() {
       },
       body: JSON.stringify({
         currency: 'usd',
-        items: [{ id: 'id' }],
+        items: ['id-1'],
         force3dSecure: true,
       }),
     });

--- a/example/src/screens/GrabPayPaymentScreen.tsx
+++ b/example/src/screens/GrabPayPaymentScreen.tsx
@@ -20,7 +20,7 @@ export default function GrabPayPaymentScreen() {
       body: JSON.stringify({
         email,
         currency: 'myr',
-        items: [{ id: 'id' }],
+        items: ['id-1'],
         request_three_d_secure: 'any',
         payment_method_types: ['grabpay'],
       }),

--- a/example/src/screens/HomeScreen.tsx
+++ b/example/src/screens/HomeScreen.tsx
@@ -292,6 +292,14 @@ export default function HomeScreen() {
               }}
             />
           </View>
+          <View style={styles.buttonContainer}>
+            <Button
+              title="Affirm"
+              onPress={() => {
+                navigation.navigate('AffirmScreen');
+              }}
+            />
+          </View>
         </>
       </Collapse>
 

--- a/example/src/screens/IdealPaymentScreen.tsx
+++ b/example/src/screens/IdealPaymentScreen.tsx
@@ -23,7 +23,7 @@ export default function IdealPaymentScreen() {
       body: JSON.stringify({
         email,
         currency: 'eur',
-        items: [{ id: 'id' }],
+        items: ['id-1'],
         request_three_d_secure: 'any',
         payment_method_types: ['ideal'],
       }),

--- a/example/src/screens/KlarnaPaymentScreen.tsx
+++ b/example/src/screens/KlarnaPaymentScreen.tsx
@@ -19,7 +19,7 @@ export default function KlarnaPaymentScreen() {
       body: JSON.stringify({
         email,
         currency: 'usd',
-        items: [{ id: 'id' }],
+        items: ['id-1'],
         payment_method_types: ['klarna'],
       }),
     });

--- a/example/src/screens/MultilineWebhookPaymentScreen.tsx
+++ b/example/src/screens/MultilineWebhookPaymentScreen.tsx
@@ -31,7 +31,7 @@ export default function MultilineWebhookPaymentScreen() {
       body: JSON.stringify({
         email,
         currency: 'usd',
-        items: [{ id: 'id' }],
+        items: ['id-1'],
         // request_three_d_secure: 'any',
       }),
     });

--- a/example/src/screens/NoWebhookPaymentScreen.tsx
+++ b/example/src/screens/NoWebhookPaymentScreen.tsx
@@ -16,7 +16,7 @@ export default function NoWebhookPaymentScreen() {
           useStripeSdk: boolean;
           paymentMethodId: string;
           currency: string;
-          items: { id: string }[];
+          items: string[];
         }
       | { paymentIntentId: string }
   ) => {
@@ -81,7 +81,7 @@ export default function NoWebhookPaymentScreen() {
       useStripeSdk: true,
       paymentMethodId: paymentMethod.id,
       currency: 'usd', // mocked data
-      items: [{ id: 'id' }],
+      items: ['id-1'],
     });
 
     const {

--- a/example/src/screens/OxxoPaymentScreen.tsx
+++ b/example/src/screens/OxxoPaymentScreen.tsx
@@ -20,7 +20,7 @@ export default function OxxoPaymentScreen() {
       body: JSON.stringify({
         email,
         currency: 'mxn',
-        items: [{ id: 'id' }],
+        items: ['id-1'],
         request_three_d_secure: 'any',
         payment_method_types: ['oxxo'],
       }),

--- a/example/src/screens/P24PaymentScreen.tsx
+++ b/example/src/screens/P24PaymentScreen.tsx
@@ -20,7 +20,7 @@ export default function P24PaymentScreen() {
       body: JSON.stringify({
         email,
         currency: 'pln',
-        items: [{ id: 'id' }],
+        items: ['id-1'],
         payment_method_types: ['p24'],
       }),
     });

--- a/example/src/screens/SepaPaymentScreen.tsx
+++ b/example/src/screens/SepaPaymentScreen.tsx
@@ -22,7 +22,7 @@ export default function SepaPaymentScreen() {
       body: JSON.stringify({
         email,
         currency: 'eur',
-        items: [{ id: 'id' }],
+        items: ['id-1'],
         payment_method_types: ['sepa_debit'],
       }),
     });

--- a/example/src/screens/SofortPaymentScreen.tsx
+++ b/example/src/screens/SofortPaymentScreen.tsx
@@ -24,7 +24,7 @@ export default function SofortPaymentScreen() {
       body: JSON.stringify({
         email,
         currency: 'eur',
-        items: [{ id: 'id' }],
+        items: ['id-1'],
         payment_method_types: ['sofort'],
       }),
     });

--- a/example/src/screens/WebhookPaymentScreen.tsx
+++ b/example/src/screens/WebhookPaymentScreen.tsx
@@ -25,7 +25,7 @@ export default function WebhookPaymentScreen() {
       body: JSON.stringify({
         email,
         currency: 'usd',
-        items: [{ id: 'id' }],
+        items: ['id-1'],
         // request_three_d_secure: 'any',
       }),
     });

--- a/ios/Mappers.swift
+++ b/ios/Mappers.swift
@@ -276,6 +276,7 @@ class Mappers {
         case STPPaymentMethodType.klarna: return "Klarna"
         case STPPaymentMethodType.USBankAccount: return "USBankAccount"
         case STPPaymentMethodType.payPal: return "PayPal"
+        case STPPaymentMethodType.affirm: return "Affirm"
         case STPPaymentMethodType.unknown: return "Unknown"
         default: return "Unknown"
         }
@@ -305,6 +306,7 @@ class Mappers {
             case "WeChatPay": return STPPaymentMethodType.weChatPay
             case "USBankAccount": return STPPaymentMethodType.USBankAccount
             case "PayPal": return STPPaymentMethodType.payPal
+            case "Affirm": return STPPaymentMethodType.affirm
             default: return STPPaymentMethodType.unknown
             }
         }

--- a/ios/PaymentMethodFactory.swift
+++ b/ios/PaymentMethodFactory.swift
@@ -53,6 +53,8 @@ class PaymentMethodFactory {
                 return try createUSBankAccountPaymentMethodParams()
             case STPPaymentMethodType.payPal:
                 return try createPayPalPaymentMethodParams()
+            case STPPaymentMethodType.affirm:
+                return try createAffirmPaymentMethodParams()
 //            case STPPaymentMethodType.weChatPay:
 //                return try createWeChatPayPaymentMethodParams()
             default:
@@ -101,6 +103,8 @@ class PaymentMethodFactory {
             case STPPaymentMethodType.USBankAccount:
                 return try createUSBankAccountPaymentMethodOptions()
             case STPPaymentMethodType.payPal:
+                return nil
+            case STPPaymentMethodType.affirm:
                 return nil
             default:
                 throw PaymentMethodError.paymentNotSupported
@@ -360,6 +364,11 @@ class PaymentMethodFactory {
     
     private func createPayPalPaymentMethodParams() throws -> STPPaymentMethodParams {
         return STPPaymentMethodParams(payPal: STPPaymentMethodPayPalParams(), billingDetails: billingDetailsParams, metadata: nil)
+    }
+    
+    private func createAffirmPaymentMethodParams() throws -> STPPaymentMethodParams {
+        let params = STPPaymentMethodAffirmParams()
+        return STPPaymentMethodParams(affirm: params, metadata: nil)
     }
 }
 

--- a/src/types/PaymentMethod.ts
+++ b/src/types/PaymentMethod.ts
@@ -42,7 +42,8 @@ export type CreateParams =
   // | WeChatPayParams
   | BancontactParams
   | USBankAccountParams
-  | PayPalParams;
+  | PayPalParams
+  | AffirmParams;
 
 export type ConfirmParams = CreateParams;
 
@@ -174,6 +175,15 @@ export interface AuBecsDebitParams {
   paymentMethodType: 'AuBecsDebit';
   paymentMethodData: { formDetails: FormDetails };
 }
+
+export type AffirmParams = {
+  paymentMethodType: 'Affirm';
+  paymentMethodData?: {
+    /** Affirm requires that shipping is present for the payment to succeed because it significantly helps with loan approval rates. Shipping details can either be provided here or via the Payment Intent- https://stripe.com/docs/api/payment_intents/create#create_payment_intent-shipping. */
+    shippingDetails?: ShippingDetails;
+    billingDetails?: BillingDetails;
+  };
+};
 
 /**
  * If paymentMethodData is null, it is assumed that the bank account details have already been attached


### PR DESCRIPTION
## Summary

Adds affirm payment method to bindings (for confirming a payment intent and creating a payment method)

## Motivation

replaces https://github.com/stripe/stripe-react-native/pull/825
closes https://github.com/stripe/stripe-react-native/issues/984

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [x] I added automated tests

## Documentation

Select one: 
- [x] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
