### PR TITLE
fix: avoid issues with gradle lintVitalRelease step

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -153,8 +153,3 @@ dependencies {
   androidTestImplementation 'androidx.test:runner:1.1.0'
   androidTestImplementation "org.mockito:mockito-core:3.+"
 }
-
-configurations {
-    // We want to include all of our compileOnly libraries in our tests
-    androidTestImplementation.extendsFrom compileOnly
-}

--- a/android/src/androidTest/java/com/reactnativestripesdk/pushprovisioning/PushProvisioningProxyTest.kt
+++ b/android/src/androidTest/java/com/reactnativestripesdk/pushprovisioning/PushProvisioningProxyTest.kt
@@ -13,9 +13,14 @@ class PushProvisioningProxyTest {
 
   @Test
   fun getApiVersion() {
-    // This value very rarely changes, so the test is hard coded
+    /**
+     * An empty string is returned because we do not include compileOnly dependencies in our tests.
+     * Including the compileOnly dependency causes some linters to complain, and one single test
+     * isn't worth it. Once the push provisioning library is split into it's own SDK, we can
+     * add back this test. (it should equal "2019-09-09" if the dependency is included).
+     */
     assertEquals(
-      "2019-09-09",
+      "",
       PushProvisioningProxy.getApiVersion()
     )
   }


### PR DESCRIPTION
## Summary

removed test that required us to include compileOnly dependencies

## Motivation
closes https://github.com/stripe/stripe-react-native/issues/1033
