### PR TITLE
Android: use FragmentActivity instead of AppCompatActivity

### DIFF
--- a/android/src/main/java/com/reactnativestripesdk/FinancialConnectionsSheetFragment.kt
+++ b/android/src/main/java/com/reactnativestripesdk/FinancialConnectionsSheetFragment.kt
@@ -5,8 +5,8 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
-import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentActivity
 import com.facebook.react.bridge.*
 import com.reactnativestripesdk.utils.*
 import com.reactnativestripesdk.utils.createError
@@ -69,7 +69,7 @@ class FinancialConnectionsSheetFragment : Fragment() {
       }
       is FinancialConnectionsSheetForTokenResult.Completed -> {
         promise.resolve(createTokenResult(result))
-        (context.currentActivity as? AppCompatActivity)?.supportFragmentManager?.beginTransaction()?.remove(this)?.commitAllowingStateLoss()
+        (context.currentActivity as? FragmentActivity)?.supportFragmentManager?.beginTransaction()?.remove(this)?.commitAllowingStateLoss()
       }
     }
   }
@@ -92,7 +92,7 @@ class FinancialConnectionsSheetFragment : Fragment() {
               it.putMap("session", mapFromSession(result.financialConnectionsSession))
             }
         )
-        (context.currentActivity as? AppCompatActivity)?.supportFragmentManager?.beginTransaction()?.remove(this)?.commitAllowingStateLoss()
+        (context.currentActivity as? FragmentActivity)?.supportFragmentManager?.beginTransaction()?.remove(this)?.commitAllowingStateLoss()
       }
     }
   }
@@ -107,7 +107,7 @@ class FinancialConnectionsSheetFragment : Fragment() {
       stripeAccountId = stripeAccountId,
     )
 
-    (context.currentActivity as? AppCompatActivity)?.let {
+    (context.currentActivity as? FragmentActivity)?.let {
       attemptToCleanupPreviousFragment(it)
       commitFragmentAndStartFlow(it)
     } ?: run {
@@ -116,13 +116,13 @@ class FinancialConnectionsSheetFragment : Fragment() {
     }
   }
 
-  private fun attemptToCleanupPreviousFragment(currentActivity: AppCompatActivity) {
+  private fun attemptToCleanupPreviousFragment(currentActivity: FragmentActivity) {
     currentActivity.supportFragmentManager.beginTransaction()
       .remove(this)
       .commitAllowingStateLoss()
   }
 
-  private fun commitFragmentAndStartFlow(currentActivity: AppCompatActivity) {
+  private fun commitFragmentAndStartFlow(currentActivity: FragmentActivity) {
     try {
       currentActivity.supportFragmentManager.beginTransaction()
         .add(this, TAG)

--- a/android/src/main/java/com/reactnativestripesdk/GooglePayLauncherFragment.kt
+++ b/android/src/main/java/com/reactnativestripesdk/GooglePayLauncherFragment.kt
@@ -5,8 +5,8 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
-import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentActivity
 import com.facebook.react.bridge.*
 import com.reactnativestripesdk.utils.*
 import com.reactnativestripesdk.utils.createError
@@ -57,7 +57,7 @@ class GooglePayLauncherFragment : Fragment() {
       allowCreditCards = googlePayParams.getBooleanOr("allowCreditCards", true),
     )
 
-    (context.currentActivity as? AppCompatActivity)?.let {
+    (context.currentActivity as? FragmentActivity)?.let {
       attemptToCleanupPreviousFragment(it)
       commitFragmentAndStartFlow(it)
     } ?: run {
@@ -66,13 +66,13 @@ class GooglePayLauncherFragment : Fragment() {
     }
   }
 
-  private fun attemptToCleanupPreviousFragment(currentActivity: AppCompatActivity) {
+  private fun attemptToCleanupPreviousFragment(currentActivity: FragmentActivity) {
     currentActivity.supportFragmentManager.beginTransaction()
       .remove(this)
       .commitAllowingStateLoss()
   }
 
-  private fun commitFragmentAndStartFlow(currentActivity: AppCompatActivity) {
+  private fun commitFragmentAndStartFlow(currentActivity: FragmentActivity) {
     try {
       currentActivity.supportFragmentManager.beginTransaction()
         .add(this, TAG)

--- a/android/src/main/java/com/reactnativestripesdk/GooglePayRequestHelper.kt
+++ b/android/src/main/java/com/reactnativestripesdk/GooglePayRequestHelper.kt
@@ -2,7 +2,7 @@ package com.reactnativestripesdk
 
 import android.app.Activity
 import android.content.Intent
-import androidx.appcompat.app.AppCompatActivity
+import androidx.fragment.app.FragmentActivity
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.WritableNativeMap
@@ -25,7 +25,7 @@ class GooglePayRequestHelper {
   companion object {
     internal const val LOAD_PAYMENT_DATA_REQUEST_CODE = 414243
 
-    internal fun createPaymentRequest(activity: AppCompatActivity, factory: GooglePayJsonFactory, googlePayParams: ReadableMap): Task<PaymentData> {
+    internal fun createPaymentRequest(activity: FragmentActivity, factory: GooglePayJsonFactory, googlePayParams: ReadableMap): Task<PaymentData> {
       val transactionInfo = buildTransactionInfo(googlePayParams)
       val merchantInfo = GooglePayJsonFactory.MerchantInfo(googlePayParams.getString("merchantName").orEmpty())
       val billingAddressParameters = buildBillingAddressParameters(googlePayParams.getMap("billingAddressConfig"))
@@ -90,7 +90,7 @@ class GooglePayRequestHelper {
       )
     }
 
-    internal fun createPaymentMethod(request: Task<PaymentData>, activity: AppCompatActivity) {
+    internal fun createPaymentMethod(request: Task<PaymentData>, activity: FragmentActivity) {
       AutoResolveHelper.resolveTask(
         request,
         activity,

--- a/android/src/main/java/com/reactnativestripesdk/PaymentLauncherFragment.kt
+++ b/android/src/main/java/com/reactnativestripesdk/PaymentLauncherFragment.kt
@@ -5,8 +5,8 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
-import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentActivity
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
 import com.reactnativestripesdk.utils.*
@@ -107,7 +107,7 @@ class PaymentLauncherFragment(
     }
 
     private fun addFragment(fragment: PaymentLauncherFragment, context: ReactApplicationContext, promise: Promise) {
-      (context.currentActivity as? AppCompatActivity)?.let {
+      (context.currentActivity as? FragmentActivity)?.let {
         try {
           it.supportFragmentManager.beginTransaction()
             .add(fragment, TAG)

--- a/android/src/main/java/com/reactnativestripesdk/PaymentSheetAppearance.kt
+++ b/android/src/main/java/com/reactnativestripesdk/PaymentSheetAppearance.kt
@@ -1,12 +1,13 @@
 package com.reactnativestripesdk
 
+import android.content.Context
 import android.graphics.Color
 import android.os.Bundle
 import com.facebook.react.bridge.ReactContext
 import com.reactnativestripesdk.utils.PaymentSheetAppearanceException
 import com.stripe.android.paymentsheet.PaymentSheet
 
-fun buildPaymentSheetAppearance(userParams: Bundle?, context: ReactContext): PaymentSheet.Appearance {
+fun buildPaymentSheetAppearance(userParams: Bundle?, context: Context): PaymentSheet.Appearance {
   val colorParams = userParams?.getBundle(PaymentSheetAppearanceKeys.COLORS)
   val lightColorParams = colorParams?.getBundle(PaymentSheetAppearanceKeys.LIGHT) ?: colorParams
   val darkColorParams = colorParams?.getBundle(PaymentSheetAppearanceKeys.DARK) ?: colorParams
@@ -20,7 +21,7 @@ fun buildPaymentSheetAppearance(userParams: Bundle?, context: ReactContext): Pay
   )
 }
 
-private fun buildTypography(fontParams: Bundle?, context: ReactContext): PaymentSheet.Typography {
+private fun buildTypography(fontParams: Bundle?, context: Context): PaymentSheet.Typography {
   return PaymentSheet.Typography.default.copy(
     sizeScaleFactor = getFloatOr(fontParams, PaymentSheetAppearanceKeys.SCALE, PaymentSheet.Typography.default.sizeScaleFactor),
     fontResId = getFontResId(fontParams, PaymentSheetAppearanceKeys.FAMILY, PaymentSheet.Typography.default.fontResId, context)
@@ -65,7 +66,7 @@ private fun buildShapes(shapeParams: Bundle?): PaymentSheet.Shapes {
   )
 }
 
-private fun buildPrimaryButton(params: Bundle?, context: ReactContext): PaymentSheet.PrimaryButton {
+private fun buildPrimaryButton(params: Bundle?, context: Context): PaymentSheet.PrimaryButton {
   if (params == null) {
     return PaymentSheet.PrimaryButton()
   }
@@ -121,7 +122,7 @@ private fun getFloatOrNull(bundle: Bundle?, key: String): Float? {
 }
 
 @Throws(PaymentSheetAppearanceException::class)
-private fun getFontResId(bundle: Bundle?, key: String, defaultValue: Int?, context: ReactContext): Int? {
+private fun getFontResId(bundle: Bundle?, key: String, defaultValue: Int?, context: Context): Int? {
   val fontErrorPrefix = "Encountered an error when setting a custom font:"
   if (bundle?.containsKey(key) != true) {
     return defaultValue

--- a/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
+++ b/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
@@ -4,7 +4,7 @@ import android.app.Activity
 import android.content.Intent
 import android.os.Parcelable
 import android.util.Log
-import androidx.appcompat.app.AppCompatActivity
+import androidx.fragment.app.FragmentActivity
 import com.facebook.react.bridge.*
 import com.facebook.react.module.annotations.ReactModule
 import com.reactnativestripesdk.addresssheet.AddressLauncherFragment
@@ -861,8 +861,8 @@ class StripeSdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJ
    * Safely get and cast the current activity as an AppCompatActivity. If that fails, the promise
    * provided will be resolved with an error message instructing the user to retry the method.
    */
-  private fun getCurrentActivityOrResolveWithError(promise: Promise?): AppCompatActivity? {
-    (currentActivity as? AppCompatActivity)?.let {
+  private fun getCurrentActivityOrResolveWithError(promise: Promise?): FragmentActivity? {
+    (currentActivity as? FragmentActivity)?.let {
       return it
     }
     promise?.resolve(createMissingActivityError())

--- a/android/src/main/java/com/reactnativestripesdk/addresssheet/AddressLauncherFragment.kt
+++ b/android/src/main/java/com/reactnativestripesdk/addresssheet/AddressLauncherFragment.kt
@@ -5,8 +5,8 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
-import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentActivity
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.bridge.WritableMap
 import com.reactnativestripesdk.utils.ErrorType
@@ -89,19 +89,19 @@ class AddressLauncherFragment : Fragment() {
       autocompleteCountries = autocompleteCountries,
     )
     this.callback = callback
-    (context.currentActivity as? AppCompatActivity)?.let {
+    (context.currentActivity as? FragmentActivity)?.let {
       attemptToCleanupPreviousFragment(it)
       commitFragmentAndStartFlow(it)
     }
   }
 
-  private fun attemptToCleanupPreviousFragment(currentActivity: AppCompatActivity) {
+  private fun attemptToCleanupPreviousFragment(currentActivity: FragmentActivity) {
     currentActivity.supportFragmentManager.beginTransaction()
       .remove(this)
       .commitAllowingStateLoss()
   }
 
-  private fun commitFragmentAndStartFlow(currentActivity: AppCompatActivity) {
+  private fun commitFragmentAndStartFlow(currentActivity: FragmentActivity) {
     try {
       currentActivity.supportFragmentManager.beginTransaction()
         .add(this, TAG)

--- a/android/src/main/java/com/reactnativestripesdk/pushprovisioning/AddToWalletButtonManager.kt
+++ b/android/src/main/java/com/reactnativestripesdk/pushprovisioning/AddToWalletButtonManager.kt
@@ -1,15 +1,15 @@
 package com.reactnativestripesdk.pushprovisioning
 
+import android.content.Context
 import com.bumptech.glide.Glide
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.common.MapBuilder
 import com.facebook.react.uimanager.SimpleViewManager
 import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.annotations.ReactProp
-import com.facebook.react.bridge.ReactApplicationContext
 
 
-class AddToWalletButtonManager(applicationContext: ReactApplicationContext) : SimpleViewManager<AddToWalletButtonView?>() {
+class AddToWalletButtonManager(applicationContext: Context) : SimpleViewManager<AddToWalletButtonView?>() {
   private val requestManager = Glide.with(applicationContext)
   override fun getName() = "AddToWalletButton"
 

--- a/android/src/main/java/com/reactnativestripesdk/utils/Extensions.kt
+++ b/android/src/main/java/com/reactnativestripesdk/utils/Extensions.kt
@@ -3,8 +3,8 @@ package com.reactnativestripesdk.utils
 import android.content.Context
 import android.view.View
 import android.view.inputmethod.InputMethodManager
-import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentActivity
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReadableMap
 
@@ -25,7 +25,7 @@ fun View.hideSoftKeyboard() {
 }
 
 fun Fragment.removeFragment(context: ReactApplicationContext) {
-  (context.currentActivity as? AppCompatActivity)?.supportFragmentManager?.let {
+  (context.currentActivity as? FragmentActivity)?.supportFragmentManager?.let {
     if (it.findFragmentByTag(this.tag) != null) {
       it.beginTransaction().remove(this).commitAllowingStateLoss()
     }


### PR DESCRIPTION
## Summary
Android: use FragmentActivity instead of AppCompatActivity to improve compatibility with Flutter

## Motivation
As discussed in a meeting this PR will change the usage of AppCompatActivity to use its super class (FragmentAcitvity) instead. Flutter uses FragmentActivity and changing this accordingly will ease the sync with new versions.

## Testing
- [ ] I tested this manually
- [ ] I added automated tests

I've been unable to run it on Android because I'm getting lots of FileNotFoundExceptions on my machine:
`java.io.FileNotFoundException: /Users/.../.gradle/caches/transforms-3/.../transformed/jetified-flipper-0.125.0/META-INF/com/android/build/gradle/aar-metadata.properties (No such file or directory)`

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
