### PR TITLE
fix: ensure all promises are only ever resolved once to fix older versions of react native

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 ### Fixes
 
 - Fixed behavior of `CardField` and `CardForm` on Android to match that on iOS; postal code input no longer accepts characters that are never present in postal codes (anything besides 0-9, a-z, A-Z, hyphens, and whitespace). [#1027](https://github.com/stripe/stripe-react-native/pull/1027).
+- Fixed an issue on older version of React Native where calling `collectBankAccountForSetup` or `collectBankAccountForPayment` and getting a `Canceled` result could cause a crash. [#1037](https://github.com/stripe/stripe-react-native/pull/1037)
 
 ## 0.14.0 - 2022-06-30
 

--- a/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
+++ b/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
@@ -177,7 +177,7 @@ class StripeSdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJ
           )
         } else {
           Log.e("StripeReactNative", "FPX payment failed. Promise and/or client secret is not set.")
-          confirmPromise?.resolve(createError(ConfirmPaymentErrorType.Failed.toString(), "FPX payment failed."))
+          confirmPromise?.resolve(createError(ConfirmPaymentErrorType.Failed.toString(), "FPX payment failed. Client secret is not set."))
         }
       }
       is AddPaymentMethodActivityStarter.Result.Failure -> {
@@ -551,12 +551,13 @@ class StripeSdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJ
 
     getCurrentActivityOrResolveWithError(promise)?.let {
       PushProvisioningProxy.isCardInWallet(it, last4) { isCardInWallet, token, error ->
-        if (error != null) {
-          promise.resolve(createCanAddCardResult(false, "MISSING_CONFIGURATION", null))
-        } else {
+        val result = error?.let {
+          createCanAddCardResult(false, "MISSING_CONFIGURATION", null)
+        } ?: run {
           val status = if (isCardInWallet) "CARD_ALREADY_EXISTS" else null
-          promise.resolve(createCanAddCardResult(!isCardInWallet, status, token))
+          createCanAddCardResult(!isCardInWallet, status, token)
         }
+        promise.resolve(result)
       }
     }
   }
@@ -569,14 +570,12 @@ class StripeSdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJ
     }
     getCurrentActivityOrResolveWithError(promise)?.let {
       PushProvisioningProxy.isCardInWallet(it, last4) { isCardInWallet, token, error ->
-        if (error != null) {
-          promise.resolve(error)
-        } else {
-          val result = WritableNativeMap()
-          result.putBoolean("isInWallet", isCardInWallet)
-          result.putMap("token", token)
-          promise.resolve(result)
+        val result = error ?: run {
+          val map = WritableNativeMap()
+          map.putBoolean("isInWallet", isCardInWallet)
+          map.putMap("token", token)
         }
+        promise.resolve(result)
       }
     }
   }
@@ -641,6 +640,7 @@ class StripeSdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJ
         promise.resolve(createResult("paymentIntent", mapFromPaymentIntentResult(result)))
       }
     }
+    
     val setupCallback = object : ApiResultCallback<SetupIntent> {
       override fun onError(e: Exception) {
         promise.resolve(createError(ErrorType.Failed.toString(), e))

--- a/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
+++ b/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
@@ -570,10 +570,11 @@ class StripeSdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJ
     }
     getCurrentActivityOrResolveWithError(promise)?.let {
       PushProvisioningProxy.isCardInWallet(it, last4) { isCardInWallet, token, error ->
-        val result = error ?: run {
+        val result: WritableMap = error ?: run {
           val map = WritableNativeMap()
           map.putBoolean("isInWallet", isCardInWallet)
           map.putMap("token", token)
+          map
         }
         promise.resolve(result)
       }
@@ -640,7 +641,7 @@ class StripeSdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJ
         promise.resolve(createResult("paymentIntent", mapFromPaymentIntentResult(result)))
       }
     }
-    
+
     val setupCallback = object : ApiResultCallback<SetupIntent> {
       override fun onError(e: Exception) {
         promise.resolve(createError(ErrorType.Failed.toString(), e))


### PR DESCRIPTION
## Summary

Fixed an issue on older version of React Native where calling `collectBankAccountForSetup` or `collectBankAccountForPayment` and getting a `Canceled` result could cause a crash. Simplified some other logic as well around resolving promises

## Motivation

fixes a bug reported by a user

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
