### PR TITLE
feat: expose returnURL parameter for handleNextAction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### New features
 
+- Add `returnURL` as an optional parameter to `handleNextAction`. Use this so the Stripe SDK can redirect back to your app after authentication. [#1104](https://github.com/stripe/stripe-react-native/pull/1104)
+
 ## Fixes
 
 - Fixed an issue where some promises on Android would never resolve when using React Native 0.65.x or under. [#1089](https://github.com/stripe/stripe-react-native/pull/1089).

--- a/example/server/index.ts
+++ b/example/server/index.ts
@@ -294,6 +294,7 @@ app.post(
           },
           use_stripe_sdk: useStripeSdk,
           customer: customers.data[0].id,
+          return_url: 'stripe-example://stripe-redirect',
         };
         const intent = await stripe.paymentIntents.create(params);
         return res.send(generateResponse(intent));
@@ -308,6 +309,7 @@ app.post(
           // If a mobile client passes `useStripeSdk`, set `use_stripe_sdk=true`
           // to take advantage of new authentication features in mobile SDKs.
           use_stripe_sdk: useStripeSdk,
+          return_url: 'stripe-example://stripe-redirect',
         };
         const intent = await stripe.paymentIntents.create(params);
         // After create, if the PaymentIntent's status is succeeded, fulfill the order.

--- a/example/src/screens/NoWebhookPaymentScreen.tsx
+++ b/example/src/screens/NoWebhookPaymentScreen.tsx
@@ -104,7 +104,8 @@ export default function NoWebhookPaymentScreen() {
     if (clientSecret && requiresAction) {
       // 4. if payment requires action calling handleNextAction
       const { error: nextActionError, paymentIntent } = await handleNextAction(
-        clientSecret
+        clientSecret,
+        'stripe-example://stripe-redirect'
       );
 
       if (nextActionError) {

--- a/ios/StripeSdk.m
+++ b/ios/StripeSdk.m
@@ -71,6 +71,7 @@ RCT_EXTERN_METHOD(
 
 RCT_EXTERN_METHOD(
                   handleNextAction:(NSString *)paymentIntentClientSecret
+                  returnURL:(NSString *)returnURL
                   resolver: (RCTPromiseResolveBlock)resolve
                   rejecter: (RCTPromiseRejectBlock)reject
                   )

--- a/ios/StripeSdk.swift
+++ b/ios/StripeSdk.swift
@@ -684,14 +684,15 @@ class StripeSdk: RCTEventEmitter, STPApplePayContextDelegate, STPBankSelectionVi
         }
     }
 
-    @objc(handleNextAction:resolver:rejecter:)
+    @objc(handleNextAction:returnURL:resolver:rejecter:)
     func handleNextAction(
         paymentIntentClientSecret: String,
+        returnURL: String?,
         resolver resolve: @escaping RCTPromiseResolveBlock,
         rejecter reject: @escaping RCTPromiseRejectBlock
     ){
         let paymentHandler = STPPaymentHandler.shared()
-        paymentHandler.handleNextAction(forPayment: paymentIntentClientSecret, with: self, returnURL: nil) { status, paymentIntent, handleActionError in
+        paymentHandler.handleNextAction(forPayment: paymentIntentClientSecret, with: self, returnURL: returnURL) { status, paymentIntent, handleActionError in
             switch (status) {
             case .failed:
                 resolve(Errors.createError(ErrorType.Failed, handleActionError))

--- a/src/NativeStripeSdk.tsx
+++ b/src/NativeStripeSdk.tsx
@@ -38,7 +38,8 @@ type NativeStripeSdkType = {
     options: PaymentMethod.CreateOptions
   ): Promise<CreatePaymentMethodResult>;
   handleNextAction(
-    paymentIntentClientSecret: string
+    paymentIntentClientSecret: string,
+    returnURL?: string | null
   ): Promise<HandleNextActionResult>;
   confirmPayment(
     paymentIntentClientSecret: string,

--- a/src/hooks/useStripe.tsx
+++ b/src/hooks/useStripe.tsx
@@ -157,9 +157,10 @@ export function useStripe() {
 
   const _handleNextAction = useCallback(
     async (
-      paymentIntentClientSecret: string
+      paymentIntentClientSecret: string,
+      returnURL?: string
     ): Promise<HandleNextActionResult> => {
-      return handleNextAction(paymentIntentClientSecret);
+      return handleNextAction(paymentIntentClientSecret, returnURL);
     },
     []
   );


### PR DESCRIPTION
## Summary

handleNextAction wasn't redirecting back to the app on iOS. This is bc the return URL has to match the `return_url` set during payment intent creation on the server (which our SDK will never know). So, this is now exposed as an optional parameter (no breaking change). 

Docs changes to https://stripe.com/docs/payments/accept-a-payment-synchronously?platform=react-native will follow

## Motivation
closes https://github.com/stripe/stripe-react-native/issues/772

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one: 
- [x] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
