### PR TITLE
Release 0.23.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.23.2 - 2023-02-06
+
 ## Fixes
 
 - Fixed a bug on Android where `canAddCardToWallet` wouldn't correctly return the `details.token` object. [#1282](https://github.com/stripe/stripe-react-native/pull/1282)


### PR DESCRIPTION
- [X] Ensure the CHANGELOG is up to date with all relevant commits since the last release
- [X] Add the version number for this release & the date to the CHANGELOG, underneath "## Unreleased" 
  - e.g. "## 1.2.3 - 2022-02-14"
- [X] Update the README if necessary (this is only required when there are breaking changes in the release, such as dropping support for an iOS || Android version)