### PR TITLE
fix: correctly pass back token for push provisioning yellow path on android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## Fixes
+
+- Fixed a bug on Android where `canAddCardToWallet` wouldn't correctly return the `details.token` object. [#1282](https://github.com/stripe/stripe-react-native/pull/1282)
+
 ## 0.23.1 - 2023-01-25
 
 ## Fixes

--- a/android/src/androidTest/java/com/reactnativestripesdk/mappers/MappersTest.kt
+++ b/android/src/androidTest/java/com/reactnativestripesdk/mappers/MappersTest.kt
@@ -1,0 +1,76 @@
+package com.reactnativestripesdk.mappers
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.WritableNativeMap
+import com.facebook.soloader.SoLoader
+import com.reactnativestripesdk.utils.createCanAddCardResult
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+
+class MappersTest {
+  private val reactApplicationContext = ReactApplicationContext(
+    ApplicationProvider.getApplicationContext<Context>()
+  )
+
+  @Before
+  fun setup(){
+    SoLoader.init(reactApplicationContext, false)
+  }
+
+
+  @Test
+  fun createCanAddCardResult_NoStatus() {
+    val result = createCanAddCardResult(
+      true,
+      null,
+      null
+    )
+    Assert.assertNotNull(result.getMap("details"))
+    Assert.assertNull(result.getMap("details")?.getString("status"))
+    Assert.assertNull(result.getMap("details")?.getMap("token"))
+    Assert.assertTrue(result.getBoolean("canAddCard"))
+  }
+
+  @Test
+  fun createCanAddCardResult_WithToken() {
+    val result = createCanAddCardResult(
+      true,
+      "CARD_ALREADY_EXISTS",
+      WritableNativeMap().also { it.putString("key", "value") }
+    )
+    Assert.assertTrue(result.getBoolean("canAddCard"))
+    val details = result.getMap("details")
+    Assert.assertEquals(details?.getString("status"), "CARD_ALREADY_EXISTS")
+    Assert.assertEquals(details?.getMap("token")?.getString("key"), "value")
+  }
+
+  @Test
+  fun createCanAddCardResult_UnsupportedDevice() {
+    val result = createCanAddCardResult(
+      false,
+      "UNSUPPORTED_DEVICE",
+      null
+    )
+    Assert.assertFalse(result.getBoolean("canAddCard"))
+    val details = result.getMap("details")
+    Assert.assertEquals(details?.getString("status"), "UNSUPPORTED_DEVICE")
+    Assert.assertNull(details?.getMap("token"))
+  }
+
+  @Test
+  fun createCanAddCardResult_MissingConfiguration() {
+    val result = createCanAddCardResult(
+      false,
+      "MISSING_CONFIGURATION",
+      null
+    )
+    Assert.assertFalse(result.getBoolean("canAddCard"))
+    val details = result.getMap("details")
+    Assert.assertEquals(details?.getString("status"), "MISSING_CONFIGURATION")
+    Assert.assertNull(details?.getMap("token"))
+  }
+}
+

--- a/android/src/main/java/com/reactnativestripesdk/pushprovisioning/TapAndPayProxy.kt
+++ b/android/src/main/java/com/reactnativestripesdk/pushprovisioning/TapAndPayProxy.kt
@@ -83,34 +83,33 @@ object TapAndPayProxy {
     }
   }
 
-  private fun mapFromTokenInfo(token: Any?): WritableMap? {
-    if (token == null) {
-      return null
-    }
+  private fun mapFromTokenInfo(token: Any?): WritableMap {
     val result = WritableNativeMap()
-    try {
-      val tokenInfoClass = Class.forName("com.google.android.gms.tapandpay.issuer.TokenInfo")
-      result.putString(
-        "id",
-        tokenInfoClass.getMethod("getIssuerTokenId").invoke(token) as String)
-      result.putString(
-        "cardLastFour",
-        tokenInfoClass.getMethod("getFpanLastFour").invoke(token) as String)
-      result.putString(
-        "issuer",
-        tokenInfoClass.getMethod("getIssuerName").invoke(token) as String)
-      result.putString(
-        "status",
-        mapFromTokenState(tokenInfoClass.getMethod("getTokenState").invoke(token) as Int))
-      result.putInt(
-        "network",
-        tokenInfoClass.getMethod("getNetwork").invoke(token) as Int)
-      result.putInt(
-        "serviceProvider",
-        tokenInfoClass.getMethod("getTokenServiceProvider").invoke(token) as Int)
-    } catch (e: Exception) {
-      Log.e(TAG,
-            "There was a problem finding the class com.google.android.gms.tapandpay.issuer.TokenInfo. Make sure you've included Google's TapAndPay dependency.")
+    token?.let {
+      try {
+        val tokenInfoClass = Class.forName("com.google.android.gms.tapandpay.issuer.TokenInfo")
+        result.putString(
+          "id",
+          tokenInfoClass.getMethod("getIssuerTokenId").invoke(it) as String)
+        result.putString(
+          "cardLastFour",
+          tokenInfoClass.getMethod("getFpanLastFour").invoke(it) as String)
+        result.putString(
+          "issuer",
+          tokenInfoClass.getMethod("getIssuerName").invoke(it) as String)
+        result.putString(
+          "status",
+          mapFromTokenState(tokenInfoClass.getMethod("getTokenState").invoke(it) as Int))
+        result.putInt(
+          "network",
+          tokenInfoClass.getMethod("getNetwork").invoke(it) as Int)
+        result.putInt(
+          "serviceProvider",
+          tokenInfoClass.getMethod("getTokenServiceProvider").invoke(it) as Int)
+      } catch (e: Exception) {
+        Log.e(TAG,
+          "There was a problem finding the class com.google.android.gms.tapandpay.issuer.TokenInfo. Make sure you've included Google's TapAndPay dependency.")
+      }
     }
     return result
   }

--- a/android/src/main/java/com/reactnativestripesdk/utils/Mappers.kt
+++ b/android/src/main/java/com/reactnativestripesdk/utils/Mappers.kt
@@ -17,14 +17,12 @@ internal fun createResult(key: String, value: WritableMap): WritableMap {
 internal fun createCanAddCardResult(canAddCard: Boolean, status: String? = null, token: WritableMap? = null): WritableNativeMap {
   val result = WritableNativeMap()
   val details = WritableNativeMap()
+  result.putBoolean("canAddCard", canAddCard)
   if (status != null) {
-    result.putBoolean("canAddCard", false)
     details.putString("status", status)
-  } else {
-    result.putBoolean("canAddCard", canAddCard)
-    if (token != null) {
-      details.putMap("token", token)
-    }
+  }
+  if (token != null) {
+    details.putMap("token", token)
   }
   result.putMap("details", details)
   return result


### PR DESCRIPTION
## Summary
`token` is now added regardless of the value of `canAddCard`, whereas previously it was only added to the details map if `canAddCard` was false.

## Motivation

In the "yellow path" on android, `canAddCard` is actually `true`

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [x] I added automated tests

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
