### PR TITLE
fix: throw underlying error, not surface error

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -373,11 +373,11 @@ PODS:
     - StripeApplePay (= 22.7.0)
     - StripeCore (= 22.7.0)
     - StripeUICore (= 22.7.0)
-  - stripe-react-native (0.17.0):
+  - stripe-react-native (0.18.1):
     - React-Core
     - Stripe (~> 22.7.0)
     - StripeFinancialConnections (~> 22.7.0)
-  - stripe-react-native/Tests (0.17.0):
+  - stripe-react-native/Tests (0.18.1):
     - React-Core
     - Stripe (~> 22.7.0)
     - StripeFinancialConnections (~> 22.7.0)
@@ -615,7 +615,7 @@ SPEC CHECKSUMS:
   RNScreens: 4a1af06327774490d97342c00aee0c2bafb497b7
   SocketRocket: fccef3f9c5cedea1353a9ef6ada904fde10d6608
   Stripe: 464637e1fe036d69343c8b62f96d38c98efc4584
-  stripe-react-native: a73da029e88fab8d3d53ff67c0b8686f3423a045
+  stripe-react-native: 97a5555af0d933cd4f85ef7ae2a938386bbc8500
   StripeApplePay: 19c54b75a272ec9d9b99f34cdec0a84cf64fad8c
   StripeCore: 42478ef61de37f1b85a4e1ac9d61bcf776bd2e2f
   StripeFinancialConnections: e4d7ae81c67b4c32ed46a22f1841abb319bb8e24


### PR DESCRIPTION
## Summary

Before this, merchants would get an error back saying to "try again in a few minutes", rather than the real actionable error (invalid param or something like that)

## Motivation

https://github.com/stripe/stripe-react-native/issues/1096

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
