### PR TITLE
fix: use mavenCentral repository instead of jCenter

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,7 +4,7 @@ buildscript {
 
   repositories {
     google()
-    jcenter()
+    mavenCentral()
   }
 
   dependencies {
@@ -57,7 +57,6 @@ android {
 
 repositories {
   mavenCentral()
-  jcenter()
   google()
 
   def found = false


### PR DESCRIPTION
## Summary
Removed jCenter repository references from build.gradle to use mavenCentral
Fixes #1186 

## Motivation
We are not anymore able to build our android app because jCenter is unavailable

## Testing
- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
