### PR TITLE
fix: Push Provisioning issues on iOS due to Apple bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Fixes
+
+- Fixed an issue on iOS where `canAddCardToWallet` would always return a `details.status` of `UNSUPPORTED_DEVICE` on iPads. [#1305](https://github.com/stripe/stripe-react-native/pull/1305)
+- Fixed an issue on iOS where `canAddCardToWallet` would always return a `{canAddCard: false}` if the card in question had been provsioned on the current device, but **had not yet been provisioned** on a paired Watch. [#1305](https://github.com/stripe/stripe-react-native/pull/1305)
+
 ## 0.24.0 - 2023-02-17
 
 ### Breaking changes

--- a/ios/PaymentPassFinder.swift
+++ b/ios/PaymentPassFinder.swift
@@ -13,14 +13,18 @@ internal class PaymentPassFinder: NSObject {
         case PAIRED_DEVICE
     }
     
-    class func findPassWithLast4(last4: String, hasPairedAppleWatch: Bool, completion: @escaping ((Bool, [PassLocation]) -> Void)) {
+    class func findPassWith(
+        primaryAccountIdentifier: String,
+        hasPairedAppleWatch: Bool,
+        completion: @escaping ((Bool, [PassLocation]) -> Void)
+    ) {
         let existingPassOnDevice: PKPass? = {
             if #available(iOS 13.4, *) {
                 return PKPassLibrary().passes(of: PKPassType.secureElement)
-                    .first(where: { $0.secureElementPass?.primaryAccountNumberSuffix == last4 && $0.secureElementPass?.passActivationState != .deactivated && !$0.isRemotePass })
+                    .first(where: { $0.secureElementPass?.primaryAccountIdentifier == primaryAccountIdentifier && $0.secureElementPass?.passActivationState != .deactivated && !$0.isRemotePass })
             } else {
                 return PKPassLibrary().passes(of: PKPassType.payment)
-                    .first(where: { $0.paymentPass?.primaryAccountNumberSuffix == last4 && $0.paymentPass?.passActivationState != .deactivated && !$0.isRemotePass })
+                    .first(where: { $0.paymentPass?.primaryAccountIdentifier == primaryAccountIdentifier && $0.paymentPass?.passActivationState != .deactivated && !$0.isRemotePass })
             }
         }()
         
@@ -41,10 +45,10 @@ internal class PaymentPassFinder: NSObject {
         let existingPassOnPairedDevices: PKPass? = {
             if #available(iOS 13.4, *) {
                 return PKPassLibrary().remoteSecureElementPasses
-                    .first(where: { $0.secureElementPass?.primaryAccountNumberSuffix == last4 && $0.secureElementPass?.passActivationState != .deactivated })
+                    .first(where: { $0.secureElementPass?.primaryAccountIdentifier == primaryAccountIdentifier && $0.secureElementPass?.passActivationState != .deactivated })
             } else {
                 return PKPassLibrary().remotePaymentPasses()
-                    .first(where: { $0.paymentPass?.primaryAccountNumberSuffix == last4 && $0.paymentPass?.passActivationState != .deactivated })
+                    .first(where: { $0.paymentPass?.primaryAccountIdentifier == primaryAccountIdentifier && $0.paymentPass?.passActivationState != .deactivated })
             }
         }()
         

--- a/ios/PushProvisioning/AddToWalletButtonView.swift
+++ b/ios/PushProvisioning/AddToWalletButtonView.swift
@@ -39,7 +39,7 @@ class AddToWalletButtonView: UIView {
     }
 
     @objc func beginPushProvisioning() {
-        if (!PushProvisioningUtils.canAddPaymentPass(primaryAccountIdentifier: cardDetails?["primaryAccountIdentifier"] as? String ?? "", isTestMode: self.testEnv)) {
+        if (!PushProvisioningUtils.canAddPaymentPass(isTestMode: self.testEnv)) {
             onCompleteAction!(
                 Errors.createError(
                     ErrorType.Failed,

--- a/ios/StripeSdk.swift
+++ b/ios/StripeSdk.swift
@@ -1022,12 +1022,7 @@ class StripeSdk: RCTEventEmitter, STPBankSelectionViewControllerDelegate, UIAdap
         resolver resolve: @escaping RCTPromiseResolveBlock,
         rejecter reject: @escaping RCTPromiseRejectBlock
     ) -> Void {
-        guard let last4 = params["cardLastFour"] as? String else {
-            resolve(Errors.createError(ErrorType.Failed, "You must provide `cardLastFour`"))
-            return
-        }
         PushProvisioningUtils.canAddCardToWallet(
-            last4: last4,
             primaryAccountIdentifier: params["primaryAccountIdentifier"] as? String ?? "",
             testEnv: params["testEnv"] as? Bool ?? false,
             hasPairedAppleWatch: params["hasPairedAppleWatch"]  as? Bool ?? false)

--- a/ios/Tests/PushProvisioningTests.swift
+++ b/ios/Tests/PushProvisioningTests.swift
@@ -11,34 +11,33 @@ import XCTest
 
 class PushProvisioningTests: XCTestCase {
     func testCanAddCardToWalletInTestMode() throws {
-        PushProvisioningUtils.canAddCardToWallet(last4: "4242",
-                                                 primaryAccountIdentifier: "",
-                                                 testEnv: true, hasPairedAppleWatch: false) { canAddCard, status in
+        PushProvisioningUtils.canAddCardToWallet(primaryAccountIdentifier: "",
+                                                 testEnv: true,
+                                                 hasPairedAppleWatch: false) { canAddCard, status in
             XCTAssertEqual(canAddCard, true)
             XCTAssertEqual(status, nil)
         }
     }
     
     func testCanAddCardToWalletInLiveMode() throws {
-        PushProvisioningUtils.canAddCardToWallet(last4: "4242",
-                                                 primaryAccountIdentifier: "",
+        PushProvisioningUtils.canAddCardToWallet(primaryAccountIdentifier: "",
                                                  testEnv: false,
                                                  hasPairedAppleWatch: false) { canAddCard, status in
             XCTAssertEqual(canAddCard, false)
-            XCTAssertEqual(status, PushProvisioningUtils.AddCardToWalletStatus.MISSING_CONFIGURATION)
+            XCTAssertEqual(status, PushProvisioningUtils.AddCardToWalletStatus.UNSUPPORTED_DEVICE)
         }
     }
     
     func testCanAddPaymentPassInTestMode() throws {
         XCTAssertEqual(
-            PushProvisioningUtils.canAddPaymentPass(primaryAccountIdentifier: "", isTestMode: true),
+            PushProvisioningUtils.canAddPaymentPass(isTestMode: true),
             true
         )
     }
     
     func testCanAddPaymentPassInLiveMode() throws {
         XCTAssertEqual(
-            PushProvisioningUtils.canAddPaymentPass(primaryAccountIdentifier: "", isTestMode: false),
+            PushProvisioningUtils.canAddPaymentPass(isTestMode: false),
             false
         )
     }

--- a/src/types/PushProvisioning.ts
+++ b/src/types/PushProvisioning.ts
@@ -39,7 +39,7 @@ export type IsCardInWalletResult =
 export type CanAddCardToWalletParams = {
   /** The `primary_account_identifier` value from the issued card. Can be an empty string. */
   primaryAccountIdentifier: string | null;
-  /** Last 4 digits of the card number. */
+  /** Last 4 digits of the card number. Required for Android. */
   cardLastFour: string;
   /** iOS only. Set this to `true` until shipping through TestFlight || App Store. If false, you must be using live cards, and have the proper iOS entitlement set up. See https://stripe.com/docs/issuing/cards/digital-wallets?platform=react-native#requesting-access-for-ios */
   testEnv?: boolean;


### PR DESCRIPTION
## Summary

There is some unexpected behavior from Apple we need to account for.

1. Calling [canAddPasses](https://developer.apple.com/documentation/passkit/pkaddpassesviewcontroller/1619212-canaddpasses) on any iPad will return `false`, even though the device **can** add payment passes, so we removed reliance on that method. 
2. There is a bug in iOS which results in the `false` response from [canAddSecureElementPass](https://developer.apple.com/documentation/passkit/pkpasslibrary/3543354-canaddsecureelementpass) when a paired Watch is still available for provisioning, so we removed reliance on that method.

## Motivation

Temporarily fix push provisioning flow on iPads and when there is a paired watch, until Apple fixes this in PassKit.

## Testing

Testing this takes a while, TODO

- [ ] I tested this manually
- [ ] I added automated tests

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
