### PR TITLE
fix(docs): incorrect way to use key-value object

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ function App() {
     initStripe({
       publishableKey: publishableKey,
       merchantIdentifier: 'merchant.identifier',
-      urlScheme="your-url-scheme",
+      urlScheme: "your-url-scheme",
     });
   }, []);
 }


### PR DESCRIPTION
As the eslint says: "Did you mean to use ':'? '=' can only be after a property name when the containing object literal is part of a destructuring pattern.".

## Summary
In the docs at ``Stripe initialization`` section, the object declaration syntax is incorrect.

## Motivation
I was looking for help then I found this. I imagine this fix can help someone in the future. ~Also I love Stripe <3~

You can see the diff below:

```import { initStripe } from '@stripe/stripe-react-native';

function App() {
  // ...

  useEffect(() => {
    initStripe({
      publishableKey: publishableKey,
      merchantIdentifier: 'merchant.identifier',

      CORRECT 👇
      urlScheme: "your-url-scheme",

      urlScheme="your-url-scheme",
      INCORRECT👆 (current)
    });
  }, []);
}
```
## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [X] I tested this manually
- [ ] I added automated tests

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [X] This PR does not result in any developer-facing changes.
