### PR TITLE
fix: add proguard file to keep optional push provisioning classes (if present)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ## Fixes
 
 - Fixed an issue where builds would error with the message `'const' enums are not supported.` [see commit](https://github.com/stripe/stripe-react-native/commit/f882bfa588aa6d23a980b4b43d2cca660ca1dd2a)
+- Fixed an issue where the `canAddCardToWallet` method would sometimes wrongly return `false` with a `details.status` of `MISSING_CONFIGURATION` in production builds. [#1215](https://github.com/stripe/stripe-react-native/pull/1215)
 
 ## 0.21.0 - 2022-11-15
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -35,6 +35,7 @@ android {
     versionName "1.0"
     vectorDrawables.useSupportLibrary = true
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+    consumerProguardFiles 'proguard-rules.txt'
   }
 
   buildTypes {

--- a/android/proguard-rules.txt
+++ b/android/proguard-rules.txt
@@ -1,0 +1,7 @@
+-keepclassmembers class com.google.android.gms.tapandpay.** {
+  public *;
+}
+
+-keepclassmembers class com.stripe.android.pushProvisioning.** {
+  public *;
+}

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -231,6 +231,8 @@ android {
     buildTypes {
         debug {
             signingConfig signingConfigs.debug
+            minifyEnabled true
+            proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
         }
         release {
             // Caution! In production, you need to generate your own keystore file.

--- a/example/android/app/proguard-rules.pro
+++ b/example/android/app/proguard-rules.pro
@@ -8,3 +8,5 @@
 #   http://developer.android.com/guide/developing/tools/proguard.html
 
 # Add any project specific keep options here:
+-keep class com.facebook.react.devsupport.** { *; }
+-dontwarn com.facebook.react.devsupport.**

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -374,7 +374,7 @@ PODS:
     - StripePayments (= 23.2.0)
     - StripePaymentsUI (= 23.2.0)
     - StripeUICore (= 23.2.0)
-  - stripe-react-native (0.20.0):
+  - stripe-react-native (0.21.0):
     - React-Core
     - Stripe (~> 23.2.0)
     - StripeApplePay (~> 23.2.0)
@@ -382,7 +382,7 @@ PODS:
     - StripePayments (~> 23.2.0)
     - StripePaymentSheet (~> 23.2.0)
     - StripePaymentsUI (~> 23.2.0)
-  - stripe-react-native/Tests (0.20.0):
+  - stripe-react-native/Tests (0.21.0):
     - React-Core
     - Stripe (~> 23.2.0)
     - StripeApplePay (~> 23.2.0)
@@ -637,7 +637,7 @@ SPEC CHECKSUMS:
   RNScreens: 4a1af06327774490d97342c00aee0c2bafb497b7
   SocketRocket: fccef3f9c5cedea1353a9ef6ada904fde10d6608
   Stripe: cc895392856dc7f401119a612e31f020b97cb8d1
-  stripe-react-native: 0aafc0344b8846d1a35f1cdc56c03aa5da878208
+  stripe-react-native: febc743cbd836030519cb3a0e53b858e06225f44
   StripeApplePay: 7e43d6b4b9f18e922ba683e549f199a4f6db6fde
   StripeCore: 6da916796f87ab91f3dae1d78a93602465964cbc
   StripeFinancialConnections: 312fbe670871c7a3227dce0e092d7d5bf209f75e


### PR DESCRIPTION
## Summary

SDK now keeps `com.google.android.gms.tapandpay` and `com.stripe.android.pushProvisioning` if present. 

## Motivation

bug fix

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [ ] I added automated tests

Tested new rules with and without these libraries present- builds succeed even with minification
## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
