### PR TITLE
[financial connections] enable native flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+### Breaking changes
+
+### New features
+
+## Fixes
+
+- Fixed the `ShippingMethod` type to contain the `isPending` field instead of a `type` field (which previously was never correct). This reflects the inputs accepted. [#1227](https://github.com/stripe/stripe-react-native/pull/1227)
+- Fixed the `ShippingMethod` type to contain the `startDate` and `endDate` keys, if applicable. [#1227](https://github.com/stripe/stripe-react-native/pull/1227)
+
 ## 0.22.0 - 2022-12-02
 
 ### Breaking changes

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -368,50 +368,50 @@ PODS:
     - React-Core
     - React-RCTImage
   - SocketRocket (0.6.0)
-  - Stripe (23.2.0):
-    - StripeApplePay (= 23.2.0)
-    - StripeCore (= 23.2.0)
-    - StripePayments (= 23.2.0)
-    - StripePaymentsUI (= 23.2.0)
-    - StripeUICore (= 23.2.0)
-  - stripe-react-native (0.21.0):
+  - Stripe (23.3.0):
+    - StripeApplePay (= 23.3.0)
+    - StripeCore (= 23.3.0)
+    - StripePayments (= 23.3.0)
+    - StripePaymentsUI (= 23.3.0)
+    - StripeUICore (= 23.3.0)
+  - stripe-react-native (0.22.0):
     - React-Core
-    - Stripe (~> 23.2.0)
-    - StripeApplePay (~> 23.2.0)
-    - StripeFinancialConnections (~> 23.2.0)
-    - StripePayments (~> 23.2.0)
-    - StripePaymentSheet (~> 23.2.0)
-    - StripePaymentsUI (~> 23.2.0)
-  - stripe-react-native/Tests (0.21.0):
+    - Stripe (~> 23.3.0)
+    - StripeApplePay (~> 23.3.0)
+    - StripeFinancialConnections (~> 23.3.0)
+    - StripePayments (~> 23.3.0)
+    - StripePaymentSheet (~> 23.3.0)
+    - StripePaymentsUI (~> 23.3.0)
+  - stripe-react-native/Tests (0.22.0):
     - React-Core
-    - Stripe (~> 23.2.0)
-    - StripeApplePay (~> 23.2.0)
-    - StripeFinancialConnections (~> 23.2.0)
-    - StripePayments (~> 23.2.0)
-    - StripePaymentSheet (~> 23.2.0)
-    - StripePaymentsUI (~> 23.2.0)
-  - StripeApplePay (23.2.0):
-    - StripeCore (= 23.2.0)
-  - StripeCore (23.2.0)
-  - StripeFinancialConnections (23.2.0):
-    - StripeCore (= 23.2.0)
-    - StripeUICore (= 23.2.0)
-  - StripePayments (23.2.0):
-    - StripeCore (= 23.2.0)
-    - StripePayments/Stripe3DS2 (= 23.2.0)
-  - StripePayments/Stripe3DS2 (23.2.0):
-    - StripeCore (= 23.2.0)
-  - StripePaymentSheet (23.2.0):
-    - StripeApplePay (= 23.2.0)
-    - StripeCore (= 23.2.0)
-    - StripePayments (= 23.2.0)
-    - StripePaymentsUI (= 23.2.0)
-  - StripePaymentsUI (23.2.0):
-    - StripeCore (= 23.2.0)
-    - StripePayments (= 23.2.0)
-    - StripeUICore (= 23.2.0)
-  - StripeUICore (23.2.0):
-    - StripeCore (= 23.2.0)
+    - Stripe (~> 23.3.0)
+    - StripeApplePay (~> 23.3.0)
+    - StripeFinancialConnections (~> 23.3.0)
+    - StripePayments (~> 23.3.0)
+    - StripePaymentSheet (~> 23.3.0)
+    - StripePaymentsUI (~> 23.3.0)
+  - StripeApplePay (23.3.0):
+    - StripeCore (= 23.3.0)
+  - StripeCore (23.3.0)
+  - StripeFinancialConnections (23.3.0):
+    - StripeCore (= 23.3.0)
+    - StripeUICore (= 23.3.0)
+  - StripePayments (23.3.0):
+    - StripeCore (= 23.3.0)
+    - StripePayments/Stripe3DS2 (= 23.3.0)
+  - StripePayments/Stripe3DS2 (23.3.0):
+    - StripeCore (= 23.3.0)
+  - StripePaymentSheet (23.3.0):
+    - StripeApplePay (= 23.3.0)
+    - StripeCore (= 23.3.0)
+    - StripePayments (= 23.3.0)
+    - StripePaymentsUI (= 23.3.0)
+  - StripePaymentsUI (23.3.0):
+    - StripeCore (= 23.3.0)
+    - StripePayments (= 23.3.0)
+    - StripeUICore (= 23.3.0)
+  - StripeUICore (23.3.0):
+    - StripeCore (= 23.3.0)
   - Yoga (1.14.0)
   - YogaKit (1.18.1):
     - Yoga (~> 1.14)
@@ -636,15 +636,15 @@ SPEC CHECKSUMS:
   RNCPicker: abc646b53a3d28ccfa3232c927a0ca52e0cf024d
   RNScreens: 4a1af06327774490d97342c00aee0c2bafb497b7
   SocketRocket: fccef3f9c5cedea1353a9ef6ada904fde10d6608
-  Stripe: cc895392856dc7f401119a612e31f020b97cb8d1
-  stripe-react-native: febc743cbd836030519cb3a0e53b858e06225f44
-  StripeApplePay: 7e43d6b4b9f18e922ba683e549f199a4f6db6fde
-  StripeCore: 6da916796f87ab91f3dae1d78a93602465964cbc
-  StripeFinancialConnections: 312fbe670871c7a3227dce0e092d7d5bf209f75e
-  StripePayments: 7651a56a2a7fe320e5e8b1cb0c2e881536b75021
-  StripePaymentSheet: 8803a9debac99541649fc18df4f4f9bdb72354c5
-  StripePaymentsUI: 50270053a2e348308d13ba4bc5082df789cb9b64
-  StripeUICore: 7727bbfd146f5c4a8dca7f9be241e2d0cdb70310
+  Stripe: 8a2e7c77fc28bff1d0961a129fac0cb2ed91ddcb
+  stripe-react-native: 1b59a802845636bb815d2977404b9ed6b69a01d9
+  StripeApplePay: 7b7a5e10891d2ea428cf1a3a737a07fe874f7e7d
+  StripeCore: 8122b0ffc76922ef0d3f3af3ecffd70c3bfabfc0
+  StripeFinancialConnections: 84eba7226fb5fde44287c537dbc0b265ac90e2c4
+  StripePayments: f263be25fd96ad8532399ecce4ac72447bcdd419
+  StripePaymentSheet: d6838cf23dc2c0bc596634201771ceec63714d60
+  StripePaymentsUI: 9b2e5059133fc2ee0e08c58e30a94045cd825b34
+  StripeUICore: 484172573bdc2f02d4607a550551be45a090c137
   Yoga: 0b84a956f7393ef1f37f3bb213c516184e4a689d
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 

--- a/example/src/screens/ApplePayScreen.tsx
+++ b/example/src/screens/ApplePayScreen.tsx
@@ -140,6 +140,8 @@ export default function ApplePayScreen() {
       detail: 'Arrives by June 29',
       label: 'Standard Shipping',
       amount: '3.21',
+      startDate: 1670554064,
+      endDate: 1670726864,
     },
     {
       identifier: 'express',
@@ -152,7 +154,11 @@ export default function ApplePayScreen() {
     {
       label: 'Subtotal',
       amount: '12.75',
-      paymentType: PlatformPay.PaymentType.Immediate,
+      paymentType: PlatformPay.PaymentType.Recurring,
+      startDate: 1670554064,
+      endDate: 1670726864,
+      intervalUnit: PlatformPay.IntervalUnit.Day,
+      intervalCount: 3,
     },
     {
       label: 'Shipping',

--- a/stripe-react-native.podspec
+++ b/stripe-react-native.podspec
@@ -1,7 +1,7 @@
 require 'json'
 
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
-stripe_version = '~> 23.2.0'
+stripe_version = '~> 23.3.0'
 
 Pod::Spec.new do |s|
   s.name         = 'stripe-react-native'


### PR DESCRIPTION
## Summary
This upgrades the native iOS library to allow for the native flow to be used for Financial Connections. It also makes some minor bug fixes: 

## Motivation

- closes https://github.com/stripe/stripe-react-native/issues/1196

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one: 
- [x] I have added relevant documentation for my changes.
- [] This PR does not result in any developer-facing changes.
