### PR TITLE
fix: remove additional margin in cardform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Fixed the `ShippingMethod` type to contain the `isPending` field instead of a `type` field (which previously was never correct). This reflects the inputs accepted. [#1227](https://github.com/stripe/stripe-react-native/pull/1227)
 - Fixed the `ShippingMethod` type to contain the `startDate` and `endDate` keys, if applicable. [#1227](https://github.com/stripe/stripe-react-native/pull/1227)
+- Fixed extra margin that was being added to `<CardForm />` on Android. [#1234](https://github.com/stripe/stripe-react-native/pull/1234)
 
 ## 0.22.0 - 2022-12-02
 

--- a/android/src/main/java/com/reactnativestripesdk/CardFieldView.kt
+++ b/android/src/main/java/com/reactnativestripesdk/CardFieldView.kt
@@ -2,7 +2,6 @@ package com.reactnativestripesdk
 
 import android.content.res.ColorStateList
 import android.graphics.Color
-import android.graphics.Typeface
 import android.os.Build
 import android.text.Editable
 import android.text.InputFilter
@@ -143,7 +142,6 @@ class CardFieldView(context: ThemedReactContext) : FrameLayout(context) {
       }
     }
 
-    mCardWidget.setPadding(40, 0, 40, 0)
     mCardWidget.background = MaterialShapeDrawable(
       ShapeAppearanceModel()
         .toBuilder()

--- a/android/src/main/java/com/reactnativestripesdk/CardFormView.kt
+++ b/android/src/main/java/com/reactnativestripesdk/CardFormView.kt
@@ -2,16 +2,12 @@ package com.reactnativestripesdk
 
 import android.content.res.ColorStateList
 import android.graphics.Color
-import android.graphics.Typeface
 import android.os.Build
 import android.text.InputFilter
 import android.view.View
 import android.view.View.OnFocusChangeListener
-import android.view.ViewGroup
 import android.widget.FrameLayout
-import androidx.core.view.marginBottom
 import androidx.core.view.setMargins
-import androidx.core.view.setPadding
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.uimanager.PixelUtil
 import com.facebook.react.uimanager.ThemedReactContext

--- a/android/src/main/java/com/reactnativestripesdk/CardFormView.kt
+++ b/android/src/main/java/com/reactnativestripesdk/CardFormView.kt
@@ -7,7 +7,11 @@ import android.os.Build
 import android.text.InputFilter
 import android.view.View
 import android.view.View.OnFocusChangeListener
+import android.view.ViewGroup
 import android.widget.FrameLayout
+import androidx.core.view.marginBottom
+import androidx.core.view.setMargins
+import androidx.core.view.setPadding
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.uimanager.PixelUtil
 import com.facebook.react.uimanager.ThemedReactContext
@@ -40,7 +44,7 @@ class CardFormView(context: ThemedReactContext) : FrameLayout(context) {
   init {
     cardFormViewBinding.cardMultilineWidgetContainer.isFocusable = true
     cardFormViewBinding.cardMultilineWidgetContainer.isFocusableInTouchMode = true
-
+    (cardFormViewBinding.cardMultilineWidgetContainer.layoutParams as MarginLayoutParams).setMargins(0)
     addView(cardForm)
     setListeners()
 
@@ -191,7 +195,6 @@ class CardFormView(context: ThemedReactContext) : FrameLayout(context) {
       }
     }
 
-    cardFormViewBinding.cardMultilineWidgetContainer.setPadding(40, 0, 40, 0)
     cardFormViewBinding.cardMultilineWidgetContainer.background = MaterialShapeDrawable(
       ShapeAppearanceModel()
         .toBuilder()


### PR DESCRIPTION
## Summary
removed some no-op setPadding lines, set cardMultilineWidgetContainer margins to zero

## Motivation
fixes https://github.com/stripe/stripe-react-native/issues/1172

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [ ] I added automated tests

before:
<img width="460" alt="Screen Shot 2022-12-07 at 11 45 27 AM" src="https://user-images.githubusercontent.com/97612659/206281067-84797f9f-4b42-4502-86c6-fc558da3d05b.png">

after:
<img width="442" alt="Screen Shot 2022-12-07 at 11 44 31 AM" src="https://user-images.githubusercontent.com/97612659/206281062-233e843f-a6e8-41e0-aef2-8e6e7a52fc1f.png">


## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
