### PR TITLE
feat: add defaultValues to CardForm and CardField

### DIFF
--- a/android/src/main/java/com/reactnativestripesdk/CardFieldView.kt
+++ b/android/src/main/java/com/reactnativestripesdk/CardFieldView.kt
@@ -175,6 +175,14 @@ class CardFieldView(context: ThemedReactContext) : FrameLayout(context) {
     }
   }
 
+  fun setDefaultValues(defaults: ReadableMap) {
+    cardInputWidgetBinding.cvcEditText.setText(defaults.getString("cvc"))
+    cardInputWidgetBinding.cardNumberEditText.setText(defaults.getString("number"))
+    cardInputWidgetBinding.postalCodeEditText.setText(defaults.getString("postalCode"))
+    val expiryDate = defaults.getString("expiryMonth")?.plus("/").plus(defaults.getString("expiryYear"))
+    cardInputWidgetBinding.expiryDateEditText.setText(expiryDate)
+  }
+
   fun setPlaceHolders(value: ReadableMap) {
     val numberPlaceholder = getValOr(value, "number", null)
     val expirationPlaceholder = getValOr(value, "expiration", null)

--- a/android/src/main/java/com/reactnativestripesdk/CardFieldViewManager.kt
+++ b/android/src/main/java/com/reactnativestripesdk/CardFieldViewManager.kt
@@ -56,6 +56,12 @@ class CardFieldViewManager : SimpleViewManager<CardFieldView>() {
     view.setPlaceHolders(placeholders)
   }
 
+  @ReactProp(name = "defaultValues")
+  fun setDefaultValues(view: CardFieldView, defaults: ReadableMap) {
+    view.setDefaultValues(defaults)
+  }
+
+
   override fun createViewInstance(reactContext: ThemedReactContext): CardFieldView {
     val stripeSdkModule: StripeSdkModule? = reactContext.getNativeModule(StripeSdkModule::class.java)
     val view = CardFieldView(reactContext)

--- a/android/src/main/java/com/reactnativestripesdk/CardFormView.kt
+++ b/android/src/main/java/com/reactnativestripesdk/CardFormView.kt
@@ -54,6 +54,11 @@ class CardFormView(context: ThemedReactContext) : FrameLayout(context) {
 
   fun setDefaultValues(defaults: ReadableMap) {
     setCountry(defaults.getString("countryCode"))
+    cardFormViewBinding.postalCode.setText(defaults.getString("postalCode"))
+    cardFormViewBinding.cardMultilineWidget.cvcEditText.setText(defaults.getString("cvc"))
+    cardFormViewBinding.cardMultilineWidget.cardNumberEditText.setText(defaults.getString("number"))
+    val expiryDate = defaults.getString("expiryMonth")?.plus("/").plus(defaults.getString("expiryYear"))
+    cardFormViewBinding.cardMultilineWidget.expiryDateEditText.setText(expiryDate)
   }
 
   private fun setCountry(countryString: String?) {

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -305,11 +305,11 @@ PODS:
     - StripeApplePay (= 22.5.1)
     - StripeCore (= 22.5.1)
     - StripeUICore (= 22.5.1)
-  - stripe-react-native (0.14.0):
+  - stripe-react-native (0.15.0):
     - React-Core
     - Stripe (~> 22.5.1)
     - StripeFinancialConnections (~> 22.5.1)
-  - stripe-react-native/Tests (0.14.0):
+  - stripe-react-native/Tests (0.15.0):
     - React-Core
     - Stripe (~> 22.5.1)
     - StripeFinancialConnections (~> 22.5.1)
@@ -492,7 +492,7 @@ SPEC CHECKSUMS:
   RNCPicker: abc646b53a3d28ccfa3232c927a0ca52e0cf024d
   RNScreens: 40a2cb40a02a609938137a1e0acfbf8fc9eebf19
   Stripe: 2b2decd03146e08a350960966d41f3028c2eac29
-  stripe-react-native: c90947c1f02761d11622dcb3cd3bd8683916b36b
+  stripe-react-native: 5817de3b998cf6ca2ccd4b91ce007b377398ecdd
   StripeApplePay: b14f06ac6fc24b56704c1e598149ed0cc45e166f
   StripeCore: 4833738f2ca4336712f279f3c2867a0a7eb67c93
   StripeFinancialConnections: 982115b82af429968d8aa78d329a42ed7ba3feab

--- a/example/src/screens/MultilineWebhookPaymentScreen.tsx
+++ b/example/src/screens/MultilineWebhookPaymentScreen.tsx
@@ -105,6 +105,11 @@ export default function MultilineWebhookPaymentScreen() {
         }}
         defaultValues={{
           countryCode: 'US',
+          number: '4242424242424242',
+          postalCode: '98989',
+          expiryMonth: '01',
+          expiryYear: '24',
+          cvc: '123',
         }}
       />
       <View style={styles.row}>

--- a/example/src/screens/WebhookPaymentScreen.tsx
+++ b/example/src/screens/WebhookPaymentScreen.tsx
@@ -104,6 +104,14 @@ export default function WebhookPaymentScreen() {
         }}
         cardStyle={inputStyles}
         style={styles.cardField}
+        countryCode="US"
+        defaultValues={{
+          number: '4242424242424242',
+          postalCode: '98989',
+          expiryMonth: '01',
+          expiryYear: '24',
+          cvc: '123',
+        }}
       />
       <View style={styles.row}>
         <Switch

--- a/ios/CardFieldManager.m
+++ b/ios/CardFieldManager.m
@@ -5,6 +5,7 @@
 @interface RCT_EXTERN_MODULE(CardFieldManager, RCTViewManager)
 RCT_EXPORT_VIEW_PROPERTY(postalCodeEnabled, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(countryCode, NSString)
+RCT_EXPORT_VIEW_PROPERTY(defaultValues, NSDictionary)
 RCT_EXPORT_VIEW_PROPERTY(onCardChange, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onFocusChange, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(cardStyle, NSDictionary)

--- a/ios/CardFieldView.swift
+++ b/ios/CardFieldView.swift
@@ -24,6 +24,13 @@ class CardFieldView: UIView, STPPaymentCardTextFieldDelegate {
         }
     }
     
+    @objc var defaultValues: NSDictionary? {
+        didSet {
+            cardField.cardParams = Mappers.mapToCardParams(defaultValues)
+            cardField.postalCode = defaultValues?["postalCode"] as? String
+        }
+    }
+    
     @objc var placeholders: NSDictionary = NSDictionary() {
         didSet {
             if let numberPlaceholder = placeholders["number"] as? String {

--- a/ios/CardFormManager.m
+++ b/ios/CardFormManager.m
@@ -5,6 +5,7 @@
 @interface RCT_EXTERN_MODULE(CardFormManager, RCTViewManager)
 RCT_EXPORT_VIEW_PROPERTY(onFormComplete, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(dangerouslyGetFullCardDetails, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(defaultValues, NSDictionary)
 RCT_EXPORT_VIEW_PROPERTY(autofocus, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(isUserInteractionEnabledValue, BOOL)
 RCT_EXTERN_METHOD(focus:(nonnull NSNumber*) reactTag)

--- a/ios/CardFormView.swift
+++ b/ios/CardFormView.swift
@@ -11,7 +11,8 @@ class CardFormView: UIView, STPCardFormViewDelegate {
     @objc var onFormComplete: RCTDirectEventBlock?
     @objc var autofocus: Bool = false
     @objc var isUserInteractionEnabledValue: Bool = true
-    
+    @objc var defaultValues: NSDictionary?
+
     override func didSetProps(_ changedProps: [String]!) {
         if let cardForm = self.cardForm {
             cardForm.removeFromSuperview()
@@ -29,6 +30,7 @@ class CardFormView: UIView, STPCardFormViewDelegate {
         self.cardForm = _cardForm
         self.addSubview(_cardForm)
         setStyles()
+        setDefaultValues()
     }
     
     @objc var cardStyle: NSDictionary = NSDictionary() {
@@ -36,7 +38,7 @@ class CardFormView: UIView, STPCardFormViewDelegate {
            setStyles()
         }
     }
-
+    
     func cardFormView(_ form: STPCardFormView, didChangeToStateComplete complete: Bool) {
         if onFormComplete != nil {
             let brand = STPCardValidator.brand(forNumber: cardForm?.cardParams?.card?.number ?? "")
@@ -78,6 +80,20 @@ class CardFormView: UIView, STPCardFormViewDelegate {
         // if let disabledBackgroundColor = cardStyle["disabledBackgroundColor"] as? String {
         //     cardForm?.disabledBackgroundColor = UIColor(hexString: disabledBackgroundColor)
         // }
+    }
+    
+    func setDefaultValues() {
+        guard let cardForm = cardForm else { return }
+        
+        let card = Mappers.mapToCardParams(defaultValues)
+        
+        let address = STPPaymentMethodAddress()
+        address.postalCode = defaultValues?["postalCode"] as? String
+        
+        let billingDetails = STPPaymentMethodBillingDetails()
+        billingDetails.address = address
+        
+        cardForm.cardParams = STPPaymentMethodParams.init(card: card, billingDetails: billingDetails, metadata: nil)
     }
     
     override init(frame: CGRect) {

--- a/ios/Mappers.swift
+++ b/ios/Mappers.swift
@@ -983,4 +983,17 @@ class Mappers {
             default: return STPPaymentMethodUSBankAccountType.checking
         }
     }
+    
+    class func mapToCardParams(_ input: NSDictionary?) -> STPPaymentMethodCardParams {
+        let params = STPPaymentMethodCardParams()
+        params.cvc = input?["cvc"] as? String
+        params.number = input?["number"] as? String
+        if let month = input?["expiryMonth"] as? String {
+            params.expMonth = NSNumber(value: Int(month) ?? 0)
+        }
+        if let year = input?["expiryYear"] as? String {
+            params.expYear = NSNumber(value: Int(year) ?? 0)
+        }
+        return params
+    }
 }

--- a/src/components/CardField.tsx
+++ b/src/components/CardField.tsx
@@ -34,6 +34,8 @@ export interface Props extends AccessibilityProps {
   postalCodeEnabled?: boolean;
   /** Controls the postal code entry shown (if the postalCodeEnabled prop is set to true). Defaults to the device's default locale. */
   countryCode?: string;
+  /** Default values which will auto-fill the CardField component. This can be especially useful for testing purposes. */
+  defaultValues?: CardFieldInput.DefaultCardValues;
   cardStyle?: CardFieldInput.Styles;
   placeholders?: CardFieldInput.Placeholders;
   autofocus?: boolean;

--- a/src/types/components/CardFieldInput.ts
+++ b/src/types/components/CardFieldInput.ts
@@ -73,3 +73,16 @@ export interface Methods {
   blur(): void;
   clear(): void;
 }
+
+export type DefaultCardValues = {
+  /** The month of expiry of the card. This should be a 1 or 2 digit string, e.g. "2" or "12". */
+  expiryMonth?: string;
+  /** The year of expiry of the card. This should be a 2 or 4 digit string, e.g. "25" or "2025". */
+  expiryYear?: string;
+  /** The postal code associated with the card. */
+  postalCode?: string;
+  /** The 16-digit card number (can be just a portion of it). */
+  number?: string;
+  /** The 3-digit cvc of the card. */
+  cvc?: string;
+};

--- a/src/types/components/CardFormView.ts
+++ b/src/types/components/CardFormView.ts
@@ -47,6 +47,16 @@ export interface Placeholders {
 export type DefaultValues = {
   /** The 2-letter country code for the country selected by default on Android. If this is null, it is set by the device's configured region in the Settings app. */
   countryCode?: string;
+  /** The month of expiry of the card. This should be a 1 or 2 digit string, e.g. "2" or "12". */
+  expiryMonth?: string;
+  /** The year of expiry of the card. This should be a 2 or 4 digit string, e.g. "25" or "2025". */
+  expiryYear?: string;
+  /** The postal code associated with the card. */
+  postalCode?: string;
+  /** The 16-digit card number (can be just a portion of it). */
+  number?: string;
+  /** The 3-digit cvc of the card. */
+  cvc?: string;
 };
 
 /**
@@ -59,7 +69,7 @@ export interface NativeProps {
   cardStyle?: Styles;
   /** Android only */
   placeholders?: Placeholders;
-  /** Android only */
+  /** Default values which will auto-fill the CardField component. This can be especially useful for testing purposes or for setting the default country. */
   defaultValues?: DefaultValues;
   // postalCodeEnabled: boolean;
   onFocusChange(


### PR DESCRIPTION
## Summary

- Added `defaultValues` prop to `CardField`. You can now programmatically set the card number, CVC, expiry date, and postal code.
- Expanded `CardForm`'s `defaultValues` prop. You can now programmatically set the card number, CVC, expiry date, and postal code.

## Motivation

closes 

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one: 
- [x] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
