### PR TITLE
fix: check for existence of pass on paired watch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ## Fixes
 
 - Fixed an issue on iOS where `confirmSetupIntent` would throw an error if the `Card` payment method was provided with the `paymentMethodId` parameter. [#1151](https://github.com/stripe/stripe-react-native/pull/1151)
+- Fixed an issue on iOS where `canAddCardToWallet` would return `false` if the card had already been provisioned on a paired device like an Apple Watch, but had not yet been provisioned on the current device. [#1162](https://github.com/stripe/stripe-react-native/pull/1162)
 
 ## 0.19.0 - 2022-09-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 ## Fixes
 
 - Fixed an issue on iOS where `confirmSetupIntent` would throw an error if the `Card` payment method was provided with the `paymentMethodId` parameter. [#1151](https://github.com/stripe/stripe-react-native/pull/1151)
-- Fixed an issue on iOS where `canAddCardToWallet` would return `false` if the card had already been provisioned on a paired device like an Apple Watch, but had not yet been provisioned on the current device. [#1162](https://github.com/stripe/stripe-react-native/pull/1162)
+- Fixed an issue on iOS where `canAddCardToWallet` would return `false` if the card had already been provisioned on a paired device like an Apple Watch, but had not yet been provisioned on the current device, and would also return `false` if the card had been provisioned on the current device, but not on a paired Apple Watch. [#1162](https://github.com/stripe/stripe-react-native/pull/1162)
 
 ## 0.19.0 - 2022-09-16
 

--- a/PaymentPassFinder.swift
+++ b/PaymentPassFinder.swift
@@ -1,0 +1,89 @@
+//
+//  PKPaymentPassFinder.swift
+//  stripe-react-native
+//
+//  Created by Charles Cruzan on 10/6/22.
+//
+
+import Foundation
+import WatchConnectivity
+
+internal class PaymentPassFinder: NSObject, WCSessionDelegate {
+    enum PassLocation: String {
+        case CURRENT_DEVICE
+        case PAIRED_DEVICE
+    }
+    
+    private var last4: String
+    private var findPassOnWatchCompletion: ((Bool, [PassLocation]) -> Void)
+    private var isPassOnCurrentDevice: Bool = false
+
+    init(last4: String, completion: @escaping ((Bool, [PassLocation]) -> Void)) {
+        self.last4 = last4
+        self.findPassOnWatchCompletion = completion
+        super.init()
+        
+        let existingPassOnDevice: PKPass? = {
+            if #available(iOS 13.4, *) {
+                return PKPassLibrary().passes(of: PKPassType.secureElement)
+                    .first(where: { $0.secureElementPass?.primaryAccountNumberSuffix == last4 && $0.secureElementPass?.passActivationState != .suspended && !$0.isRemotePass })
+            } else {
+                return PKPassLibrary().passes(of: PKPassType.payment)
+                    .first(where: { $0.paymentPass?.primaryAccountNumberSuffix == last4 && $0.paymentPass?.passActivationState != .suspended && !$0.isRemotePass })
+            }
+        }()
+        
+        self.isPassOnCurrentDevice = existingPassOnDevice != nil
+        
+        if WCSession.isSupported() {
+            findPassOnWatchCompletion = completion
+            let session = WCSession.default
+            session.delegate = self
+            session.activate()
+        } else {
+            completion(!isPassOnCurrentDevice, isPassOnCurrentDevice ? [PassLocation.CURRENT_DEVICE] : [])
+        }
+    }
+    
+    // no paired device: return pass on device (if exists), canAddPass = !ifExists
+    // paired device, no pass: return pass on device, canAddPass = true
+    // paried device, pass: return pass on paired device, return pass on device (if exists) canAddPass = !ifExists
+    
+    
+    // START: WCSessionDelegate methods
+    
+    func session(_ session: WCSession, activationDidCompleteWith activationState: WCSessionActivationState, error: Error?) {
+        if activationState == .activated {
+            let existingPassOnPairedDevices: PKPass? = {
+                if #available(iOS 13.4, *) {
+                    return PKPassLibrary().remoteSecureElementPasses
+                        .first(where: { $0.secureElementPass?.primaryAccountNumberSuffix == last4 && $0.secureElementPass?.passActivationState != .suspended })
+                } else {
+                    return PKPassLibrary().remotePaymentPasses()
+                        .first(where: { $0.paymentPass?.primaryAccountNumberSuffix == last4 && $0.paymentPass?.passActivationState != .suspended })
+                }
+            }()
+            
+            var passLocations: [PassLocation] = []
+            if (isPassOnCurrentDevice) {
+                passLocations.append(.CURRENT_DEVICE)
+            }
+            if (existingPassOnPairedDevices != nil) {
+                passLocations.append(.PAIRED_DEVICE)
+            }
+            
+            findPassOnWatchCompletion(
+                passLocations.count < 2,
+                passLocations
+            )
+        } else {
+            findPassOnWatchCompletion(!isPassOnCurrentDevice, isPassOnCurrentDevice ? [PassLocation.CURRENT_DEVICE] : [])
+        }
+    }
+    
+    func sessionDidBecomeInactive(_ session: WCSession) {}
+    
+    func sessionDidDeactivate(_ session: WCSession) {}
+    
+    // END: WCSessionDelegate methods
+}

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -373,11 +373,11 @@ PODS:
     - StripeApplePay (= 22.8.1)
     - StripeCore (= 22.8.1)
     - StripeUICore (= 22.8.1)
-  - stripe-react-native (0.18.1):
+  - stripe-react-native (0.19.0):
     - React-Core
     - Stripe (~> 22.8.1)
     - StripeFinancialConnections (~> 22.8.1)
-  - stripe-react-native/Tests (0.18.1):
+  - stripe-react-native/Tests (0.19.0):
     - React-Core
     - Stripe (~> 22.8.1)
     - StripeFinancialConnections (~> 22.8.1)
@@ -615,7 +615,7 @@ SPEC CHECKSUMS:
   RNScreens: 4a1af06327774490d97342c00aee0c2bafb497b7
   SocketRocket: fccef3f9c5cedea1353a9ef6ada904fde10d6608
   Stripe: b4cf3aa317a8e984b930d3545bac10b490dd3106
-  stripe-react-native: 0a6687da9a81bf4a9f80374d3fddd103e0e8dd1a
+  stripe-react-native: 0e50141806454839806143db5ce514a0cddd4d12
   StripeApplePay: 858c1dadc39b658d317661dea8cc2b7158533a17
   StripeCore: 52e0aba2fad604455692db593bf5edc04758b760
   StripeFinancialConnections: 40f6c8f86a4ddfcfe981d4da343828637abb3e69

--- a/ios/PaymentPassFinder.swift
+++ b/ios/PaymentPassFinder.swift
@@ -6,84 +6,45 @@
 //
 
 import Foundation
-import WatchConnectivity
 
-internal class PaymentPassFinder: NSObject, WCSessionDelegate {
+internal class PaymentPassFinder {
     enum PassLocation: String {
         case CURRENT_DEVICE
         case PAIRED_DEVICE
     }
-
-    private var last4: String
-    private var findPassOnWatchCompletion: ((Bool, [PassLocation]) -> Void)
-    private var isPassOnCurrentDevice: Bool = false
-
-    init(last4: String, completion: @escaping ((Bool, [PassLocation]) -> Void)) {
-        self.last4 = last4
-        self.findPassOnWatchCompletion = completion
-        super.init()
-
+    
+    class func findPassWithLast4(last4: String, completion: @escaping ((Bool, [PassLocation]) -> Void)) {
         let existingPassOnDevice: PKPass? = {
             if #available(iOS 13.4, *) {
                 return PKPassLibrary().passes(of: PKPassType.secureElement)
-                    .first(where: { $0.secureElementPass?.primaryAccountNumberSuffix == last4 && $0.secureElementPass?.passActivationState != .suspended && !$0.isRemotePass })
+                    .first(where: { $0.secureElementPass?.primaryAccountNumberSuffix == last4 && $0.secureElementPass?.passActivationState != .deactivated && !$0.isRemotePass })
             } else {
                 return PKPassLibrary().passes(of: PKPassType.payment)
-                    .first(where: { $0.paymentPass?.primaryAccountNumberSuffix == last4 && $0.paymentPass?.passActivationState != .suspended && !$0.isRemotePass })
+                    .first(where: { $0.paymentPass?.primaryAccountNumberSuffix == last4 && $0.paymentPass?.passActivationState != .deactivated && !$0.isRemotePass })
             }
         }()
-
-        self.isPassOnCurrentDevice = existingPassOnDevice != nil
-
-        if WCSession.isSupported() {
-            findPassOnWatchCompletion = completion
-            let session = WCSession.default
-            session.delegate = self
-            session.activate()
-        } else {
-            completion(!isPassOnCurrentDevice, isPassOnCurrentDevice ? [PassLocation.CURRENT_DEVICE] : [])
-        }
-    }
-
-    // no paired device: return pass on device (if exists), canAddPass = !ifExists
-    // paired device, no pass: return pass on device, canAddPass = true
-    // paried device, pass: return pass on paired device, return pass on device (if exists) canAddPass = !ifExists
-
-
-    // START: WCSessionDelegate methods
-
-    func session(_ session: WCSession, activationDidCompleteWith activationState: WCSessionActivationState, error: Error?) {
-        if activationState == .activated {
-            let existingPassOnPairedDevices: PKPass? = {
-                if #available(iOS 13.4, *) {
-                    return PKPassLibrary().remoteSecureElementPasses
-                        .first(where: { $0.secureElementPass?.primaryAccountNumberSuffix == last4 && $0.secureElementPass?.passActivationState != .suspended })
-                } else {
-                    return PKPassLibrary().remotePaymentPasses()
-                        .first(where: { $0.paymentPass?.primaryAccountNumberSuffix == last4 && $0.paymentPass?.passActivationState != .suspended })
-                }
-            }()
-
-            var passLocations: [PassLocation] = []
-            if (isPassOnCurrentDevice) {
-                passLocations.append(.CURRENT_DEVICE)
+        
+        let existingPassOnPairedDevices: PKPass? = {
+            if #available(iOS 13.4, *) {
+                return PKPassLibrary().remoteSecureElementPasses
+                    .first(where: { $0.secureElementPass?.primaryAccountNumberSuffix == last4 && $0.secureElementPass?.passActivationState != .deactivated })
+            } else {
+                return PKPassLibrary().remotePaymentPasses()
+                    .first(where: { $0.paymentPass?.primaryAccountNumberSuffix == last4 && $0.paymentPass?.passActivationState != .deactivated })
             }
-            if (existingPassOnPairedDevices != nil) {
-                passLocations.append(.PAIRED_DEVICE)
-            }
-
-            findPassOnWatchCompletion(
-                passLocations.count < 2,
-                passLocations
-            )
-        } else {
-            findPassOnWatchCompletion(!isPassOnCurrentDevice, isPassOnCurrentDevice ? [PassLocation.CURRENT_DEVICE] : [])
+        }()
+        
+        var passLocations: [PassLocation] = []
+        if (existingPassOnDevice != nil) {
+            passLocations.append(.CURRENT_DEVICE)
         }
+        if (existingPassOnPairedDevices != nil) {
+            passLocations.append(.PAIRED_DEVICE)
+        }
+        
+        completion(
+            passLocations.count < 2,
+            passLocations
+        )
     }
-
-    func sessionDidBecomeInactive(_ session: WCSession) {}
-
-    func sessionDidDeactivate(_ session: WCSession) {}
-
-    // END: WCSessionDelegate methods
 }

--- a/ios/PaymentPassFinder.swift
+++ b/ios/PaymentPassFinder.swift
@@ -13,7 +13,7 @@ internal class PaymentPassFinder: NSObject, WCSessionDelegate {
         case CURRENT_DEVICE
         case PAIRED_DEVICE
     }
-    
+
     private var last4: String
     private var findPassOnWatchCompletion: ((Bool, [PassLocation]) -> Void)
     private var isPassOnCurrentDevice: Bool = false
@@ -22,7 +22,7 @@ internal class PaymentPassFinder: NSObject, WCSessionDelegate {
         self.last4 = last4
         self.findPassOnWatchCompletion = completion
         super.init()
-        
+
         let existingPassOnDevice: PKPass? = {
             if #available(iOS 13.4, *) {
                 return PKPassLibrary().passes(of: PKPassType.secureElement)
@@ -32,9 +32,9 @@ internal class PaymentPassFinder: NSObject, WCSessionDelegate {
                     .first(where: { $0.paymentPass?.primaryAccountNumberSuffix == last4 && $0.paymentPass?.passActivationState != .suspended && !$0.isRemotePass })
             }
         }()
-        
+
         self.isPassOnCurrentDevice = existingPassOnDevice != nil
-        
+
         if WCSession.isSupported() {
             findPassOnWatchCompletion = completion
             let session = WCSession.default
@@ -44,14 +44,14 @@ internal class PaymentPassFinder: NSObject, WCSessionDelegate {
             completion(!isPassOnCurrentDevice, isPassOnCurrentDevice ? [PassLocation.CURRENT_DEVICE] : [])
         }
     }
-    
+
     // no paired device: return pass on device (if exists), canAddPass = !ifExists
     // paired device, no pass: return pass on device, canAddPass = true
     // paried device, pass: return pass on paired device, return pass on device (if exists) canAddPass = !ifExists
-    
-    
+
+
     // START: WCSessionDelegate methods
-    
+
     func session(_ session: WCSession, activationDidCompleteWith activationState: WCSessionActivationState, error: Error?) {
         if activationState == .activated {
             let existingPassOnPairedDevices: PKPass? = {
@@ -63,7 +63,7 @@ internal class PaymentPassFinder: NSObject, WCSessionDelegate {
                         .first(where: { $0.paymentPass?.primaryAccountNumberSuffix == last4 && $0.paymentPass?.passActivationState != .suspended })
                 }
             }()
-            
+
             var passLocations: [PassLocation] = []
             if (isPassOnCurrentDevice) {
                 passLocations.append(.CURRENT_DEVICE)
@@ -71,7 +71,7 @@ internal class PaymentPassFinder: NSObject, WCSessionDelegate {
             if (existingPassOnPairedDevices != nil) {
                 passLocations.append(.PAIRED_DEVICE)
             }
-            
+
             findPassOnWatchCompletion(
                 passLocations.count < 2,
                 passLocations
@@ -80,10 +80,10 @@ internal class PaymentPassFinder: NSObject, WCSessionDelegate {
             findPassOnWatchCompletion(!isPassOnCurrentDevice, isPassOnCurrentDevice ? [PassLocation.CURRENT_DEVICE] : [])
         }
     }
-    
+
     func sessionDidBecomeInactive(_ session: WCSession) {}
-    
+
     func sessionDidDeactivate(_ session: WCSession) {}
-    
+
     // END: WCSessionDelegate methods
 }

--- a/ios/StripeSdk.swift
+++ b/ios/StripeSdk.swift
@@ -1044,7 +1044,7 @@ class StripeSdk: RCTEventEmitter, STPApplePayContextDelegate, STPBankSelectionVi
             resolve(Errors.createError(ErrorType.Failed, "You must provide `cardLastFour`"))
             return
         }
-        resolve(["isInWallet": PushProvisioningUtils.passExistsWith(last4: last4)])
+        resolve(["isInWallet": PushProvisioningUtils.getPassLocation(last4: last4) != .NONE])
     }
     
     @objc(collectBankAccountToken:resolver:rejecter:)

--- a/ios/StripeSdk.swift
+++ b/ios/StripeSdk.swift
@@ -1025,13 +1025,16 @@ class StripeSdk: RCTEventEmitter, STPApplePayContextDelegate, STPBankSelectionVi
             resolve(Errors.createError(ErrorType.Failed, "You must provide `cardLastFour`"))
             return
         }
-        let (canAddCard, status) = PushProvisioningUtils.canAddCardToWallet(last4: last4,
-                                                 primaryAccountIdentifier: params["primaryAccountIdentifier"] as? String ?? "",
-                                                 testEnv: params["testEnv"] as? Bool ?? false)
-        resolve([
-            "canAddCard": canAddCard,
-            "details": ["status": status?.rawValue],
-        ])
+        PushProvisioningUtils.canAddCardToWallet(
+            last4: last4,
+            primaryAccountIdentifier: params["primaryAccountIdentifier"] as? String ?? "",
+            testEnv: params["testEnv"] as? Bool ?? false)
+        { canAddCard, status in
+            resolve([
+                "canAddCard": canAddCard,
+                "details": ["status": status?.rawValue],
+            ])
+        }
     }
     
     @objc(isCardInWallet:resolver:rejecter:)
@@ -1044,7 +1047,7 @@ class StripeSdk: RCTEventEmitter, STPApplePayContextDelegate, STPBankSelectionVi
             resolve(Errors.createError(ErrorType.Failed, "You must provide `cardLastFour`"))
             return
         }
-        resolve(["isInWallet": PushProvisioningUtils.getPassLocation(last4: last4) != .NONE])
+        resolve(["isInWallet": PushProvisioningUtils.getPassLocation(last4: last4) != nil])
     }
     
     @objc(collectBankAccountToken:resolver:rejecter:)

--- a/ios/Tests/PushProvisioningTests.swift
+++ b/ios/Tests/PushProvisioningTests.swift
@@ -42,8 +42,8 @@ class PushProvisioningTests: XCTestCase {
     
     func testCheckIfPassExists() throws {
         XCTAssertEqual(
-            PushProvisioningUtils.passExistsWith(last4: "4242"),
-            false
+            PushProvisioningUtils.getPassLocation(last4: "4242"),
+            .NONE
         )
     }
 }

--- a/ios/Tests/PushProvisioningTests.swift
+++ b/ios/Tests/PushProvisioningTests.swift
@@ -11,19 +11,21 @@ import XCTest
 
 class PushProvisioningTests: XCTestCase {
     func testCanAddCardToWalletInTestMode() throws {
-        let (canAddCard, status) = PushProvisioningUtils.canAddCardToWallet(last4: "4242",
+        PushProvisioningUtils.canAddCardToWallet(last4: "4242",
                                                  primaryAccountIdentifier: "",
-                                                 testEnv: true)
-        XCTAssertEqual(canAddCard, true)
-        XCTAssertEqual(status, nil)
+                                                                            testEnv: true) { canAddCard, status in
+            XCTAssertEqual(canAddCard, true)
+            XCTAssertEqual(status, nil)
+        }
     }
 
     func testCanAddCardToWalletInLiveMode() throws {
-        let (canAddCard, status) = PushProvisioningUtils.canAddCardToWallet(last4: "4242",
+        PushProvisioningUtils.canAddCardToWallet(last4: "4242",
                                                  primaryAccountIdentifier: "",
-                                                 testEnv: false)
-        XCTAssertEqual(canAddCard, false)
-        XCTAssertEqual(status, PushProvisioningUtils.AddCardToWalletStatus.MISSING_CONFIGURATION)
+                                                                            testEnv: false) { canAddCard, status in
+            XCTAssertEqual(canAddCard, false)
+            XCTAssertEqual(status, PushProvisioningUtils.AddCardToWalletStatus.MISSING_CONFIGURATION)
+        }
     }
     
     func testCanAddPaymentPassInTestMode() throws {
@@ -43,7 +45,7 @@ class PushProvisioningTests: XCTestCase {
     func testCheckIfPassExists() throws {
         XCTAssertEqual(
             PushProvisioningUtils.getPassLocation(last4: "4242"),
-            .NONE
+            nil
         )
     }
 }

--- a/ios/pushprovisioning/PushProvisioningUtils.swift
+++ b/ios/pushprovisioning/PushProvisioningUtils.swift
@@ -31,7 +31,7 @@ internal class PushProvisioningUtils {
                 canAddCard = false
                 status = AddCardToWalletStatus.CARD_ALREADY_EXISTS
             case .PAIRED_DEVICE:
-                canAddCard = false
+                canAddCard = true
                 status = AddCardToWalletStatus.CARD_EXISTS_ON_PAIRED_DEVICE
             case .NONE:
                break

--- a/ios/pushprovisioning/PushProvisioningUtils.swift
+++ b/ios/pushprovisioning/PushProvisioningUtils.swift
@@ -26,7 +26,7 @@ internal class PushProvisioningUtils {
         if (!canAddCard) {
             completion(canAddCard, AddCardToWalletStatus.MISSING_CONFIGURATION)
         } else {
-            _ = PaymentPassFinder.init(last4: last4) {canAddCardToADevice, passLocations in
+            PaymentPassFinder.findPassWithLast4(last4: last4) {canAddCardToADevice, passLocations in
                 var status: AddCardToWalletStatus? = nil
                 if (!canAddCardToADevice) {
                     status = AddCardToWalletStatus.CARD_ALREADY_EXISTS

--- a/ios/pushprovisioning/PushProvisioningUtils.swift
+++ b/ios/pushprovisioning/PushProvisioningUtils.swift
@@ -25,9 +25,17 @@ internal class PushProvisioningUtils {
         
         if (!canAddCard) {
             status = AddCardToWalletStatus.MISSING_CONFIGURATION
-        } else if (PushProvisioningUtils.passExistsWith(last4: last4)) {
-            canAddCard = false
-            status = AddCardToWalletStatus.CARD_ALREADY_EXISTS
+        } else {
+            switch PushProvisioningUtils.getPassLocation(last4: last4) {
+            case .CURRENT_DEVICE:
+                canAddCard = false
+                status = AddCardToWalletStatus.CARD_ALREADY_EXISTS
+            case .PAIRED_DEVICE:
+                canAddCard = false
+                status = AddCardToWalletStatus.CARD_EXISTS_ON_PAIRED_DEVICE
+            case .NONE:
+               break
+            }
         }
 
         return (canAddCard, status)
@@ -45,20 +53,40 @@ internal class PushProvisioningUtils {
         }
     }
     
-    class func passExistsWith(last4: String) -> Bool {
-        let existingPass: PKPass? = {
+    class func getPassLocation(last4: String) -> PassLocation {
+        let existingPassOnDevice: PKPass? = {
             if #available(iOS 13.4, *) {
-                return PKPassLibrary().passes(of: PKPassType.secureElement).first(where: {$0.secureElementPass?.primaryAccountNumberSuffix == last4})
+                return PKPassLibrary().passes(of: PKPassType.secureElement)
+                    .first(where: { $0.secureElementPass?.primaryAccountNumberSuffix == last4 && $0.secureElementPass?.passActivationState != .suspended && !$0.isRemotePass })
             } else {
-                return PKPassLibrary().passes(of: PKPassType.payment).first(where: {$0.paymentPass?.primaryAccountNumberSuffix == last4})
+                return PKPassLibrary().passes(of: PKPassType.payment)
+                    .first(where: { $0.paymentPass?.primaryAccountNumberSuffix == last4 && $0.paymentPass?.passActivationState != .suspended && !$0.isRemotePass })
             }
         }()
-        return existingPass != nil
+        
+        let existingPassOnPairedDevices: PKPass? = {
+            if #available(iOS 13.4, *) {
+                return PKPassLibrary().remoteSecureElementPasses
+                    .first(where: { $0.secureElementPass?.primaryAccountNumberSuffix == last4 && $0.secureElementPass?.passActivationState != .suspended })
+            } else {
+                return PKPassLibrary().remotePaymentPasses()
+                    .first(where: { $0.paymentPass?.primaryAccountNumberSuffix == last4 && $0.paymentPass?.passActivationState != .suspended })
+            }
+        }()
+        
+        return existingPassOnDevice != nil ? PassLocation.CURRENT_DEVICE : (existingPassOnPairedDevices != nil ? PassLocation.PAIRED_DEVICE : PassLocation.NONE)
     }
     
     enum AddCardToWalletStatus: String {
         case UNSUPPORTED_DEVICE
         case MISSING_CONFIGURATION
         case CARD_ALREADY_EXISTS
+        case CARD_EXISTS_ON_PAIRED_DEVICE
+    }
+    
+    enum PassLocation: String {
+        case CURRENT_DEVICE
+        case PAIRED_DEVICE
+        case NONE
     }
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -316,7 +316,7 @@ export type CanAddCardToWalletResult =
           | 'MISSING_CONFIGURATION'
           | 'UNSUPPORTED_DEVICE'
           | 'CARD_ALREADY_EXISTS'
-          | 'CARD_EXISTS_ON_PAIRED_DEVICE';
+          | 'CARD_EXISTS_ON_SOME_DEVICES';
       };
       error?: undefined;
     }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -315,7 +315,8 @@ export type CanAddCardToWalletResult =
         status?:
           | 'MISSING_CONFIGURATION'
           | 'UNSUPPORTED_DEVICE'
-          | 'CARD_ALREADY_EXISTS';
+          | 'CARD_ALREADY_EXISTS'
+          | 'CARD_EXISTS_ON_PAIRED_DEVICE';
       };
       error?: undefined;
     }


### PR DESCRIPTION
## Summary

`canAddCardToWallet` now check specifically for the existence of passes that exist on paired device like apple watches. If a pass exists on another paired device, then the merchant **should** show the 'add to apple wallet' button. added another status to the enum for debugging/clarity.

## Motivation

Apple's guidelines around this have changed.

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
