### PR TITLE
fix: unduplicate registered views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Fixed the `ShippingMethod` type to contain the `isPending` field instead of a `type` field (which previously was never correct). This reflects the inputs accepted. [#1227](https://github.com/stripe/stripe-react-native/pull/1227)
 - Fixed the `ShippingMethod` type to contain the `startDate` and `endDate` keys, if applicable. [#1227](https://github.com/stripe/stripe-react-native/pull/1227)
+- Fixed instances of the "duplicate registered views" error. [#1233](https://github.com/stripe/stripe-react-native/pull/1233)
 
 ## 0.22.0 - 2022-12-02
 

--- a/src/components/ApplePayButton.tsx
+++ b/src/components/ApplePayButton.tsx
@@ -1,14 +1,7 @@
-import type { ApplePayButtonComponent } from '../types';
 import React, { useMemo } from 'react';
-import {
-  AccessibilityProps,
-  requireNativeComponent,
-  StyleProp,
-  ViewStyle,
-} from 'react-native';
-
-const ApplePayButtonNative =
-  requireNativeComponent<ApplePayButtonComponent.NativeProps>('ApplePayButton');
+import ApplePayButtonNative from './ApplePayButtonNative';
+import type { AccessibilityProps, StyleProp, ViewStyle } from 'react-native';
+import type { ApplePayButtonComponent } from '../types';
 
 /**
  *  Apple Pay Button Component Props

--- a/src/components/ApplePayButtonNative.tsx
+++ b/src/components/ApplePayButtonNative.tsx
@@ -1,0 +1,5 @@
+import { requireNativeComponent } from 'react-native';
+import type { ApplePayButtonComponent } from '../types';
+const ApplePayButtonNative =
+  requireNativeComponent<ApplePayButtonComponent.NativeProps>('ApplePayButton');
+export default ApplePayButtonNative;

--- a/src/components/GooglePayButton.tsx
+++ b/src/components/GooglePayButton.tsx
@@ -3,12 +3,10 @@ import {
   AccessibilityProps,
   StyleProp,
   ViewStyle,
-  requireNativeComponent,
   TouchableOpacity,
   StyleSheet,
 } from 'react-native';
-
-const GooglePayButtonNative = requireNativeComponent<any>('GooglePayButton');
+import GooglePayButtonNative from './GooglePayButtonNative';
 
 /**
  *  Google Pay Button Component Props

--- a/src/components/GooglePayButtonNative.tsx
+++ b/src/components/GooglePayButtonNative.tsx
@@ -1,0 +1,7 @@
+import { requireNativeComponent } from 'react-native';
+import type { GooglePayButtonComponent } from '../types';
+const GooglePayButtonNative =
+  requireNativeComponent<GooglePayButtonComponent.NativeProps>(
+    'GooglePayButton'
+  );
+export default GooglePayButtonNative;

--- a/src/components/PlatformPayButton.tsx
+++ b/src/components/PlatformPayButton.tsx
@@ -3,7 +3,6 @@ import {
   AccessibilityProps,
   StyleProp,
   ViewStyle,
-  requireNativeComponent,
   TouchableOpacity,
   StyleSheet,
   Platform,
@@ -15,9 +14,8 @@ import {
   ShippingMethod,
   ShippingContact,
 } from '../types/PlatformPay';
-
-const GooglePayButtonNative = requireNativeComponent<any>('GooglePayButton');
-const ApplePayButtonNative = requireNativeComponent<any>('ApplePayButton');
+import GooglePayButtonNative from './GooglePayButtonNative';
+import ApplePayButtonNative from './ApplePayButtonNative';
 
 /**
  *  PlatformPayButton Component Props

--- a/src/types/components/ApplePayButtonComponent.ts
+++ b/src/types/components/ApplePayButtonComponent.ts
@@ -1,11 +1,27 @@
-import type { StyleProp, ViewStyle } from 'react-native';
-
+import type { StyleProp, ViewStyle, NativeSyntheticEvent } from 'react-native';
+import type { ShippingMethod, ShippingContact } from '../PlatformPay';
 export interface NativeProps {
   style?: StyleProp<ViewStyle>;
+  disabled?: boolean;
   type?: number;
   buttonStyle?: number;
   borderRadius?: number;
   onPressAction?(): void;
+  onShippingMethodSelectedAction?: (
+    value: NativeSyntheticEvent<{
+      shippingMethod: ShippingMethod;
+    }>
+  ) => void;
+  onShippingContactSelectedAction?: (
+    value: NativeSyntheticEvent<{
+      shippingContact: ShippingContact;
+    }>
+  ) => void;
+  onCouponCodeEnteredAction?: (
+    value: NativeSyntheticEvent<{
+      couponCode: string;
+    }>
+  ) => void;
 }
 
 export type Type =

--- a/src/types/components/GooglePayButtonComponent.ts
+++ b/src/types/components/GooglePayButtonComponent.ts
@@ -1,0 +1,6 @@
+import type { StyleProp, ViewStyle } from 'react-native';
+export interface NativeProps {
+  style?: StyleProp<ViewStyle>;
+  type?: number;
+  buttonType?: string;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -21,6 +21,7 @@ import * as SetupIntent from './SetupIntent';
 import * as ThreeDSecure from './ThreeDSecure';
 import * as GooglePay from './GooglePay';
 import * as ApplePayButtonComponent from './components/ApplePayButtonComponent';
+import * as GooglePayButtonComponent from './components/GooglePayButtonComponent';
 import * as AuBECSDebitFormComponent from './components/AuBECSDebitFormComponent';
 import * as CardFieldInput from './components/CardFieldInput';
 import * as CardFormView from './components/CardFormView';
@@ -37,6 +38,7 @@ export {
   ThreeDSecure,
   GooglePay,
   ApplePayButtonComponent,
+  GooglePayButtonComponent,
   AuBECSDebitFormComponent,
   CardFieldInput,
   CardFormView,


### PR DESCRIPTION
## Summary
wraps the `requireNativeComponent` into it's own file 

## Motivation
fixes https://github.com/stripe/stripe-react-native/issues/1225
## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
