### PR TITLE
docs: Update Troubleshooting instructions for creating a new Swift file

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ Follow these steps to resolve this:
 
 - Open your project via Xcode, go to `project -> build settings`, find `library search paths` and remove all swift related entries such as:
   `$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)` and `$(TOOLCHAIN_DIR)/usr/lib/swift-5.0/$(PLATFORM_NAME)`.
-- Create a new Swift file to the project (File > New > File > Swift), give it any name (e.g. `Fix.swift`) and create a bridging header when prompted by Xcode.
+- Create a new Swift file to the project (File > New > File > Swift), give it any name (e.g. `Fix.swift`), check the appropriate Targets and create a bridging header when prompted by Xcode.
 
 ### `TypeError: null is not an object (evaluating '_NativeStripeSdk.default.initialise')` on Android
 


### PR DESCRIPTION
## Summary
Updated docs.

## Motivation
When following these [troubleshooting instructions](https://github.com/stripe/stripe-react-native#undefined-symbols-for-architecture-x86_64-on-ios), at the "Create a new Swift file..." step, XCode was not prompting me to create a bridging header. It turns out you must check the appropriate Target for this dialog to appear. I have updated the instructions accordingly.

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [ ] I tested this manually
- [ ] I added automated tests
- [x] N/A

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
- [x] This is a documentation change.