### PR TITLE
fix: Android FinancialConnections functionality not working for Connect accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,11 @@
 ### New features
 
 - `confirmPayment` can now be called with _just_ a client secret (e.g. `await confirmPayment("payment-intent-id")`), in other words the payment method can be excluded. If the payment method is excluded, it is assumed by the SDK that you have attached the payment method on the server-side during payment intent creation. [#1084](https://github.com/stripe/stripe-react-native/pull/1084)
+- Payment Sheet now supports Link on iOS. [#1086](https://github.com/stripe/stripe-react-native/pull/1086).
 
 ### Fixes
+
+- Fixed a bug on Android where `collectBankAccountForPayment`, `collectBankAccountForSetup`, `collectBankAccountToken`, and `collectFinancialConnectionsAccounts` wouldn't work with Stripe Connect accounts. [#1086](https://github.com/stripe/stripe-react-native/pull/1086).
 
 ## 0.17.0 - 2022-08-11
 

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,2 +1,2 @@
 StripeSdk_kotlinVersion=1.6.21
-StripeSdk_stripeVersion=20.8.+
+StripeSdk_stripeVersion=20.9.+

--- a/android/src/main/java/com/reactnativestripesdk/CollectBankAccountLauncherFragment.kt
+++ b/android/src/main/java/com/reactnativestripesdk/CollectBankAccountLauncherFragment.kt
@@ -24,6 +24,7 @@ import com.stripe.android.payments.bankaccount.navigation.CollectBankAccountResu
 class CollectBankAccountLauncherFragment(
   private val context: ReactApplicationContext,
   private val publishableKey: String,
+  private val stripeAccountId: String?,
   private val clientSecret: String,
   private val isPaymentIntent: Boolean,
   private val collectParams:  CollectBankAccountConfiguration.USBankAccount,
@@ -48,12 +49,14 @@ class CollectBankAccountLauncherFragment(
     if (isPaymentIntent) {
       collectBankAccountLauncher.presentWithPaymentIntent(
         publishableKey,
+        stripeAccountId,
         clientSecret,
         collectParams
       )
     } else {
       collectBankAccountLauncher.presentWithSetupIntent(
         publishableKey,
+        stripeAccountId,
         clientSecret,
         collectParams
       )

--- a/android/src/main/java/com/reactnativestripesdk/FinancialConnectionsSheetFragment.kt
+++ b/android/src/main/java/com/reactnativestripesdk/FinancialConnectionsSheetFragment.kt
@@ -11,12 +11,10 @@ import com.facebook.react.bridge.*
 import com.reactnativestripesdk.utils.*
 import com.reactnativestripesdk.utils.createError
 import com.reactnativestripesdk.utils.createMissingActivityError
-import com.reactnativestripesdk.utils.createResult
 import com.reactnativestripesdk.utils.mapFromToken
 import com.stripe.android.financialconnections.FinancialConnectionsSheet
 import com.stripe.android.financialconnections.FinancialConnectionsSheetForTokenResult
 import com.stripe.android.financialconnections.FinancialConnectionsSheetResult
-import com.stripe.android.financialconnections.FinancialConnectionsSheetResultCallback
 import com.stripe.android.financialconnections.model.*
 
 class FinancialConnectionsSheetFragment : Fragment() {
@@ -26,8 +24,7 @@ class FinancialConnectionsSheetFragment : Fragment() {
 
   private lateinit var promise: Promise
   private lateinit var context: ReactApplicationContext
-  private lateinit var clientSecret: String
-  private lateinit var publishableKey: String
+  private lateinit var configuration: FinancialConnectionsSheet.Configuration
   private lateinit var mode: Mode
 
   override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?,
@@ -44,10 +41,7 @@ class FinancialConnectionsSheetFragment : Fragment() {
           this,
           ::onFinancialConnectionsSheetForTokenResult
         ).present(
-          configuration = FinancialConnectionsSheet.Configuration(
-            financialConnectionsSessionClientSecret = clientSecret,
-            publishableKey = publishableKey
-          )
+          configuration = configuration
         )
       }
       Mode.ForSession -> {
@@ -55,10 +49,7 @@ class FinancialConnectionsSheetFragment : Fragment() {
           this,
           ::onFinancialConnectionsSheetForDataResult
         ).present(
-          configuration = FinancialConnectionsSheet.Configuration(
-            financialConnectionsSessionClientSecret = clientSecret,
-            publishableKey = publishableKey
-          )
+          configuration = configuration
         )
       }
     }
@@ -106,12 +97,15 @@ class FinancialConnectionsSheetFragment : Fragment() {
     }
   }
 
-  fun presentFinancialConnectionsSheet(clientSecret: String, mode: Mode, publishableKey: String, promise: Promise, context: ReactApplicationContext) {
+  fun presentFinancialConnectionsSheet(clientSecret: String, mode: Mode, publishableKey: String, stripeAccountId: String?, promise: Promise, context: ReactApplicationContext) {
     this.promise = promise
     this.context = context
-    this.clientSecret = clientSecret
-    this.publishableKey = publishableKey
     this.mode = mode
+    this.configuration = FinancialConnectionsSheet.Configuration(
+      financialConnectionsSessionClientSecret = clientSecret,
+      publishableKey = publishableKey,
+      stripeAccountId = stripeAccountId,
+    )
 
     (context.currentActivity as? AppCompatActivity)?.let {
       attemptToCleanupPreviousFragment(it)

--- a/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
+++ b/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
@@ -619,6 +619,7 @@ class StripeSdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJ
     collectBankAccountLauncherFragment = CollectBankAccountLauncherFragment(
       reactApplicationContext,
       publishableKey,
+      stripeAccountId,
       clientSecret,
       isPaymentIntent,
       collectParams,
@@ -710,7 +711,7 @@ class StripeSdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJ
       return
     }
     financialConnectionsSheetFragment = FinancialConnectionsSheetFragment().also {
-      it.presentFinancialConnectionsSheet(clientSecret, FinancialConnectionsSheetFragment.Mode.ForToken, publishableKey, promise, reactApplicationContext)
+      it.presentFinancialConnectionsSheet(clientSecret, FinancialConnectionsSheetFragment.Mode.ForToken, publishableKey, stripeAccountId, promise, reactApplicationContext)
     }
   }
 
@@ -721,7 +722,7 @@ class StripeSdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJ
       return
     }
     financialConnectionsSheetFragment = FinancialConnectionsSheetFragment().also {
-      it.presentFinancialConnectionsSheet(clientSecret, FinancialConnectionsSheetFragment.Mode.ForSession, publishableKey, promise, reactApplicationContext)
+      it.presentFinancialConnectionsSheet(clientSecret, FinancialConnectionsSheetFragment.Mode.ForSession, publishableKey, stripeAccountId, promise, reactApplicationContext)
     }
   }
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -368,31 +368,31 @@ PODS:
     - React-Core
     - React-RCTImage
   - SocketRocket (0.6.0)
-  - Stripe (22.6.0):
-    - Stripe/Stripe3DS2 (= 22.6.0)
-    - StripeApplePay (= 22.6.0)
-    - StripeCore (= 22.6.0)
-    - StripeUICore (= 22.6.0)
+  - Stripe (22.7.0):
+    - Stripe/Stripe3DS2 (= 22.7.0)
+    - StripeApplePay (= 22.7.0)
+    - StripeCore (= 22.7.0)
+    - StripeUICore (= 22.7.0)
   - stripe-react-native (0.17.0):
     - React-Core
-    - Stripe (~> 22.6.0)
-    - StripeFinancialConnections (~> 22.6.0)
+    - Stripe (~> 22.7.0)
+    - StripeFinancialConnections (~> 22.7.0)
   - stripe-react-native/Tests (0.17.0):
     - React-Core
-    - Stripe (~> 22.6.0)
-    - StripeFinancialConnections (~> 22.6.0)
-  - Stripe/Stripe3DS2 (22.6.0):
-    - StripeApplePay (= 22.6.0)
-    - StripeCore (= 22.6.0)
-    - StripeUICore (= 22.6.0)
-  - StripeApplePay (22.6.0):
-    - StripeCore (= 22.6.0)
-  - StripeCore (22.6.0)
-  - StripeFinancialConnections (22.6.0):
-    - StripeCore (= 22.6.0)
-    - StripeUICore (= 22.6.0)
-  - StripeUICore (22.6.0):
-    - StripeCore (= 22.6.0)
+    - Stripe (~> 22.7.0)
+    - StripeFinancialConnections (~> 22.7.0)
+  - Stripe/Stripe3DS2 (22.7.0):
+    - StripeApplePay (= 22.7.0)
+    - StripeCore (= 22.7.0)
+    - StripeUICore (= 22.7.0)
+  - StripeApplePay (22.7.0):
+    - StripeCore (= 22.7.0)
+  - StripeCore (22.7.0)
+  - StripeFinancialConnections (22.7.0):
+    - StripeCore (= 22.7.0)
+    - StripeUICore (= 22.7.0)
+  - StripeUICore (22.7.0):
+    - StripeCore (= 22.7.0)
   - Yoga (1.14.0)
   - YogaKit (1.18.1):
     - Yoga (~> 1.14)
@@ -614,12 +614,12 @@ SPEC CHECKSUMS:
   RNCPicker: abc646b53a3d28ccfa3232c927a0ca52e0cf024d
   RNScreens: 4a1af06327774490d97342c00aee0c2bafb497b7
   SocketRocket: fccef3f9c5cedea1353a9ef6ada904fde10d6608
-  Stripe: 4dfbdf728f31b178f682bde8709336ec9a2c29e8
-  stripe-react-native: 59457dafb0202c1049d2fb59820158bd1d4fa84e
-  StripeApplePay: 5c1a8b4b017c48f824dfb27e6ea05a328d7c57c8
-  StripeCore: 9b44be7bcfe6905257f5094ab2d76fdf8adb5747
-  StripeFinancialConnections: a40f31f6e1424120a5032e45dd213ded3e1dcf97
-  StripeUICore: b09d3bc4f00ebc3f3b415e429df3454a575a3a13
+  Stripe: 464637e1fe036d69343c8b62f96d38c98efc4584
+  stripe-react-native: a73da029e88fab8d3d53ff67c0b8686f3423a045
+  StripeApplePay: 19c54b75a272ec9d9b99f34cdec0a84cf64fad8c
+  StripeCore: 42478ef61de37f1b85a4e1ac9d61bcf776bd2e2f
+  StripeFinancialConnections: e4d7ae81c67b4c32ed46a22f1841abb319bb8e24
+  StripeUICore: a8748e6c865f0b0e1e6bb767667f3b132977b033
   Yoga: 236056dd74cda4d9d76c20306fd8c20bb087614d
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 

--- a/stripe-react-native.podspec
+++ b/stripe-react-native.podspec
@@ -1,7 +1,7 @@
 require 'json'
 
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
-stripe_version = '~> 22.6.0'
+stripe_version = '~> 22.7.0'
 
 Pod::Spec.new do |s|
   s.name         = 'stripe-react-native'


### PR DESCRIPTION
## Summary

Upgraded native stripe-android library, and pass down the `stripeAccountId` to both `CollectBankAccountLauncher` and `FinancialConnectionsSheet.Configuration`. Also upgraded iOS since a new version was released. 

## Motivation

Fixed a bug on Android where `collectBankAccountForPayment`, `collectBankAccountForSetup`, `collectBankAccountToken`, and `collectFinancialConnectionsAccounts` wouldn't work with Stripe Connect accounts. 

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [ ] I added automated tests

## Documentation

no user-facing changes required to get this fix
