### PR TITLE
fix: allow apple pay shipping events to emit

### DIFF
--- a/ios/ApplePayViewController.swift
+++ b/ios/ApplePayViewController.swift
@@ -122,13 +122,13 @@ extension StripeSdk : PKPaymentAuthorizationViewControllerDelegate, STPApplePayC
         didSelect shippingMethod: PKShippingMethod,
         handler: @escaping (PKPaymentRequestShippingMethodUpdate) -> Void
     ) {
+        if (self.hasLegacyApplePayListeners) {
+            // Legacy, remove when useApplePay hook is removed
+            sendEvent(withName: "onDidSetShippingMethod", body: ["shippingMethod": Mappers.mapFromShippingMethod(shippingMethod: shippingMethod)])
+        }
         if let callback = self.shippingMethodUpdateJSCallback {
             self.shippingMethodUpdateCompletion = handler
             callback(["shippingMethod": Mappers.mapFromShippingMethod(shippingMethod: shippingMethod)])
-            if (self.hasLegacyApplePayListeners) {
-                // Legacy, remove when useApplePay hook is removed
-                sendEvent(withName: "onDidSetShippingMethod", body: ["shippingMethod": Mappers.mapFromShippingMethod(shippingMethod: shippingMethod)])
-            }
         } else {
             handler(
                 PKPaymentRequestShippingMethodUpdate.init(paymentSummaryItems: applePaySummaryItems)
@@ -141,13 +141,14 @@ extension StripeSdk : PKPaymentAuthorizationViewControllerDelegate, STPApplePayC
         didSelectShippingContact contact: PKContact,
         handler: @escaping (PKPaymentRequestShippingContactUpdate) -> Void
     ) {
+        if (self.hasLegacyApplePayListeners) {
+            // Legacy, remove when useApplePay hook is removed
+            sendEvent(withName: "onDidSetShippingContact", body: ["shippingContact": Mappers.mapFromShippingContact(shippingContact: contact)])
+        }
         if let callback = self.shippingContactUpdateJSCallback {
             self.shippingContactUpdateCompletion = handler
             callback(["shippingContact": Mappers.mapFromShippingContact(shippingContact: contact)])
-            if (self.hasLegacyApplePayListeners) {
-                // Legacy, remove when useApplePay hook is removed
-                sendEvent(withName: "onDidSetShippingContact", body: ["shippingContact": Mappers.mapFromShippingContact(shippingContact: contact)])
-            }
+
         } else {
             handler(
                 PKPaymentRequestShippingContactUpdate.init(

--- a/ios/ApplePayViewController.swift
+++ b/ios/ApplePayViewController.swift
@@ -148,7 +148,6 @@ extension StripeSdk : PKPaymentAuthorizationViewControllerDelegate, STPApplePayC
         if let callback = self.shippingContactUpdateJSCallback {
             self.shippingContactUpdateCompletion = handler
             callback(["shippingContact": Mappers.mapFromShippingContact(shippingContact: contact)])
-
         } else {
             handler(
                 PKPaymentRequestShippingContactUpdate.init(


### PR DESCRIPTION
## Summary
`onDidSetShippingMethod` & `onDidSetShippingContact` events will again send data back to the `useApplePay` hook listeners as well as by using the standard `const eventEmitter = new NativeEventEmitter(NativeModules.StripeSdk);` listeners

What happened was that the:
```swift
if let callback = self.shippingMethodUpdateJSCallback { ... }
```

Would never be set in any place other than using the `ApplePayButton` component from Stripe, meaning that if you were using the `useApplePay` hook or needed to listen to the shipping changes, it would skip and never trigger the `sendEvent` function

## Motivation
I needed to listen to the shipping address changes programatically because the app we use has shipping available to different countries which require different tax calculations and currencies.

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [ ] I tested this manually
- [x] I added automated tests

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
