### PR TITLE
Release 0.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.19.0 - 2022-09-16
+
 ### Breaking changes
 
 - To comply with Google's [new branding guidelines for the Google Pay button](https://developers.google.com/pay/api/android/guides/brand-guidelines), the `<GooglePayButton />` component's `type` prop now only accepts `standard` or `pay` (`pay_shadow`, `pay_dark`, `standard_shadow`, and `standard_dark` were all removed). It defaults to `standard`. [#1135](https://github.com/stripe/stripe-react-native/pull/1135)

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ to your `app.json` file, where `merchantIdentifier` is the Apple merchant ID obt
 #### Android
 
 - Android 5.0 (API level 21) and above
-  - Your `compileSdkVersion` must be `32`. See [this issue](https://github.com/stripe/stripe-react-native/issues/812) for potential workarounds.
+  - Your `compileSdkVersion` must be `33`. See [this issue](https://github.com/stripe/stripe-react-native/issues/812) for potential workarounds.
 - Android gradle plugin 4.x and above
 
 _Components_


### PR DESCRIPTION
- [x] Ensure the CHANGELOG is up to date with all relevant commits since the last release
- [x] Add the version number for this release & the date to the CHANGELOG, underneath "## Unreleased"
    - e.g. "## 1.2.3 - 2022-02-14"
- [x] Update the README if necessary (this is only required when there are breaking changes in the release, such as dropping support for an iOS || Android version)