### PR TITLE
chore: add else to avoid kotlin error exhaustive "when"

### DIFF
--- a/android/src/main/java/com/reactnativestripesdk/utils/Mappers.kt
+++ b/android/src/main/java/com/reactnativestripesdk/utils/Mappers.kt
@@ -490,6 +490,7 @@ internal fun mapNextAction(type: NextActionType?, data: NextActionData?): Writab
     NextActionType.BlikAuthorize, NextActionType.UseStripeSdk, null -> {
       return null
     }
+    else -> throw IllegalStateException("Someone forgot to add enough fragment cases to 'when' clause!")
   }
   return nextActionMap
 }


### PR DESCRIPTION
## Summary
Fix the problem when try to compile kotlin show a error because the "when" clausure is exhaustive

## Motivation
Fixing a bug when try to use the library

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
