### PR TITLE
feat: make nfc check optional on android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Features
+
+- Added the `supportsTapToPay` option to `canAddCardToWallet`. [#1308](https://github.com/stripe/stripe-react-native/pull/1308)
+
 ## 0.24.0 - 2023-02-17
 
 ### Breaking changes

--- a/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
+++ b/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
@@ -696,7 +696,7 @@ class StripeSdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJ
       return
     }
 
-    if (!PushProvisioningProxy.isNFCEnabled(reactApplicationContext)) {
+    if (params.getBooleanOr("supportsTapToPay", true) && !PushProvisioningProxy.isNFCEnabled(reactApplicationContext)) {
       promise.resolve(createCanAddCardResult(false, "UNSUPPORTED_DEVICE"))
       return
     }

--- a/android/src/main/java/com/reactnativestripesdk/pushprovisioning/PushProvisioningProxy.kt
+++ b/android/src/main/java/com/reactnativestripesdk/pushprovisioning/PushProvisioningProxy.kt
@@ -33,7 +33,7 @@ object PushProvisioningProxy {
   fun isNFCEnabled(context: ReactApplicationContext): Boolean {
     return if (context.packageManager.hasSystemFeature(PackageManager.FEATURE_NFC)) {
       val adapter = NfcAdapter.getDefaultAdapter(context)
-      adapter.isEnabled
+      adapter?.isEnabled ?: false
     } else {
       false
     }

--- a/src/types/PushProvisioning.ts
+++ b/src/types/PushProvisioning.ts
@@ -45,6 +45,8 @@ export type CanAddCardToWalletParams = {
   testEnv?: boolean;
   /** iOS only. Set this to `true` if: your user has an Apple Watch device currently paired, and you want to check that device for the presence of the specified card. */
   hasPairedAppleWatch?: boolean;
+  /** Android only, defaults to `true`. Set this to `false` if you'd like to allow users without NFC-enabled devices to add cards to the wallet. NFC is required for paying in stores. */
+  supportsTapToPay?: boolean;
 };
 
 export type CanAddCardToWalletResult =


### PR DESCRIPTION
## Summary

Fixes a null pointer access error, and also introduces the `supportsTapToPay` field for `canAddCardToWallet()`. This field defaults to true, but when set to false, it will disable the check for NFC compatibility and allow merchants to provision cards on devices without tap to pay functionality


## Motivation
closes https://github.com/stripe/stripe-react-native/issues/1306

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one: 
- [x] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
