### PR TITLE
fix: confirmPlatformPaySetupIntent on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## Fixes
+
+- Fixed an issue with `confirmPlatformPaySetupIntent` on iOS. [#1266](https://github.com/stripe/stripe-react-native/pull/1266)
+
 ## 0.23.0 - 2023-01-09
 
 ### Breaking changes

--- a/ios/ApplePayViewController.swift
+++ b/ios/ApplePayViewController.swift
@@ -167,6 +167,8 @@ extension StripeSdk : PKPaymentAuthorizationViewControllerDelegate, STPApplePayC
     ) {
         if let clientSecret = self.confirmApplePayPaymentClientSecret {
             completion(clientSecret, nil)
+        } else if let clientSecret = self.confirmApplePaySetupClientSecret {
+            completion(clientSecret, nil)
         } else {
             self.applePayCompletionCallback = completion
             let method = Mappers.mapFromPaymentMethod(paymentMethod.splitApplePayAddressByNewline())


### PR DESCRIPTION


## Motivation
closes https://github.com/stripe/stripe-react-native/issues/1261

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
