### PR TITLE
fix: remove instances of RCTConvert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Fixed an issue with `createPlatformPayPaymentMethod` on iOS where a "Canceled" error could be returned in production. [#1236](https://github.com/stripe/stripe-react-native/issues/1236)
 - Fixed an issue where the `PlatformPayButton` with `type={PlatformPay.ButtonType.GooglePayMark}` would be unclickable. [#1236](https://github.com/stripe/stripe-react-native/issues/1236)
 - Fixed an issue on Android where `CardField` would render without the necessary padding. [48debb2](https://github.com/stripe/stripe-react-native/commit/48debb27de4b02d8309b4e42737be066cdf33835)
+- Fixed an issue on iOS where providing a `null` value to certain method parameters would result in a crash. [#1252](https://github.com/stripe/stripe-react-native/pull/1252)
 
 ## 0.22.1 - 2022-12-07
 

--- a/ios/Mappers.swift
+++ b/ios/Mappers.swift
@@ -502,19 +502,19 @@ class Mappers {
             return nil
         }
         let billing = STPPaymentMethodBillingDetails()
-        billing.email = RCTConvert.nsString(billingDetails["email"])
-        billing.phone = RCTConvert.nsString(billingDetails["phone"])
-        billing.name = RCTConvert.nsString(billingDetails["name"])
+        billing.email = billingDetails["email"] as? String
+        billing.phone = billingDetails["phone"] as? String
+        billing.name = billingDetails["name"] as? String
 
         let address = STPPaymentMethodAddress()
 
         if let addressMap = billingDetails["address"] as? NSDictionary {
-            address.city = RCTConvert.nsString(addressMap["city"])
-            address.postalCode = RCTConvert.nsString(addressMap["postalCode"])
-            address.country = RCTConvert.nsString(addressMap["country"])
-            address.line1 = RCTConvert.nsString(addressMap["line1"])
-            address.line2 = RCTConvert.nsString(addressMap["line2"])
-            address.state = RCTConvert.nsString(addressMap["state"])
+            address.city = addressMap["city"] as? String
+            address.postalCode = addressMap["postalCode"] as? String
+            address.country = addressMap["country"] as? String
+            address.line1 = addressMap["line1"] as? String
+            address.line2 = addressMap["line2"] as? String
+            address.state = addressMap["state"] as? String
         }
 
         billing.address = address

--- a/ios/PaymentMethodFactory.swift
+++ b/ios/PaymentMethodFactory.swift
@@ -158,7 +158,7 @@ class PaymentMethodFactory {
     private func createCardPaymentMethodParams() throws -> STPPaymentMethodParams {
         if let token = paymentMethodData?["token"] as? String {
             let methodParams = STPPaymentMethodCardParams()
-            methodParams.token = RCTConvert.nsString(token)
+            methodParams.token = token
             return STPPaymentMethodParams(card: methodParams, billingDetails: billingDetailsParams, metadata: nil)
         }
 

--- a/ios/StripeSdk.swift
+++ b/ios/StripeSdk.swift
@@ -94,10 +94,10 @@ class StripeSdk: RCTEventEmitter, STPBankSelectionViewControllerDelegate, UIAdap
         StripeAPI.defaultPublishableKey = publishableKey
         STPAPIClient.shared.stripeAccount = stripeAccountId
 
-        let name = RCTConvert.nsString(appInfo["name"]) ?? ""
-        let partnerId = RCTConvert.nsString(appInfo["partnerId"]) ?? ""
-        let version = RCTConvert.nsString(appInfo["version"]) ?? ""
-        let url = RCTConvert.nsString(appInfo["url"]) ?? ""
+        let name = appInfo["name"] as? String ?? ""
+        let partnerId = appInfo["partnerId"] as? String ?? ""
+        let version = appInfo["version"] as? String ?? ""
+        let url = appInfo["url"] as? String ?? ""
 
         STPAPIClient.shared.appInfo = STPAppInfo(name: name, partnerId: partnerId, version: version, url: url)
         self.merchantIdentifier = merchantIdentifier


### PR DESCRIPTION
## Summary

remove RCTConvert

## Motivation

fix https://github.com/stripe/stripe-react-native/issues/1240 and avoid other instances

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
