### PR TITLE
chore: remove 'safepay' reference from client side code

### DIFF
--- a/example/src/components/PaymentScreen.tsx
+++ b/example/src/components/PaymentScreen.tsx
@@ -23,8 +23,7 @@ const PaymentScreen: React.FC<Props> = ({
         await initStripe({
           publishableKey,
           merchantIdentifier: 'merchant.com.stripe.react.native',
-          urlScheme:
-            paymentMethod === 'wechat_pay' ? undefined : 'stripe-example',
+          urlScheme: 'stripe-example',
           setReturnUrlSchemeOnAndroid: true,
         });
         setLoading(false);

--- a/example/src/screens/HomeScreen.tsx
+++ b/example/src/screens/HomeScreen.tsx
@@ -19,9 +19,11 @@ export default function HomeScreen() {
 
   const handleDeepLink = useCallback(
     async (url: string | null) => {
-      if (url && url.includes('safepay')) {
-        await handleURLCallback(url);
-        navigation.navigate('PaymentResultScreen', { url });
+      if (url) {
+        const stripeHandled = await handleURLCallback(url);
+        if (stripeHandled) {
+          navigation.navigate('PaymentResultScreen', { url });
+        }
       }
     },
     [navigation, handleURLCallback]


### PR DESCRIPTION
## Summary

`safepay` is appended to the url scheme in a couple cases in the SDK in order to form a valid url to pass as a `returnURL`. However, there is no need for the client to be aware of this, since the `handleURLCallback` function returns a promise that resolves to a boolean indicating whether or not stripe handled that URL. Merchants can check that value, and if its false, it was not a Stripe url – handle the URL normally as you would

## Motivation
closes https://github.com/stripe/stripe-react-native/issues/1101

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [ ] I tested this manually
- [ ] I added automated tests

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
