### PR TITLE
fix: move NativeEventEmitter inside hook

### DIFF
--- a/src/hooks/useApplePay.tsx
+++ b/src/hooks/useApplePay.tsx
@@ -3,8 +3,6 @@ import { useCallback, useEffect, useState } from 'react';
 import { useStripe } from './useStripe';
 import { NativeEventEmitter, NativeModules } from 'react-native';
 
-const eventEmitter = new NativeEventEmitter(NativeModules.StripeSdk);
-
 export interface Props {
   /**
    *
@@ -105,6 +103,7 @@ export function useApplePay({
   );
 
   useEffect(() => {
+    const eventEmitter = new NativeEventEmitter(NativeModules.StripeSdk);
     const didSetShippingMethodListener = eventEmitter.addListener(
       SET_SHIPPING_METHOD_CALLBACK_NAME,
       onDidSetShippingMethod


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
Move NativeEventEmitter instantiation to useEffect hook as stated in [the doc](https://reactnative.dev/docs/native-modules-android#sending-events-to-javascript).

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a link to the relevant issue, a code snippet, or an example project that demonstrates the bug. -->
There was a warning on Android because the emitter was instantiated but never used (addListeners/remove). This PR removes the warning. 
### Before 
<img width="394" alt="image (8)" src="https://user-images.githubusercontent.com/90315377/206147023-46da6110-9790-4c1b-bc61-89997405eb0a.png">

### After
<img width="394" alt="image (7)" src="https://user-images.githubusercontent.com/90315377/206147078-aa42c50a-c340-4d59-89e7-59655387d572.png">


## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [X] I tested this manually
- [ ] I added automated tests

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [X] This PR does not result in any developer-facing changes.
