### PR TITLE
fix: 'when' expression must be exhaustive. Kotlin 1.7.10

### DIFF
--- a/android/src/main/java/com/reactnativestripesdk/utils/Mappers.kt
+++ b/android/src/main/java/com/reactnativestripesdk/utils/Mappers.kt
@@ -487,10 +487,7 @@ internal fun mapNextAction(type: NextActionType?, data: NextActionData?): Writab
     NextActionType.AlipayRedirect -> { // TODO: Can't access, private
       return null
     }
-    NextActionType.BlikAuthorize, NextActionType.UseStripeSdk, null -> {
-      return null
-    }
-    else -> {
+    NextActionType.BlikAuthorize, NextActionType.UseStripeSdk, NextActionType.UpiAwaitNotification,  null -> {
       return null
     }
   }

--- a/android/src/main/java/com/reactnativestripesdk/utils/Mappers.kt
+++ b/android/src/main/java/com/reactnativestripesdk/utils/Mappers.kt
@@ -490,6 +490,9 @@ internal fun mapNextAction(type: NextActionType?, data: NextActionData?): Writab
     NextActionType.BlikAuthorize, NextActionType.UseStripeSdk, null -> {
       return null
     }
+    else -> {
+      return null
+    }
   }
   return nextActionMap
 }


### PR DESCRIPTION
fix: 'when' expression must be exhaustive, add necessary 'UpiAwaitNotification' branch or 'else' branch instead

When upgrading Kotlin version to 1.7.10, this error show up. So an 'else' condition is added in order to make the library compile again. It could easily be another specific case that contemplates 'UpiAwaitNotification' as well.

## Summary
When upgrading Kotlin version to 1.7.10, this error show up. So an 'else' condition is added in order to make the library compile again. It could easily be another specific case that contemplates 'UpiAwaitNotification' as well.

## Motivation
I believe this is a needed change for the library compatibility with Kotlin 1.7.10 new version. At least it was necessary for my project to build again.

## Testing
- [ x ] I tested this manually
- [ ] I added automated tests

## Documentation

Select one: 
- [ x ] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
