### PR TITLE
addListener/removeListeners stubs for RN 0.65+ compatibility

### DIFF
--- a/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
+++ b/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
@@ -112,6 +112,16 @@ class StripeSdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJ
     )
 
   @ReactMethod
+  fun addListener(eventName: String) {
+    // Keep: Required for RN built in Event Emitter Calls.
+  }
+
+  @ReactMethod
+  fun removeListeners(count: Int) {
+    // Keep: Required for RN built in Event Emitter Calls.
+  }
+
+  @ReactMethod
   fun initialise(params: ReadableMap, promise: Promise) {
     val publishableKey = getValOr(params, "publishableKey", null) as String
     val appInfo = getMapOrNull(params, "appInfo") as ReadableMap


### PR DESCRIPTION
## Summary
This PR adds `addListener` and `removeListeners` functions to `StripeSdkModule` to appease React Native 0.65+ builds.

## Motivation
Without this change several warnings are surfaced that are mentioned in issue #1032. React Native's motivation for surfacing this warning can be found in the commit comments [here](https://github.com/facebook/react-native/commit/114be1d2170bae2d29da749c07b45acf931e51e2).

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
