### PR TITLE
feat: add support for additional cardStyles in CardForm on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### New features
 
+- Added support for `borderColor`, `borderRadius`, and `cursorColor` to `CardForm`'s `cardStyle` prop on iOS (already exists on Android).
+
 ### Fixes
 
 - Reduced the size of the `@stripe/stripe-react-native` by preventing unnecessary files from being published. [#1043](https://github.com/stripe/stripe-react-native/pull/1043)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### New features
 
-- Added support for `borderColor`, `borderRadius`, and `cursorColor` to `CardForm`'s `cardStyle` prop on iOS (already exists on Android).
+- Added support for `borderColor`, `borderRadius`, and `cursorColor` to `CardForm`'s `cardStyle` prop on iOS (already exists on Android). [#1048](https://github.com/stripe/stripe-react-native/pull/1048)
 
 ### Fixes
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -305,11 +305,11 @@ PODS:
     - StripeApplePay (= 22.5.1)
     - StripeCore (= 22.5.1)
     - StripeUICore (= 22.5.1)
-  - stripe-react-native (0.14.0):
+  - stripe-react-native (0.15.0):
     - React-Core
     - Stripe (~> 22.5.1)
     - StripeFinancialConnections (~> 22.5.1)
-  - stripe-react-native/Tests (0.14.0):
+  - stripe-react-native/Tests (0.15.0):
     - React-Core
     - Stripe (~> 22.5.1)
     - StripeFinancialConnections (~> 22.5.1)
@@ -492,7 +492,7 @@ SPEC CHECKSUMS:
   RNCPicker: abc646b53a3d28ccfa3232c927a0ca52e0cf024d
   RNScreens: 40a2cb40a02a609938137a1e0acfbf8fc9eebf19
   Stripe: 2b2decd03146e08a350960966d41f3028c2eac29
-  stripe-react-native: c90947c1f02761d11622dcb3cd3bd8683916b36b
+  stripe-react-native: 5817de3b998cf6ca2ccd4b91ce007b377398ecdd
   StripeApplePay: b14f06ac6fc24b56704c1e598149ed0cc45e166f
   StripeCore: 4833738f2ca4336712f279f3c2867a0a7eb67c93
   StripeFinancialConnections: 982115b82af429968d8aa78d329a42ed7ba3feab

--- a/ios/CardFormView.swift
+++ b/ios/CardFormView.swift
@@ -75,6 +75,26 @@ class CardFormView: UIView, STPCardFormViewDelegate {
         if let backgroundColor = cardStyle["backgroundColor"] as? String {
             cardForm?.backgroundColor = UIColor(hexString: backgroundColor)
         }
+        /**
+                    The following reveals a bug in STPCardFormView where there's a extra space in the layer,
+                        and thus must remain commented out for now.
+         
+         if let borderWidth = cardStyle["borderWidth"] as? Int {
+             cardForm?.layer.borderWidth = CGFloat(borderWidth)
+         } else {
+             cardForm?.layer.borderWidth = CGFloat(0)
+         }
+         
+         */
+        if let borderColor = cardStyle["borderColor"] as? String {
+            cardForm?.layer.borderColor = UIColor(hexString: borderColor).cgColor
+        }
+        if let borderRadius = cardStyle["borderRadius"] as? Int {
+            cardForm?.layer.cornerRadius = CGFloat(borderRadius)
+        }
+        if let cursorColor = cardStyle["cursorColor"] as? String {
+            cardForm?.tintColor = UIColor(hexString: cursorColor)
+        }
         // if let disabledBackgroundColor = cardStyle["disabledBackgroundColor"] as? String {
         //     cardForm?.disabledBackgroundColor = UIColor(hexString: disabledBackgroundColor)
         // }

--- a/src/components/CardForm.tsx
+++ b/src/components/CardForm.tsx
@@ -33,11 +33,11 @@ export interface Props extends AccessibilityProps {
   autofocus?: boolean;
   testID?: string;
 
-  /** All styles except backgroundColor are Android only */
+  /** All styles except backgroundColor, cursorColor, borderColor, and borderRadius are Android only */
   cardStyle?: CardFormView.Styles;
   // isUserInteractionEnabled?: boolean;
 
-  // TODO: will make it public when android-sdk allows for this
+  // TODO: will make it public when iOS SDK allows for this
   // postalCodeEnabled?: boolean;
 
   /** Android only */


### PR DESCRIPTION
## Summary

configure the CALayer's borderColor and borderRadius, and the UIView's tintColor (which `STPCardFormView` uses for the cursor color)

## Motivation
partially addresses https://github.com/stripe/stripe-react-native/issues/563

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one: 
- [x] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
