### PR TITLE
feat: allow confirmPayment to be called without payment method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### New features
 
+- `confirmPayment` can now be called with _just_ a client secret (e.g. `await confirmPayment("payment-intent-id")`), in other words the payment method can be excluded. If the payment method is excluded, it is assumed by the SDK that you have attached the payment method on the server-side during payment intent creation. [#1084](https://github.com/stripe/stripe-react-native/pull/1084)
+
 ### Fixes
 
 - Fixed an issue where `collectBankAccountForPayment` and `collectBankAccountForSetup` would fail on Android when using React Native 0.65.x or under. [#1059](https://github.com/stripe/stripe-react-native/pull/1059)

--- a/android/src/main/java/com/reactnativestripesdk/PaymentMethodCreateParamsFactory.kt
+++ b/android/src/main/java/com/reactnativestripesdk/PaymentMethodCreateParamsFactory.kt
@@ -203,14 +203,13 @@ class PaymentMethodCreateParamsFactory(
   }
 
   @Throws(PaymentMethodCreateParamsException::class)
-  fun createParams(clientSecret: String, paymentMethodType: PaymentMethod.Type, isPaymentIntent: Boolean): ConfirmStripeIntentParams {
+  fun createParams(clientSecret: String, paymentMethodType: PaymentMethod.Type?, isPaymentIntent: Boolean): ConfirmStripeIntentParams {
     try {
       return when (paymentMethodType) {
         PaymentMethod.Type.Card -> createCardStripeIntentParams(clientSecret, isPaymentIntent)
         PaymentMethod.Type.USBankAccount -> createUSBankAccountStripeIntentParams(clientSecret, isPaymentIntent)
         PaymentMethod.Type.PayPal -> createPayPalStripeIntentParams(clientSecret, isPaymentIntent)
         PaymentMethod.Type.Affirm -> createAffirmStripeIntentParams(clientSecret, isPaymentIntent)
-
         PaymentMethod.Type.Ideal,
         PaymentMethod.Type.Alipay,
         PaymentMethod.Type.Sofort,
@@ -241,6 +240,7 @@ class PaymentMethodCreateParamsFactory(
             )
           }
         }
+        null -> ConfirmPaymentIntentParams.create(clientSecret)
         else -> {
           throw Exception("This paymentMethodType is not supported yet")
         }

--- a/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
+++ b/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
@@ -376,12 +376,15 @@ class StripeSdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJ
 //  }
 
   @ReactMethod
-  fun confirmPayment(paymentIntentClientSecret: String, params: ReadableMap, options: ReadableMap, promise: Promise) {
+  fun confirmPayment(paymentIntentClientSecret: String, params: ReadableMap?, options: ReadableMap, promise: Promise) {
     val paymentMethodData = getMapOrNull(params, "paymentMethodData")
-    val paymentMethodType = getValOr(params, "paymentMethodType")?.let { mapToPaymentMethodType(it) } ?: run {
-      promise.resolve(createError(ConfirmPaymentErrorType.Failed.toString(), "You must provide paymentMethodType"))
-      return
-    }
+    val paymentMethodType = if (params != null)
+      mapToPaymentMethodType(params.getString("paymentMethodType")) ?: run {
+        promise.resolve(createError(ConfirmPaymentErrorType.Failed.toString(), "You must provide paymentMethodType"))
+        return
+      }
+    else
+      null // Expect that payment method was attached on the server
 
     val testOfflineBank = getBooleanOrFalse(params, "testOfflineBank")
 

--- a/ios/Errors.swift
+++ b/ios/Errors.swift
@@ -50,7 +50,7 @@ class Errors {
     class func createError (_ code: String, _ error: NSError?) -> NSDictionary {
         let value: NSDictionary = [
             "code": code,
-            "message": error?.userInfo[STPError.errorMessageKey] ?? NSNull(),
+            "message": error?.userInfo[STPError.errorMessageKey] ?? error?.localizedDescription ?? NSNull(),
             "localizedMessage": error?.localizedDescription ?? NSNull(),
             "declineCode": error?.userInfo[STPError.stripeDeclineCodeKey] ?? NSNull(),
             "stripeErrorCode": error?.userInfo[STPError.stripeErrorCodeKey] ?? NSNull(),

--- a/ios/StripeSdk.swift
+++ b/ios/StripeSdk.swift
@@ -800,7 +800,7 @@ class StripeSdk: RCTEventEmitter, STPApplePayContextDelegate, STPBankSelectionVi
     @objc(confirmPayment:data:options:resolver:rejecter:)
     func confirmPayment(
         paymentIntentClientSecret: String,
-        params: NSDictionary,
+        params: NSDictionary?,
         options: NSDictionary,
         resolver resolve: @escaping RCTPromiseResolveBlock,
         rejecter reject: @escaping RCTPromiseRejectBlock
@@ -808,13 +808,13 @@ class StripeSdk: RCTEventEmitter, STPApplePayContextDelegate, STPBankSelectionVi
         self.confirmPaymentResolver = resolve
         self.confirmPaymentClientSecret = paymentIntentClientSecret
 
-        let paymentMethodData = params["paymentMethodData"] as? NSDictionary
-        let type = Mappers.mapToPaymentMethodType(type: params["paymentMethodType"] as? String)
-        guard let paymentMethodType = type else {
-            resolve(Errors.createError(ErrorType.Failed, "You must provide paymentMethodType"))
+        let paymentMethodData = params?["paymentMethodData"] as? NSDictionary
+        let (missingPaymentMethodError, paymentMethodType) = getPaymentMethodType(params: params)
+        if (missingPaymentMethodError != nil) {
+            resolve(missingPaymentMethodError)
             return
         }
-
+        
         if (paymentMethodType == .FPX) {
             let testOfflineBank = paymentMethodData?["testOfflineBank"] as? Bool
             if (testOfflineBank == false || testOfflineBank == nil) {
@@ -831,10 +831,24 @@ class StripeSdk: RCTEventEmitter, STPApplePayContextDelegate, STPBankSelectionVi
             STPPaymentHandler.shared().confirmPayment(paymentIntentParams, with: self, completion: onCompleteConfirmPayment)
         }
     }
+    
+    func getPaymentMethodType(
+        params: NSDictionary?
+    ) -> (NSDictionary?, STPPaymentMethodType?) {
+        if let params = params {
+            guard let paymentMethodType = Mappers.mapToPaymentMethodType(type: params["paymentMethodType"] as? String) else {
+                return (Errors.createError(ErrorType.Failed, "You must provide paymentMethodType"), nil)
+            }
+            return (nil, paymentMethodType)
+        } else {
+            // If params aren't provided, it means we expect that the payment method was attached on the server side
+            return (nil, nil)
+        }
+    }
 
     func createPaymentIntentParams(
         paymentIntentClientSecret: String,
-        paymentMethodType: STPPaymentMethodType,
+        paymentMethodType: STPPaymentMethodType?,
         paymentMethodData: NSDictionary?,
         options: NSDictionary
     ) -> (NSDictionary?, STPPaymentIntentParams) {
@@ -846,6 +860,8 @@ class StripeSdk: RCTEventEmitter, STPApplePayContextDelegate, STPBankSelectionVi
             if (paymentMethodType == .USBankAccount && paymentMethodData == nil) {
                 return STPPaymentIntentParams(clientSecret: paymentIntentClientSecret, paymentMethodType: .USBankAccount)
             } else {
+                guard let paymentMethodType = paymentMethodType else { return STPPaymentIntentParams(clientSecret: paymentIntentClientSecret) }
+                
                 let paymentMethodId = paymentMethodData?["paymentMethodId"] as? String
                 let parameters = STPPaymentIntentParams(clientSecret: paymentIntentClientSecret)
 

--- a/src/NativeStripeSdk.tsx
+++ b/src/NativeStripeSdk.tsx
@@ -1,6 +1,7 @@
 import { NativeModules } from 'react-native';
 import type {
   PaymentMethod,
+  PaymentIntent,
   ApplePay,
   PaymentSheet,
   SetupIntent,
@@ -40,8 +41,8 @@ type NativeStripeSdkType = {
   ): Promise<HandleNextActionResult>;
   confirmPayment(
     paymentIntentClientSecret: string,
-    params: PaymentMethod.ConfirmParams,
-    options: PaymentMethod.ConfirmOptions
+    params?: PaymentIntent.ConfirmParams,
+    options?: PaymentIntent.ConfirmOptions
   ): Promise<ConfirmPaymentResult>;
   isApplePaySupported(): Promise<boolean>;
   presentApplePay(params: ApplePay.PresentParams): Promise<ApplePayResult>;

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -140,7 +140,7 @@ export const retrieveSetupIntent = async (
 
 export const confirmPayment = async (
   paymentIntentClientSecret: string,
-  params: PaymentIntent.ConfirmParams,
+  params?: PaymentIntent.ConfirmParams,
   options: PaymentIntent.ConfirmOptions = {}
 ): Promise<ConfirmPaymentResult> => {
   try {

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -139,6 +139,14 @@ export const retrieveSetupIntent = async (
   }
 };
 
+/**
+ * Confirm and, if necessary, authenticate a PaymentIntent.
+ *
+ * @param paymentIntentClientSecret The client_secret of the associated [PaymentIntent](https://stripe.com/docs/api/payment_intents).
+ * @param params An optional object that contains data related to the payment method used to confirm this payment. If no object is provided (undefined), then it is assumed that the payment method has already been [attached  to the Payment Intent](https://stripe.com/docs/api/payment_intents/create#create_payment_intent-payment_method).
+ * @param options An optional object that contains options for this payment method.
+ * @returns A promise that resolves to an object containing either a `paymentIntent` field, or an `error` field.
+ */
 export const confirmPayment = async (
   paymentIntentClientSecret: string,
   params?: PaymentIntent.ConfirmParams,

--- a/src/hooks/useConfirmPayment.tsx
+++ b/src/hooks/useConfirmPayment.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useState } from 'react';
-import type { PaymentMethod } from '../types';
+import type { PaymentIntent } from '../types';
 import { useStripe } from './useStripe';
 
 /**
@@ -12,8 +12,8 @@ export function useConfirmPayment() {
   const _confirmPayment = useCallback(
     async (
       paymentIntentClientSecret: string,
-      data: PaymentMethod.ConfirmParams,
-      options: PaymentMethod.ConfirmOptions = {}
+      data?: PaymentIntent.ConfirmParams,
+      options: PaymentIntent.ConfirmOptions = {}
     ) => {
       setLoading(true);
 

--- a/src/hooks/useStripe.tsx
+++ b/src/hooks/useStripe.tsx
@@ -1,5 +1,6 @@
 import type {
   PaymentMethod,
+  PaymentIntent,
   ApplePay,
   PaymentSheet,
   CreatePaymentMethodResult,
@@ -114,8 +115,8 @@ export function useStripe() {
   const _confirmPayment = useCallback(
     async (
       paymentIntentClientSecret: string,
-      data: PaymentMethod.ConfirmParams,
-      options: PaymentMethod.ConfirmOptions = {}
+      data?: PaymentIntent.ConfirmParams,
+      options: PaymentIntent.ConfirmOptions = {}
     ): Promise<ConfirmPaymentResult> => {
       return confirmPayment(paymentIntentClientSecret, data, options);
     },


### PR DESCRIPTION
## Summary

allows merchants to confirm a payment intent that has had the payment method attached on the server side

## Motivation
closes https://github.com/stripe/stripe-react-native/issues/614

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one: 
- [x] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
