### PR TITLE
fix: expose account balance cash and credit on iOS

### DIFF
--- a/ios/FinancialConnections.swift
+++ b/ios/FinancialConnections.swift
@@ -137,9 +137,8 @@ class FinancialConnections {
         return [
             "asOf": balance.asOf * 1000,
             "type": mapFromBalanceType(balance.type),
-//             TODO: Protected by internal on iOS only. PR is out to fix
-            "cash": ["available": NSNull()],   // balance.cash?.available
-            "credit": ["used": NSNull()], // balance.credit?.used
+            "cash": ["available": balance.cash?.available],
+            "credit": ["used": balance.credit?.used],
             "current": balance.current,
         ]
     }


### PR DESCRIPTION
## Summary

these fields were internal before, so we couldn't pass them back

## Motivation

make ios api consistent with android

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
