### PR TITLE
fix: do not double-create Stripe token in Apple Pay flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## Fixes
+
+- Fixed an issue with `createPlatformPayPaymentMethod` on iOS where a "Canceled" error could be returned in production. [#1236](https://github.com/stripe/stripe-react-native/issues/1236)
+
 ## 0.22.1 - 2022-12-07
 
 ## Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,15 @@
 
 ## Unreleased
 
+### Breaking changes
+
+- `createPlatformPayPaymentMethod` no longer returns a `token` object. [#1236](https://github.com/stripe/stripe-react-native/issues/1236)
+  - If your integration depends on Stripe's Tokens API, please use `createPlatformPayToken`, which accepts identical arguments.
+
 ## Fixes
 
 - Fixed an issue with `createPlatformPayPaymentMethod` on iOS where a "Canceled" error could be returned in production. [#1236](https://github.com/stripe/stripe-react-native/issues/1236)
+- Fixed an issue where the `PlatformPayButton` with `type={PlatformPay.ButtonType.GooglePayMark}` would be unclickable. [#1236](https://github.com/stripe/stripe-react-native/issues/1236)
 
 ## 0.22.1 - 2022-12-07
 

--- a/android/src/main/java/com/reactnativestripesdk/GooglePayRequestHelper.kt
+++ b/android/src/main/java/com/reactnativestripesdk/GooglePayRequestHelper.kt
@@ -51,11 +51,11 @@ class GooglePayRequestHelper {
       val isPhoneNumberRequired = params?.getBooleanOr("isPhoneNumberRequired", false)
       val isRequired = params?.getBooleanOr("isRequired", false)
       val allowedCountryCodes = if (params?.hasKey("allowedCountryCodes") == true)
-        params.getArray("allowedCountryCodes") as Array<String> else Locale.getISOCountries()
+        params.getArray("allowedCountryCodes")?.toArrayList()?.toSet() as? Set<String> else null
 
       return GooglePayJsonFactory.ShippingAddressParameters(
         isRequired = isRequired ?: false,
-        allowedCountryCodes = allowedCountryCodes.toSet(),
+        allowedCountryCodes = allowedCountryCodes ?: Locale.getISOCountries().toSet(),
         phoneNumberRequired = isPhoneNumberRequired ?: false
       )
     }
@@ -98,12 +98,16 @@ class GooglePayRequestHelper {
       )
     }
 
-    internal fun handleGooglePaymentMethodResult(resultCode: Int, data: Intent?, stripe: Stripe, promise: Promise) {
+    internal fun handleGooglePaymentMethodResult(resultCode: Int, data: Intent?, stripe: Stripe, forToken: Boolean, promise: Promise) {
       when (resultCode) {
         Activity.RESULT_OK -> {
           data?.let { intent ->
             PaymentData.getFromIntent(intent)?.let {
-              resolveWithPaymentMethodAndToken(it, stripe, promise)
+              if (forToken) {
+                resolveWithToken(it, promise)
+              } else {
+                resolveWithPaymentMethod(it, stripe, promise)
+              }
             }
           }
         }
@@ -118,13 +122,9 @@ class GooglePayRequestHelper {
       }
     }
 
-    private fun resolveWithPaymentMethodAndToken(paymentData: PaymentData, stripe: Stripe, promise: Promise) {
+    private fun resolveWithPaymentMethod(paymentData: PaymentData, stripe: Stripe, promise: Promise) {
       val paymentInformation = JSONObject(paymentData.toJson())
-      val googlePayResult = GooglePayResult.fromJson(paymentInformation)
       val promiseResult = WritableNativeMap()
-      googlePayResult.token?.let {
-        promiseResult.putMap("token", mapFromToken(it))
-      }
       stripe.createPaymentMethod(
         PaymentMethodCreateParams.createFromGooglePay(paymentInformation),
         callback = object : ApiResultCallback<PaymentMethod> {
@@ -138,6 +138,18 @@ class GooglePayRequestHelper {
           }
         }
       )
+    }
+
+    private fun resolveWithToken(paymentData: PaymentData, promise: Promise) {
+      val paymentInformation = JSONObject(paymentData.toJson())
+      val googlePayResult = GooglePayResult.fromJson(paymentInformation)
+      val promiseResult = WritableNativeMap()
+      googlePayResult.token?.let {
+        promiseResult.putMap("token", mapFromToken(it))
+        promise.resolve(promiseResult)
+      } ?: run {
+        promise.resolve(createError("Failed", "Unexpected response from Google Pay. No token was found."))
+      }
     }
   }
 }

--- a/android/src/main/res/layout/googlepay_mark_button.xml
+++ b/android/src/main/res/layout/googlepay_mark_button.xml
@@ -7,9 +7,7 @@
   android:focusable="true"
   android:minWidth="1dp"
   android:background="@drawable/googlepay_mark_background">
-
   <ImageView
-    android:id="@+id/imageView2"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:cropToPadding="true"

--- a/docs/Platform-Pay-Migration.md
+++ b/docs/Platform-Pay-Migration.md
@@ -15,7 +15,8 @@
 
 - `confirmPlatformPaySetupIntent` if you were using them to confirm a setup intent
 - `confirmPlatformPayPayment` if you were using them to confirm a payment intent
-- `createPlatformPayPaymentMethod` if you were using them to create a payment method (this was impossible previously with Apple Pay, so it was only possible on Android). This method also now creates and returns the Stripe token object.
+- `createPlatformPayPaymentMethod` if you were using them to create a payment method (this was impossible previously with Apple Pay, so it was only possible on Android).
+- `createPlatformPayToken` if you are migrating from Tipsi Stripe and your payments code still uses the legacy Tokens API.
 
 # `updateApplePaySummaryItems`
 

--- a/example/src/screens/ApplePayScreen.tsx
+++ b/example/src/screens/ApplePayScreen.tsx
@@ -23,6 +23,7 @@ export default function ApplePayScreen() {
   const [clientSecret, setClientSecret] = useState<String | null>(null);
   const {
     createPlatformPayPaymentMethod,
+    createPlatformPayToken,
     isPlatformPaySupported,
     confirmPlatformPayPayment,
   } = usePlatformPay();
@@ -245,36 +246,57 @@ export default function ApplePayScreen() {
   };
 
   const createPaymentMethod = async () => {
-    const { paymentMethod, token, error } =
-      await createPlatformPayPaymentMethod({
-        applePay: {
-          cartItems: cart,
-          merchantCountryCode: 'US',
-          currencyCode: 'USD',
-          shippingMethods,
-          requiredShippingAddressFields: [
-            PlatformPay.ContactField.EmailAddress,
-            PlatformPay.ContactField.PhoneNumber,
-            PlatformPay.ContactField.PostalAddress,
-            PlatformPay.ContactField.Name,
-          ],
-          requiredBillingContactFields: [
-            PlatformPay.ContactField.PostalAddress,
-          ],
-          supportsCouponCode: true,
-          couponCode: '123',
-          shippingType: PlatformPay.ApplePayShippingType.StorePickup,
-          additionalEnabledNetworks: ['JCB'],
-        },
-      });
+    const { paymentMethod, error } = await createPlatformPayPaymentMethod({
+      applePay: {
+        cartItems: cart,
+        merchantCountryCode: 'US',
+        currencyCode: 'USD',
+        shippingMethods,
+        requiredShippingAddressFields: [
+          PlatformPay.ContactField.EmailAddress,
+          PlatformPay.ContactField.PhoneNumber,
+          PlatformPay.ContactField.PostalAddress,
+          PlatformPay.ContactField.Name,
+        ],
+        requiredBillingContactFields: [PlatformPay.ContactField.PostalAddress],
+        supportsCouponCode: true,
+        couponCode: '123',
+        shippingType: PlatformPay.ApplePayShippingType.StorePickup,
+        additionalEnabledNetworks: ['JCB'],
+      },
+    });
     if (error) {
       Alert.alert(error.code, error.localizedMessage);
     } else {
-      Alert.alert(
-        'Success',
-        'Check the logs for payment method and token details.'
-      );
+      Alert.alert('Success', 'Check the logs for payment method details.');
       console.log(JSON.stringify(paymentMethod, null, 2));
+    }
+  };
+
+  const createToken = async () => {
+    const { token, error } = await createPlatformPayToken({
+      applePay: {
+        cartItems: cart,
+        merchantCountryCode: 'US',
+        currencyCode: 'USD',
+        shippingMethods,
+        requiredShippingAddressFields: [
+          PlatformPay.ContactField.EmailAddress,
+          PlatformPay.ContactField.PhoneNumber,
+          PlatformPay.ContactField.PostalAddress,
+          PlatformPay.ContactField.Name,
+        ],
+        requiredBillingContactFields: [PlatformPay.ContactField.PostalAddress],
+        supportsCouponCode: true,
+        couponCode: '123',
+        shippingType: PlatformPay.ApplePayShippingType.StorePickup,
+        additionalEnabledNetworks: ['JCB'],
+      },
+    });
+    if (error) {
+      Alert.alert(error.code, error.localizedMessage);
+    } else {
+      Alert.alert('Success', 'Check the logs for token details.');
       console.log(JSON.stringify(token, null, 2));
     }
   };
@@ -328,6 +350,28 @@ export default function ApplePayScreen() {
           }}
         />
 
+        <PlatformPayButton
+          onPress={createToken}
+          type={PlatformPay.ButtonType.SetUp}
+          appearance={PlatformPay.ButtonStyle.Black}
+          borderRadius={4}
+          disabled={!isApplePaySupported}
+          style={styles.createPaymentMethodButton}
+          onCouponCodeEntered={couponCodeListener}
+          onShippingContactSelected={({ shippingContact }) => {
+            console.log(JSON.stringify(shippingContact, null, 2));
+            updatePlatformPaySheet({
+              applePay: { cartItems: cart, shippingMethods, errors: [] },
+            });
+          }}
+          onShippingMethodSelected={({ shippingMethod }) => {
+            console.log(JSON.stringify(shippingMethod, null, 2));
+            updatePlatformPaySheet({
+              applePay: { cartItems: cart, shippingMethods, errors: [] },
+            });
+          }}
+        />
+
         {showAddToWalletButton && (
           <AddToWalletButton
             androidAssetSource={{}}
@@ -361,13 +405,13 @@ const styles = StyleSheet.create({
   payButton: {
     width: '65%',
     height: 50,
-    marginTop: 40,
+    marginTop: 20,
     alignSelf: 'center',
   },
   createPaymentMethodButton: {
     width: '65%',
     height: 50,
-    marginTop: 40,
+    marginTop: 20,
     alignSelf: 'center',
   },
 });

--- a/example/src/screens/GooglePayScreen.tsx
+++ b/example/src/screens/GooglePayScreen.tsx
@@ -4,6 +4,7 @@ import {
   Constants,
   canAddCardToWallet,
   createPlatformPayPaymentMethod,
+  createPlatformPayToken,
   confirmPlatformPayPayment,
   GooglePayCardToken,
   isPlatformPaySupported,
@@ -123,34 +124,57 @@ export default function GooglePayScreen() {
     As an alternative you can only create a paymentMethod instead of confirming the payment.
   */
   const createPaymentMethod = async () => {
-    const { error, paymentMethod, token } =
-      await createPlatformPayPaymentMethod({
-        googlePay: {
-          amount: 12,
-          currencyCode: 'USD',
-          testEnv: true,
-          merchantName: 'Test',
-          merchantCountryCode: 'US',
-          billingAddressConfig: {
-            format: PlatformPay.BillingAddressFormat.Full,
-            isPhoneNumberRequired: true,
-            isRequired: true,
-          },
-          shippingAddressConfig: {
-            isRequired: true,
-          },
-          isEmailRequired: true,
+    const { error, paymentMethod } = await createPlatformPayPaymentMethod({
+      googlePay: {
+        amount: 12,
+        currencyCode: 'USD',
+        testEnv: true,
+        merchantName: 'Test',
+        merchantCountryCode: 'US',
+        billingAddressConfig: {
+          format: PlatformPay.BillingAddressFormat.Full,
+          isPhoneNumberRequired: true,
+          isRequired: true,
         },
-      });
+        shippingAddressConfig: {
+          isRequired: true,
+        },
+        isEmailRequired: true,
+      },
+    });
 
     if (error) {
       Alert.alert('Failure', error.localizedMessage);
     } else {
-      Alert.alert(
-        'Success',
-        'Check the logs for payment method and token details.'
-      );
+      Alert.alert('Success', 'Check the logs for payment method details.');
       console.log(JSON.stringify(paymentMethod, null, 2));
+    }
+  };
+
+  const createToken = async () => {
+    const { error, token } = await createPlatformPayToken({
+      googlePay: {
+        amount: 12,
+        currencyCode: 'USD',
+        testEnv: true,
+        merchantName: 'Test',
+        merchantCountryCode: 'US',
+        billingAddressConfig: {
+          format: PlatformPay.BillingAddressFormat.Full,
+          isPhoneNumberRequired: true,
+          isRequired: true,
+        },
+        shippingAddressConfig: {
+          isRequired: true,
+        },
+        isEmailRequired: true,
+      },
+    });
+
+    if (error) {
+      Alert.alert('Failure', error.localizedMessage);
+    } else {
+      Alert.alert('Success', 'Check the logs for token details.');
       console.log(JSON.stringify(token, null, 2));
     }
   };
@@ -172,43 +196,53 @@ export default function GooglePayScreen() {
 
   return (
     <PaymentScreen>
-      <PlatformPayButton
-        disabled={!isGooglePaySupported || !clientSecret}
-        style={styles.payButton}
-        type={PlatformPay.ButtonType.Pay}
-        onPress={pay}
-      />
+      <View style={styles.row}>
+        <PlatformPayButton
+          disabled={!isGooglePaySupported || !clientSecret}
+          style={styles.payButton}
+          type={PlatformPay.ButtonType.Pay}
+          onPress={pay}
+        />
+      </View>
 
       <View style={styles.row}>
         <PlatformPayButton
-          disabled={!false}
+          disabled={!isGooglePaySupported}
           style={styles.standardButton}
           type={PlatformPay.ButtonType.GooglePayMark}
           onPress={createPaymentMethod}
         />
+
+        <PlatformPayButton
+          disabled={!isGooglePaySupported}
+          style={styles.standardButton}
+          onPress={createToken}
+        />
       </View>
       {showAddToWalletButton && isGooglePaySupported && (
-        <AddToWalletButton
-          androidAssetSource={Image.resolveAssetSource(AddToGooglePayPNG)}
-          style={styles.addToWalletButton}
-          cardDetails={{
-            name: cardDetails?.cardholder?.name,
-            primaryAccountIdentifier:
-              cardDetails?.wallet?.primary_account_identifier,
-            lastFour: cardDetails?.last4,
-            description: 'Added by Stripe',
-          }}
-          token={androidCardToken}
-          ephemeralKey={ephemeralKey}
-          onComplete={({ error }) => {
-            Alert.alert(
-              error ? error.code : 'Success',
-              error
-                ? error.message
-                : 'Card was successfully added to the wallet.'
-            );
-          }}
-        />
+        <View style={styles.row}>
+          <AddToWalletButton
+            androidAssetSource={Image.resolveAssetSource(AddToGooglePayPNG)}
+            style={styles.addToWalletButton}
+            cardDetails={{
+              name: cardDetails?.cardholder?.name,
+              primaryAccountIdentifier:
+                cardDetails?.wallet?.primary_account_identifier,
+              lastFour: cardDetails?.last4,
+              description: 'Added by Stripe',
+            }}
+            token={androidCardToken}
+            ephemeralKey={ephemeralKey}
+            onComplete={({ error }) => {
+              Alert.alert(
+                error ? error.code : 'Success',
+                error
+                  ? error.message
+                  : 'Card was successfully added to the wallet.'
+              );
+            }}
+          />
+        </View>
       )}
     </PaymentScreen>
   );
@@ -217,6 +251,9 @@ export default function GooglePayScreen() {
 const styles = StyleSheet.create({
   row: {
     marginTop: 30,
+    flexDirection: 'row',
+    width: '100%',
+    justifyContent: 'space-around',
   },
   payButton: {
     width: 202,
@@ -227,7 +264,6 @@ const styles = StyleSheet.create({
     height: 48,
   },
   addToWalletButton: {
-    marginTop: 30,
     width: 190,
     height: 60,
   },

--- a/ios/ApplePayUtils.swift
+++ b/ios/ApplePayUtils.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 import StripePaymentSheet
-import Stripe
 
 class ApplePayUtils {
     
@@ -312,32 +311,6 @@ class ApplePayUtils {
             merchantCountryCode: countryCode,
             paymentSummaryItems:paymentSummaryItems.count > 0 ? paymentSummaryItems : nil
         )
-    }
-    
-    public class func billingDetails(from payment: PKPayment) -> STPPaymentMethodBillingDetails {
-        let billingDetails = STPPaymentMethodBillingDetails()
-        if let billingContact = payment.billingContact {
-            let billingAddress = STPAddress(pkContact: billingContact)
-            billingDetails.name = billingAddress.name
-            billingDetails.email = billingAddress.email
-            billingDetails.phone = billingAddress.phone
-            if (payment.billingContact?.postalAddress != nil) {
-                billingDetails.address = STPPaymentMethodAddress(address: billingAddress)
-            }
-        }
-
-        // Get email and phone from the PKPayment.shippingDetails
-        if let shippingContact = payment.shippingContact {
-            let shippingAddress = STPAddress(pkContact: shippingContact)
-            if billingDetails.email == nil && shippingAddress.email != nil {
-                billingDetails.email = shippingAddress.email
-            }
-            if billingDetails.phone == nil && shippingAddress.phone != nil {
-                billingDetails.phone = shippingAddress.phone
-            }
-        }
-        
-        return billingDetails
     }
 }
 

--- a/ios/ApplePayUtils.swift
+++ b/ios/ApplePayUtils.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import StripePaymentSheet
+import Stripe
 
 class ApplePayUtils {
     
@@ -311,6 +312,32 @@ class ApplePayUtils {
             merchantCountryCode: countryCode,
             paymentSummaryItems:paymentSummaryItems.count > 0 ? paymentSummaryItems : nil
         )
+    }
+    
+    public class func billingDetails(from payment: PKPayment) -> STPPaymentMethodBillingDetails {
+        let billingDetails = STPPaymentMethodBillingDetails()
+        if let billingContact = payment.billingContact {
+            let billingAddress = STPAddress(pkContact: billingContact)
+            billingDetails.name = billingAddress.name
+            billingDetails.email = billingAddress.email
+            billingDetails.phone = billingAddress.phone
+            if (payment.billingContact?.postalAddress != nil) {
+                billingDetails.address = STPPaymentMethodAddress(address: billingAddress)
+            }
+        }
+
+        // Get email and phone from the PKPayment.shippingDetails
+        if let shippingContact = payment.shippingContact {
+            let shippingAddress = STPAddress(pkContact: shippingContact)
+            if billingDetails.email == nil && shippingAddress.email != nil {
+                billingDetails.email = shippingAddress.email
+            }
+            if billingDetails.phone == nil && shippingAddress.phone != nil {
+                billingDetails.phone = shippingAddress.phone
+            }
+        }
+        
+        return billingDetails
     }
 }
 

--- a/ios/ApplePayViewController.swift
+++ b/ios/ApplePayViewController.swift
@@ -15,11 +15,19 @@ extension StripeSdk : PKPaymentAuthorizationViewControllerDelegate, STPApplePayC
         handler completion: @escaping (PKPaymentAuthorizationResult) -> Void
     ) {
         applePaymentMethodFlowCanBeCanceled = false
-        STPAPIClient.shared.createPaymentMethod(with: payment) { paymentMethod, error in
+        STPAPIClient.shared.createToken(with: payment) { token, error in
             if let error = error {
                 self.createPlatformPayPaymentMethodResolver?(Errors.createError(ErrorType.Failed, error))
             } else {
-                STPAPIClient.shared.createToken(with: payment) { token, error in
+                let cardParams = STPPaymentMethodCardParams()
+                cardParams.token = token?.tokenId
+                let billingDetails = ApplePayUtils.billingDetails(from: payment)
+                let paymentMethodParams = STPPaymentMethodParams(
+                    card: cardParams,
+                    billingDetails: billingDetails,
+                    metadata: nil
+                )
+                STPAPIClient.shared.createPaymentMethod(with: paymentMethodParams) { paymentMethod, error in
                     if let error = error {
                         self.createPlatformPayPaymentMethodResolver?(Errors.createError(ErrorType.Failed, error))
                     } else {

--- a/ios/ApplePayViewController.swift
+++ b/ios/ApplePayViewController.swift
@@ -15,31 +15,31 @@ extension StripeSdk : PKPaymentAuthorizationViewControllerDelegate, STPApplePayC
         handler completion: @escaping (PKPaymentAuthorizationResult) -> Void
     ) {
         applePaymentMethodFlowCanBeCanceled = false
-        STPAPIClient.shared.createToken(with: payment) { token, error in
-            if let error = error {
-                self.createPlatformPayPaymentMethodResolver?(Errors.createError(ErrorType.Failed, error))
-            } else {
-                let cardParams = STPPaymentMethodCardParams()
-                cardParams.token = token?.tokenId
-                let billingDetails = ApplePayUtils.billingDetails(from: payment)
-                let paymentMethodParams = STPPaymentMethodParams(
-                    card: cardParams,
-                    billingDetails: billingDetails,
-                    metadata: nil
-                )
-                STPAPIClient.shared.createPaymentMethod(with: paymentMethodParams) { paymentMethod, error in
-                    if let error = error {
-                        self.createPlatformPayPaymentMethodResolver?(Errors.createError(ErrorType.Failed, error))
-                    } else {
-                        var promiseResult = ["paymentMethod": Mappers.mapFromPaymentMethod(paymentMethod?.splitApplePayAddressByNewline()) ?? [:]]
-                        if let token = token {
-                            promiseResult["token"] = Mappers.mapFromToken(token: token.splitApplePayAddressByNewline())
-                        }
-                        self.createPlatformPayPaymentMethodResolver?(promiseResult)
-                    }
+        
+        if (platformPayUsesDeprecatedTokenFlow) {
+            STPAPIClient.shared.createToken(with: payment) { token, error in
+                if let error = error {
+                    self.createPlatformPayPaymentMethodResolver?(Errors.createError(ErrorType.Failed, error))
+                } else {
+                    let promiseResult = [
+                        "token": token != nil ? Mappers.mapFromToken(token: token!.splitApplePayAddressByNewline()) : [:]
+                    ]
+                    self.createPlatformPayPaymentMethodResolver?(promiseResult)
                 }
+                completion(PKPaymentAuthorizationResult.init(status: .success, errors: nil))
             }
-            completion(PKPaymentAuthorizationResult.init(status: .success, errors: nil))
+        } else {
+            STPAPIClient.shared.createPaymentMethod(with: payment) { paymentMethod, error in
+                if let error = error {
+                    self.createPlatformPayPaymentMethodResolver?(Errors.createError(ErrorType.Failed, error))
+                } else {
+                    let promiseResult = [
+                        "paymentMethod": Mappers.mapFromPaymentMethod(paymentMethod?.splitApplePayAddressByNewline()) ?? [:]
+                    ]
+                    self.createPlatformPayPaymentMethodResolver?(promiseResult)
+                }
+                completion(PKPaymentAuthorizationResult.init(status: .success, errors: nil))
+            }
         }
     }
     

--- a/ios/StripeSdk.m
+++ b/ios/StripeSdk.m
@@ -26,6 +26,7 @@ RCT_EXTERN_METHOD(
 
 RCT_EXTERN_METHOD(
                   createPlatformPayPaymentMethod:(NSDictionary *)params
+                  usesDeprecatedTokenFlow:(BOOL)usesDeprecatedTokenFlow
                   resolver: (RCTPromiseResolveBlock)resolve
                   rejecter: (RCTPromiseRejectBlock)reject)
 

--- a/ios/StripeSdk.swift
+++ b/ios/StripeSdk.swift
@@ -29,6 +29,7 @@ class StripeSdk: RCTEventEmitter, STPBankSelectionViewControllerDelegate, UIAdap
     
     var applePaymentAuthorizationController: PKPaymentAuthorizationViewController? = nil
     var createPlatformPayPaymentMethodResolver: RCTPromiseResolveBlock? = nil
+    var platformPayUsesDeprecatedTokenFlow = false
     var applePaymentMethodFlowCanBeCanceled = false
     
     var confirmPaymentClientSecret: String? = nil
@@ -536,8 +537,9 @@ class StripeSdk: RCTEventEmitter, STPBankSelectionViewControllerDelegate, UIAdap
         resolve(StripeAPI.deviceSupportsApplePay())
     }
     
-    @objc(createPlatformPayPaymentMethod:resolver:rejecter:)
+    @objc(createPlatformPayPaymentMethod:usesDeprecatedTokenFlow:resolver:rejecter:)
     func createPlatformPayPaymentMethod(params: NSDictionary,
+                                        usesDeprecatedTokenFlow: Bool,
                                           resolver resolve: @escaping RCTPromiseResolveBlock,
                                           rejecter reject: @escaping RCTPromiseRejectBlock) {
         guard let applePayPatams = params["applePay"] as? NSDictionary else {
@@ -554,6 +556,7 @@ class StripeSdk: RCTEventEmitter, STPBankSelectionViewControllerDelegate, UIAdap
         self.applePayShippingMethods = paymentRequest.shippingMethods ?? []
         self.applePayShippingAddressErrors = nil
         self.applePayCouponCodeErrors = nil
+        platformPayUsesDeprecatedTokenFlow = usesDeprecatedTokenFlow
         applePaymentMethodFlowCanBeCanceled = true
         createPlatformPayPaymentMethodResolver = resolve
         self.applePaymentAuthorizationController = PKPaymentAuthorizationViewController(paymentRequest: paymentRequest)

--- a/ios/Tests/ApplePayUtilsTests.swift
+++ b/ios/Tests/ApplePayUtilsTests.swift
@@ -177,6 +177,10 @@ class ApplePayUtilsTests: XCTestCase {
         }
     }
     
+    func test_billingDetails_emptyPKPayment() throws {
+        let result = ApplePayUtils.billingDetails(from: PKPayment.init())
+        XCTAssertNotNil(result)
+    }
     
     private struct TestFixtures {
         static let MERCHANT_ID = "merchant.com.id"

--- a/ios/Tests/ApplePayUtilsTests.swift
+++ b/ios/Tests/ApplePayUtilsTests.swift
@@ -177,11 +177,6 @@ class ApplePayUtilsTests: XCTestCase {
         }
     }
     
-    func test_billingDetails_emptyPKPayment() throws {
-        let result = ApplePayUtils.billingDetails(from: PKPayment.init())
-        XCTAssertNotNil(result)
-    }
-    
     private struct TestFixtures {
         static let MERCHANT_ID = "merchant.com.id"
         static let COUNTRY_CODE = "US"

--- a/jest/mock.js
+++ b/jest/mock.js
@@ -34,6 +34,9 @@ const mockFunctions = {
   dismissPlatformPay: jest.fn(async () => true),
   createPlatformPayPaymentMethod: jest.fn(async () => ({
     paymentMethod: {},
+    error: null,
+  })),
+  createPlatformPayToken: jest.fn(async () => ({
     token: {},
     error: null,
   })),
@@ -176,6 +179,9 @@ const mockHooks = {
     })),
     createPlatformPayPaymentMethod: jest.fn(async () => ({
       ...mockFunctions.createPlatformPayPaymentMethod(),
+    })),
+    createPlatformPayToken: jest.fn(async () => ({
+      ...mockFunctions.createPlatformPayToken(),
     })),
     updatePlatformPaySheet: jest.fn(async () => ({
       ...mockFunctions.updatePlatformPaySheet(),

--- a/src/NativeStripeSdk.tsx
+++ b/src/NativeStripeSdk.tsx
@@ -111,8 +111,9 @@ type NativeStripeSdkType = {
     googlePay?: GooglePay.IsSupportedParams;
   }): Promise<boolean>;
   createPlatformPayPaymentMethod(
-    params: PlatformPay.PaymentMethodParams
-  ): Promise<PlatformPay.PaymentMethodResult>;
+    params: PlatformPay.PaymentMethodParams,
+    usesDeprecatedTokenFlow: boolean
+  ): Promise<PlatformPay.PaymentMethodResult | PlatformPay.TokenResult>;
   dismissPlatformPay(): Promise<boolean>;
   updatePlatformPaySheet(
     summaryItems: Array<ApplePay.CartSummaryItem>,

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -810,16 +810,19 @@ export const dismissPlatformPay = async (): Promise<boolean> => {
 };
 
 /**
- * Launches the relevant native wallet sheet (Apple Pay on iOS, Google Pay on Android) in order to create a Stripe [PaymentMethod](https://stripe.com/docs/api/payment_methods) and [token](https://stripe.com/docs/api/tokens).
+ * Launches the relevant native wallet sheet (Apple Pay on iOS, Google Pay on Android) in order to create a Stripe [PaymentMethod](https://stripe.com/docs/api/payment_methods).
  * @param params an object describing the Apple Pay and Google Pay configurations.
- * @returns An object with an error field if something went wrong or the flow was cancelled, otherwise an object with both `paymentMethod` and `token` fields.
+ * @returns An object with an error field if something went wrong or the flow was cancelled, otherwise an object with a `paymentMethod` field.
  */
 export const createPlatformPayPaymentMethod = async (
   params: PlatformPay.PaymentMethodParams
 ): Promise<PlatformPay.PaymentMethodResult> => {
   try {
-    const { error, paymentMethod, token } =
-      await NativeStripeSdk.createPlatformPayPaymentMethod(params);
+    const { error, paymentMethod } =
+      (await NativeStripeSdk.createPlatformPayPaymentMethod(
+        params,
+        false
+      )) as PlatformPay.PaymentMethodResult;
     if (error) {
       return {
         error,
@@ -827,6 +830,34 @@ export const createPlatformPayPaymentMethod = async (
     }
     return {
       paymentMethod: paymentMethod!,
+    };
+  } catch (error: any) {
+    return {
+      error,
+    };
+  }
+};
+
+/**
+ * @deprecated The Tokens API is deprecated, you should use Payment Methods and `createPlatformPayPaymentMethod` instead.  Launches the relevant native wallet sheet (Apple Pay on iOS, Google Pay on Android) in order to create a Stripe [token](https://stripe.com/docs/api/tokens).
+ * @param params an object describing the Apple Pay and Google Pay configurations.
+ * @returns An object with an error field if something went wrong or the flow was cancelled, otherwise an object with a `token` field.
+ */
+export const createPlatformPayToken = async (
+  params: PlatformPay.PaymentMethodParams
+): Promise<PlatformPay.TokenResult> => {
+  try {
+    const { error, token } =
+      (await NativeStripeSdk.createPlatformPayPaymentMethod(
+        params,
+        true
+      )) as PlatformPay.TokenResult;
+    if (error) {
+      return {
+        error,
+      };
+    }
+    return {
       token: token!,
     };
   } catch (error: any) {

--- a/src/hooks/usePlatformPay.tsx
+++ b/src/hooks/usePlatformPay.tsx
@@ -15,6 +15,7 @@ export function usePlatformPay() {
     confirmPlatformPaySetupIntent,
     confirmPlatformPayPayment,
     createPlatformPayPaymentMethod,
+    createPlatformPayToken,
     dismissPlatformPay,
     updatePlatformPaySheet,
     canAddCardToWallet,
@@ -68,6 +69,18 @@ export function usePlatformPay() {
       return result;
     },
     [createPlatformPayPaymentMethod]
+  );
+
+  const _createPlatformPayToken = useCallback(
+    async (params: PlatformPay.PaymentMethodParams) => {
+      setLoading(true);
+
+      const result = await createPlatformPayToken(params);
+      setLoading(false);
+
+      return result;
+    },
+    [createPlatformPayToken]
   );
 
   const _dismissPlatformPay = useCallback(async () => {
@@ -143,6 +156,12 @@ export function usePlatformPay() {
      * @returns An object with an error field if something went wrong or the flow was cancelled, otherwise an object with both `paymentMethod` and `token` fields.
      */
     createPlatformPayPaymentMethod: _createPlatformPayPaymentMethod,
+    /**
+     * @deprecated The Tokens API is deprecated, you should use Payment Methods and `createPlatformPayPaymentMethod` instead.  Launches the relevant native wallet sheet (Apple Pay on iOS, Google Pay on Android) in order to create a Stripe [token](https://stripe.com/docs/api/tokens).
+     * @param params an object describing the Apple Pay and Google Pay configurations.
+     * @returns An object with an error field if something went wrong or the flow was cancelled, otherwise an object with a `token` field.
+     */
+    createPlatformPayToken: _createPlatformPayToken,
     /**
      * Dismiss the Apple Pay sheet if it is open. iOS only, this is a no-op on Android.
      * @returns A boolean indicating whether or not the sheet was successfully closed. Will return false if the Apple Pay sheet was not open.

--- a/src/hooks/useStripe.tsx
+++ b/src/hooks/useStripe.tsx
@@ -72,6 +72,7 @@ import {
   confirmPlatformPayPayment,
   dismissPlatformPay,
   createPlatformPayPaymentMethod,
+  createPlatformPayToken,
   updatePlatformPaySheet,
   openPlatformPaySetup,
 } from '../functions';
@@ -367,6 +368,15 @@ export function useStripe() {
     []
   );
 
+  const _createPlatformPayToken = useCallback(
+    async (
+      params: PlatformPay.PaymentMethodParams
+    ): Promise<PlatformPay.TokenResult> => {
+      return createPlatformPayToken(params);
+    },
+    []
+  );
+
   const _updatePlatformPaySheet = useCallback(
     async (params: {
       applePay: {
@@ -426,6 +436,7 @@ export function useStripe() {
     confirmPlatformPayPayment: _confirmPlatformPayPayment,
     dismissPlatformPay: _dismissPlatformPay,
     createPlatformPayPaymentMethod: _createPlatformPayPaymentMethod,
+    createPlatformPayToken: _createPlatformPayToken,
     updatePlatformPaySheet: _updatePlatformPaySheet,
     openPlatformPaySetup: _openPlatformPaySetup,
   };

--- a/src/types/PlatformPay.ts
+++ b/src/types/PlatformPay.ts
@@ -296,11 +296,19 @@ export type IsGooglePaySupportedParams = IsSupportedParams;
 export type PaymentMethodResult =
   | {
       paymentMethod: PaymentMethod;
-      token: Token;
       error?: undefined;
     }
   | {
       paymentMethod?: undefined;
+      error: StripeError<PlatformPayError>;
+    };
+
+export type TokenResult =
+  | {
+      token: Token;
+      error?: undefined;
+    }
+  | {
       token?: undefined;
       error: StripeError<PlatformPayError>;
     };


### PR DESCRIPTION

## Motivation
fixes https://github.com/stripe/stripe-react-native/issues/1236
## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [x] I added automated tests

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
