### PR TITLE
fix: fix inconsistent border width and radius on Android (#1181)

### DIFF
--- a/android/src/main/java/com/reactnativestripesdk/CardFieldView.kt
+++ b/android/src/main/java/com/reactnativestripesdk/CardFieldView.kt
@@ -11,6 +11,7 @@ import android.util.Log
 import android.widget.FrameLayout
 import androidx.core.os.LocaleListCompat
 import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.uimanager.PixelUtil
 import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.UIManagerModule
 import com.facebook.react.uimanager.events.EventDispatcher
@@ -146,14 +147,14 @@ class CardFieldView(context: ThemedReactContext) : FrameLayout(context) {
     mCardWidget.background = MaterialShapeDrawable(
       ShapeAppearanceModel()
         .toBuilder()
-        .setAllCorners(CornerFamily.ROUNDED, (borderRadius * 2).toFloat())
+        .setAllCorners(CornerFamily.ROUNDED, PixelUtil.toPixelFromDIP(borderRadius.toDouble()))
         .build()
     ).also { shape ->
       shape.strokeWidth = 0.0f
       shape.strokeColor = ColorStateList.valueOf(Color.parseColor("#000000"))
       shape.fillColor = ColorStateList.valueOf(Color.parseColor("#FFFFFF"))
       borderWidth?.let {
-        shape.strokeWidth = (it * 2).toFloat()
+        shape.strokeWidth = PixelUtil.toPixelFromDIP(it.toDouble())
       }
       borderColor?.let {
         shape.strokeColor = ColorStateList.valueOf(Color.parseColor(it))

--- a/android/src/main/java/com/reactnativestripesdk/CardFormView.kt
+++ b/android/src/main/java/com/reactnativestripesdk/CardFormView.kt
@@ -9,6 +9,7 @@ import android.view.View
 import android.view.View.OnFocusChangeListener
 import android.widget.FrameLayout
 import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.uimanager.PixelUtil
 import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.UIManagerModule
 import com.facebook.react.uimanager.events.EventDispatcher
@@ -194,14 +195,14 @@ class CardFormView(context: ThemedReactContext) : FrameLayout(context) {
     cardFormViewBinding.cardMultilineWidgetContainer.background = MaterialShapeDrawable(
       ShapeAppearanceModel()
         .toBuilder()
-        .setAllCorners(CornerFamily.ROUNDED, (borderRadius * 2).toFloat())
+        .setAllCorners(CornerFamily.ROUNDED, PixelUtil.toPixelFromDIP(borderRadius.toDouble()))
         .build()
     ).also { shape ->
       shape.strokeWidth = 0.0f
       shape.strokeColor = ColorStateList.valueOf(Color.parseColor("#000000"))
       shape.fillColor = ColorStateList.valueOf(Color.parseColor("#FFFFFF"))
       borderWidth?.let {
-        shape.strokeWidth = (it * 2).toFloat()
+        shape.strokeWidth = PixelUtil.toPixelFromDIP(it.toDouble())
       }
       borderColor?.let {
         shape.strokeColor = ColorStateList.valueOf(Color.parseColor(it))


### PR DESCRIPTION
## Summary
The dimension values coming from the JS side should be regarded as DIP values and be properly converted. This PR handles the `borderWidth` and `borderRadius` values with the `PixelUtil.toPixelFromDIP` util function provided by React Native. See [the similar usage in RN's codebase](https://github.com/facebook/react-native/blob/5449148482271d60c87f6e5fa4483e69d4410320/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.java#L130).


## Motivation
#1181 

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [ ] I added automated tests

### Before:

| CardField | CardForm |
| ------------- | ------------- |
| ![Screenshot_20221024_112115](https://user-images.githubusercontent.com/7088631/197443539-4340b143-99df-4c09-a77a-55379b804567.png) | ![Screenshot_20221024_112417](https://user-images.githubusercontent.com/7088631/197443551-3dfdfb61-ec5a-4726-9a7c-7982c05ad366.png) |

### After:

| CardField | CardForm |
| ------------- | ------------- |
| ![Screenshot_20221024_112601](https://user-images.githubusercontent.com/7088631/197443576-e24964bc-9349-4fda-a785-20ccd55559a7.png) | ![Screenshot_20221024_112618](https://user-images.githubusercontent.com/7088631/197443589-0954f63c-68f7-41f9-9715-0d3cc4f4c622.png) |

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
