### PR TITLE
feat: add cashapp and paypal payment methods, and option to pass MandateData via SDK

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,2 +1,2 @@
 StripeSdk_kotlinVersion=1.8.0
-StripeSdk_stripeVersion=[20.19.2, 20.20.0[
+StripeSdk_stripeVersion=[20.20.0, 20.22.0[

--- a/android/src/main/java/com/reactnativestripesdk/PaymentMethodCreateParamsFactory.kt
+++ b/android/src/main/java/com/reactnativestripesdk/PaymentMethodCreateParamsFactory.kt
@@ -37,6 +37,7 @@ class PaymentMethodCreateParamsFactory(
         PaymentMethod.Type.USBankAccount -> createUSBankAccountParams(paymentMethodData)
         PaymentMethod.Type.PayPal -> createPayPalParams()
         PaymentMethod.Type.Affirm -> createAffirmParams()
+        PaymentMethod.Type.CashAppPay -> createCashAppParams()
         else -> {
           throw Exception("This paymentMethodType is not supported yet")
         }
@@ -203,12 +204,16 @@ class PaymentMethodCreateParamsFactory(
   }
 
   @Throws(PaymentMethodCreateParamsException::class)
+  private fun createCashAppParams(): PaymentMethodCreateParams {
+    return PaymentMethodCreateParams.createCashAppPay(billingDetailsParams)
+  }
+
+  @Throws(PaymentMethodCreateParamsException::class)
   fun createParams(clientSecret: String, paymentMethodType: PaymentMethod.Type?, isPaymentIntent: Boolean): ConfirmStripeIntentParams {
     try {
       return when (paymentMethodType) {
         PaymentMethod.Type.Card -> createCardStripeIntentParams(clientSecret, isPaymentIntent)
         PaymentMethod.Type.USBankAccount -> createUSBankAccountStripeIntentParams(clientSecret, isPaymentIntent)
-        PaymentMethod.Type.PayPal -> createPayPalStripeIntentParams(clientSecret, isPaymentIntent)
         PaymentMethod.Type.Affirm -> createAffirmStripeIntentParams(clientSecret, isPaymentIntent)
         PaymentMethod.Type.Ideal,
         PaymentMethod.Type.Alipay,
@@ -223,7 +228,9 @@ class PaymentMethodCreateParamsFactory(
         PaymentMethod.Type.Fpx,
         PaymentMethod.Type.AfterpayClearpay,
         PaymentMethod.Type.AuBecsDebit,
-        PaymentMethod.Type.Klarna -> {
+        PaymentMethod.Type.Klarna,
+        PaymentMethod.Type.PayPal,
+        PaymentMethod.Type.CashAppPay -> {
           val params = createPaymentMethodParams(paymentMethodType)
 
           return if (isPaymentIntent) {
@@ -232,11 +239,13 @@ class PaymentMethodCreateParamsFactory(
                 paymentMethodCreateParams = params,
                 clientSecret = clientSecret,
                 setupFutureUsage = mapToPaymentIntentFutureUsage(getValOr(options, "setupFutureUsage")),
+                mandateData = buildMandateDataParams()
               )
           } else {
             ConfirmSetupIntentParams.create(
               paymentMethodCreateParams = params,
               clientSecret = clientSecret,
+              mandateData = buildMandateDataParams()
             )
           }
         }
@@ -340,20 +349,6 @@ class PaymentMethodCreateParamsFactory(
   }
 
   @Throws(PaymentMethodCreateParamsException::class)
-  private fun createPayPalStripeIntentParams(clientSecret: String, isPaymentIntent: Boolean): ConfirmStripeIntentParams {
-    if (!isPaymentIntent) {
-      throw PaymentMethodCreateParamsException("PayPal is not yet supported through SetupIntents.")
-    }
-
-    val params = createPayPalParams()
-
-    return ConfirmPaymentIntentParams.createWithPaymentMethodCreateParams(
-      paymentMethodCreateParams = params,
-      clientSecret = clientSecret,
-    )
-  }
-
-  @Throws(PaymentMethodCreateParamsException::class)
   private fun createAffirmStripeIntentParams(clientSecret: String, isPaymentIntent: Boolean): ConfirmStripeIntentParams {
     if (!isPaymentIntent) {
       throw PaymentMethodCreateParamsException("Affirm is not yet supported through SetupIntents.")
@@ -366,6 +361,7 @@ class PaymentMethodCreateParamsFactory(
         paymentMethodCreateParams = params,
         clientSecret = clientSecret,
         setupFutureUsage = mapToPaymentIntentFutureUsage(getValOr(options, "setupFutureUsage")),
+        mandateData = buildMandateDataParams()
       )
   }
 
@@ -400,6 +396,20 @@ class PaymentMethodCreateParamsFactory(
       billingDetailsParams,
       null
     )
+  }
+
+  private fun buildMandateDataParams(): MandateDataParams? {
+    getMapOrNull(paymentMethodData, "mandateData")?.let {
+      getMapOrNull(it, "customerAcceptance")?.let { customerAcceptance ->
+        getMapOrNull(it, "online")?.let { onlineParams ->
+          return MandateDataParams(MandateDataParams.Type.Online(
+            ipAddress = getValOr(onlineParams, "ipAddress", "") ?: "",
+            userAgent = getValOr(onlineParams, "userAgent", "") ?: "",
+          ))
+        }
+      }
+    }
+    return null
   }
 }
 

--- a/android/src/main/java/com/reactnativestripesdk/PaymentMethodCreateParamsFactory.kt
+++ b/android/src/main/java/com/reactnativestripesdk/PaymentMethodCreateParamsFactory.kt
@@ -399,9 +399,9 @@ class PaymentMethodCreateParamsFactory(
   }
 
   private fun buildMandateDataParams(): MandateDataParams? {
-    getMapOrNull(paymentMethodData, "mandateData")?.let {
-      getMapOrNull(it, "customerAcceptance")?.let { customerAcceptance ->
-        getMapOrNull(it, "online")?.let { onlineParams ->
+    getMapOrNull(paymentMethodData, "mandateData")?.let { mandateData ->
+      getMapOrNull(mandateData, "customerAcceptance")?.let { customerAcceptance ->
+        getMapOrNull(customerAcceptance, "online")?.let { onlineParams ->
           return MandateDataParams(MandateDataParams.Type.Online(
             ipAddress = getValOr(onlineParams, "ipAddress", "") ?: "",
             userAgent = getValOr(onlineParams, "userAgent", "") ?: "",

--- a/android/src/main/java/com/reactnativestripesdk/utils/Mappers.kt
+++ b/android/src/main/java/com/reactnativestripesdk/utils/Mappers.kt
@@ -123,6 +123,7 @@ internal fun mapPaymentMethodType(type: PaymentMethod.Type?): String {
     PaymentMethod.Type.USBankAccount -> "USBankAccount"
     PaymentMethod.Type.PayPal -> "PayPal"
     PaymentMethod.Type.Affirm -> "Affirm"
+    PaymentMethod.Type.CashAppPay -> "CashApp"
     else -> "Unknown"
   }
 }
@@ -152,6 +153,7 @@ internal fun mapToPaymentMethodType(type: String?): PaymentMethod.Type? {
     "USBankAccount" -> PaymentMethod.Type.USBankAccount
     "PayPal" -> PaymentMethod.Type.PayPal
     "Affirm" -> PaymentMethod.Type.Affirm
+    "CashApp" -> PaymentMethod.Type.CashAppPay
     else -> null
   }
 }

--- a/e2e-tests/cashapp-payment.yml
+++ b/e2e-tests/cashapp-payment.yml
@@ -4,9 +4,9 @@ appId: ${APP_ID}
 - tapOn: "Wallets"
 - scrollUntilVisible:
     element:
-      text: "PayPal"
+      text: "CashApp"
     direction: DOWN
-- tapOn: "PayPal"
+- tapOn: "CashApp"
 - assertVisible:
     text: "E-mail"
 - tapOn:

--- a/e2e-tests/cashapp-setup.yml
+++ b/e2e-tests/cashapp-setup.yml
@@ -4,18 +4,18 @@ appId: ${APP_ID}
 - tapOn: "Wallets"
 - scrollUntilVisible:
     element:
-      text: "PayPal"
+      text: "CashApp"
     direction: DOWN
-- tapOn: "PayPal"
+- tapOn: "CashApp"
 - assertVisible:
     text: "E-mail"
 - tapOn:
     text: "E-mail"
 - inputText: "test@stripe.com"
 - tapOn:
-    text: "Pay"
+    text: "Setup for later"
     retryTapIfNoChange: false
-- tapOn: "AUTHORIZE TEST PAYMENT"
+- tapOn: "AUTHORIZE TEST SETUP"
 - assertVisible:
     text: "Success"
 - tapOn: "OK"

--- a/e2e-tests/paypal-setup.yml
+++ b/e2e-tests/paypal-setup.yml
@@ -13,9 +13,9 @@ appId: ${APP_ID}
     text: "E-mail"
 - inputText: "test@stripe.com"
 - tapOn:
-    text: "Pay"
+    text: "Setup for later"
     retryTapIfNoChange: false
-- tapOn: "AUTHORIZE TEST PAYMENT"
+- tapOn: "AUTHORIZE TEST SETUP"
 - assertVisible:
     text: "Success"
 - tapOn: "OK"

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -368,50 +368,50 @@ PODS:
     - React-Core
     - React-RCTImage
   - SocketRocket (0.6.0)
-  - Stripe (23.4.2):
-    - StripeApplePay (= 23.4.2)
-    - StripeCore (= 23.4.2)
-    - StripePayments (= 23.4.2)
-    - StripePaymentsUI (= 23.4.2)
-    - StripeUICore (= 23.4.2)
+  - Stripe (23.5.0):
+    - StripeApplePay (= 23.5.0)
+    - StripeCore (= 23.5.0)
+    - StripePayments (= 23.5.0)
+    - StripePaymentsUI (= 23.5.0)
+    - StripeUICore (= 23.5.0)
   - stripe-react-native (0.25.0):
     - React-Core
-    - Stripe (~> 23.4.0)
-    - StripeApplePay (~> 23.4.0)
-    - StripeFinancialConnections (~> 23.4.0)
-    - StripePayments (~> 23.4.0)
-    - StripePaymentSheet (~> 23.4.0)
-    - StripePaymentsUI (~> 23.4.0)
+    - Stripe (~> 23.5.0)
+    - StripeApplePay (~> 23.5.0)
+    - StripeFinancialConnections (~> 23.5.0)
+    - StripePayments (~> 23.5.0)
+    - StripePaymentSheet (~> 23.5.0)
+    - StripePaymentsUI (~> 23.5.0)
   - stripe-react-native/Tests (0.25.0):
     - React-Core
-    - Stripe (~> 23.4.0)
-    - StripeApplePay (~> 23.4.0)
-    - StripeFinancialConnections (~> 23.4.0)
-    - StripePayments (~> 23.4.0)
-    - StripePaymentSheet (~> 23.4.0)
-    - StripePaymentsUI (~> 23.4.0)
-  - StripeApplePay (23.4.2):
-    - StripeCore (= 23.4.2)
-  - StripeCore (23.4.2)
-  - StripeFinancialConnections (23.4.2):
-    - StripeCore (= 23.4.2)
-    - StripeUICore (= 23.4.2)
-  - StripePayments (23.4.2):
-    - StripeCore (= 23.4.2)
-    - StripePayments/Stripe3DS2 (= 23.4.2)
-  - StripePayments/Stripe3DS2 (23.4.2):
-    - StripeCore (= 23.4.2)
-  - StripePaymentSheet (23.4.2):
-    - StripeApplePay (= 23.4.2)
-    - StripeCore (= 23.4.2)
-    - StripePayments (= 23.4.2)
-    - StripePaymentsUI (= 23.4.2)
-  - StripePaymentsUI (23.4.2):
-    - StripeCore (= 23.4.2)
-    - StripePayments (= 23.4.2)
-    - StripeUICore (= 23.4.2)
-  - StripeUICore (23.4.2):
-    - StripeCore (= 23.4.2)
+    - Stripe (~> 23.5.0)
+    - StripeApplePay (~> 23.5.0)
+    - StripeFinancialConnections (~> 23.5.0)
+    - StripePayments (~> 23.5.0)
+    - StripePaymentSheet (~> 23.5.0)
+    - StripePaymentsUI (~> 23.5.0)
+  - StripeApplePay (23.5.0):
+    - StripeCore (= 23.5.0)
+  - StripeCore (23.5.0)
+  - StripeFinancialConnections (23.5.0):
+    - StripeCore (= 23.5.0)
+    - StripeUICore (= 23.5.0)
+  - StripePayments (23.5.0):
+    - StripeCore (= 23.5.0)
+    - StripePayments/Stripe3DS2 (= 23.5.0)
+  - StripePayments/Stripe3DS2 (23.5.0):
+    - StripeCore (= 23.5.0)
+  - StripePaymentSheet (23.5.0):
+    - StripeApplePay (= 23.5.0)
+    - StripeCore (= 23.5.0)
+    - StripePayments (= 23.5.0)
+    - StripePaymentsUI (= 23.5.0)
+  - StripePaymentsUI (23.5.0):
+    - StripeCore (= 23.5.0)
+    - StripePayments (= 23.5.0)
+    - StripeUICore (= 23.5.0)
+  - StripeUICore (23.5.0):
+    - StripeCore (= 23.5.0)
   - Yoga (1.14.0)
   - YogaKit (1.18.1):
     - Yoga (~> 1.14)
@@ -636,15 +636,15 @@ SPEC CHECKSUMS:
   RNCPicker: 0bf8ef8f7800524f32d2bb2a8bcadd53eda0ecd1
   RNScreens: 34cc502acf1b916c582c60003dc3089fa01dc66d
   SocketRocket: fccef3f9c5cedea1353a9ef6ada904fde10d6608
-  Stripe: d66defd3c57dd95373078c87449737913230f918
-  stripe-react-native: bf67d91ee381e8972b1b183ee7e0ab90ba0932ce
-  StripeApplePay: 3b5644c55b3bd58e6fc54bb0d89352cd96496fa0
-  StripeCore: 727a9f9ec21aa20eccdb357950a7886f8f3bbf8a
-  StripeFinancialConnections: 65ffa16c4fc0ae86bf6ad17982bc4d8e2f7c0180
-  StripePayments: 08793f39f68c4551ccb501717e4c1b892536ff86
-  StripePaymentSheet: cbdd507e72773c3d16a3e87059f8113aa75e8ce9
-  StripePaymentsUI: 2b1647054756be34abaf52e1f58dba7d08bfedd3
-  StripeUICore: 1fbe9a33b73633127205175c0e255a4bfb052212
+  Stripe: 52dea7bd3ef1a679af8406915724b30017713ae9
+  stripe-react-native: 479082d9d2ffd0cade3b1b8d2e3425a46d4ce2cb
+  StripeApplePay: e17b49bd1b44817325fcd3c2400b2b21f2462a9a
+  StripeCore: 8cfb64927054f378af165629d2522894d03bd8fc
+  StripeFinancialConnections: 607d63237ec9304b42507d3fd4b4a754f01d41e1
+  StripePayments: 99c899c85eec727e35ecbccb76e21eb42aeb680b
+  StripePaymentSheet: a6f0116067fec8b3fe8ca583db9efc019725e4ac
+  StripePaymentsUI: e832ad4db17c3e2b82a69efbd86aea354d1cd77a
+  StripeUICore: e2c0f925b7446fb7bf73314bd2435dadb1d4057c
   Yoga: 0b84a956f7393ef1f37f3bb213c516184e4a689d
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 

--- a/example/package.json
+++ b/example/package.json
@@ -38,7 +38,7 @@
     "nodemon": "^2.0.19",
     "path": "^0.12.7",
     "react-test-renderer": "18.0.0",
-    "stripe": "^9.0.0",
+    "stripe": "^11.0.0",
     "typescript": "^4.5.5"
   }
 }

--- a/example/server/index.ts
+++ b/example/server/index.ts
@@ -70,6 +70,10 @@ function getKeys(payment_method?: string) {
       publishable_key = process.env.STRIPE_PUBLISHABLE_KEY_WECHAT;
       secret_key = process.env.STRIPE_SECRET_KEY_WECHAT;
       break;
+    case 'paypal':
+      publishable_key = process.env.STRIPE_PUBLISHABLE_KEY_UK;
+      secret_key = process.env.STRIPE_SECRET_KEY_UK;
+      break;
     default:
       publishable_key = process.env.STRIPE_PUBLISHABLE_KEY;
       secret_key = process.env.STRIPE_SECRET_KEY;
@@ -112,7 +116,7 @@ app.post(
     const { secret_key } = getKeys(payment_method_types[0]);
 
     const stripe = new Stripe(secret_key as string, {
-      apiVersion: '2020-08-27',
+      apiVersion: '2022-11-15',
       typescript: true,
     });
 
@@ -172,7 +176,7 @@ app.post(
     const { secret_key } = getKeys();
 
     const stripe = new Stripe(secret_key as string, {
-      apiVersion: '2020-08-27',
+      apiVersion: '2022-11-15',
       typescript: true,
     });
     const customers = await stripe.customers.list({
@@ -250,7 +254,7 @@ app.post(
     const { secret_key } = getKeys();
 
     const stripe = new Stripe(secret_key as string, {
-      apiVersion: '2020-08-27',
+      apiVersion: '2022-11-15',
       typescript: true,
     });
 
@@ -339,7 +343,7 @@ app.post('/create-setup-intent', async (req, res) => {
   const { secret_key } = getKeys(payment_method_types[0]);
 
   const stripe = new Stripe(secret_key as string, {
-    apiVersion: '2020-08-27',
+    apiVersion: '2022-11-15',
     typescript: true,
   });
   const customer = await stripe.customers.create({ email });
@@ -352,8 +356,8 @@ app.post('/create-setup-intent', async (req, res) => {
       customer_acceptance: {
         type: 'online',
         online: {
-          ip_address: '',
-          user_agent: '',
+          ip_address: '1.1.1.1',
+          user_agent: 'test-user-agent',
         },
       },
     },
@@ -387,7 +391,7 @@ app.post(
     const { secret_key } = getKeys();
 
     const stripe = new Stripe(secret_key as string, {
-      apiVersion: '2020-08-27',
+      apiVersion: '2022-11-15',
       typescript: true,
     });
     // console.log('webhook!', req);
@@ -450,7 +454,7 @@ app.post('/charge-card-off-session', async (req, res) => {
   const { secret_key } = getKeys();
 
   const stripe = new Stripe(secret_key as string, {
-    apiVersion: '2020-08-27',
+    apiVersion: '2022-11-15',
     typescript: true,
   });
 
@@ -524,7 +528,7 @@ app.post('/payment-sheet', async (_, res) => {
   const { secret_key } = getKeys();
 
   const stripe = new Stripe(secret_key as string, {
-    apiVersion: '2020-08-27',
+    apiVersion: '2022-11-15',
     typescript: true,
   });
 
@@ -541,7 +545,7 @@ app.post('/payment-sheet', async (_, res) => {
 
   const ephemeralKey = await stripe.ephemeralKeys.create(
     { customer: customer.id },
-    { apiVersion: '2020-08-27' }
+    { apiVersion: '2022-11-15' }
   );
   const paymentIntent = await stripe.paymentIntents.create({
     amount: 5099,
@@ -574,7 +578,7 @@ app.post('/payment-sheet-subscription', async (_, res) => {
   const { secret_key } = getKeys();
 
   const stripe = new Stripe(secret_key as string, {
-    apiVersion: '2020-08-27',
+    apiVersion: '2022-11-15',
     typescript: true,
   });
 
@@ -591,7 +595,7 @@ app.post('/payment-sheet-subscription', async (_, res) => {
 
   const ephemeralKey = await stripe.ephemeralKeys.create(
     { customer: customer.id },
-    { apiVersion: '2020-08-27' }
+    { apiVersion: '2022-11-15' }
   );
   const subscription = await stripe.subscriptions.create({
     customer: customer.id,
@@ -641,7 +645,7 @@ app.post('/issuing-card-details', async (req, res) => {
   const { secret_key } = getKeys();
 
   const stripe = new Stripe(secret_key as string, {
-    apiVersion: '2020-08-27',
+    apiVersion: '2022-11-15',
     typescript: true,
   });
 
@@ -664,7 +668,7 @@ app.post('/financial-connections-sheet', async (_, res) => {
   const { secret_key } = getKeys();
 
   const stripe = new Stripe(secret_key as string, {
-    apiVersion: '2020-08-27',
+    apiVersion: '2022-11-15',
     typescript: true,
   });
 

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -40,6 +40,7 @@ import ACHSetupScreen from './screens/ACHSetupScreen';
 import PayPalScreen from './screens/PayPalScreen';
 import AffirmScreen from './screens/AffirmScreen';
 import CollectBankAccountScreen from './screens/CollectBankAccountScreen';
+import CashAppScreen from './screens/CashAppScreen';
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
 
@@ -79,6 +80,7 @@ export type RootStackParamList = {
   ACHPaymentScreen: undefined;
   ACHSetupScreen: undefined;
   PayPalScreen: undefined;
+  CashAppScreen: undefined;
   AffirmScreen: undefined;
   CollectBankAccountScreen: undefined;
 };
@@ -222,6 +224,7 @@ export default function App() {
           <Stack.Screen name="ACHPaymentScreen" component={ACHPaymentScreen} />
           <Stack.Screen name="ACHSetupScreen" component={ACHSetupScreen} />
           <Stack.Screen name="PayPalScreen" component={PayPalScreen} />
+          <Stack.Screen name="CashAppScreen" component={CashAppScreen} />
           <Stack.Screen name="AffirmScreen" component={AffirmScreen} />
           <Stack.Screen
             name="CollectBankAccountScreen"

--- a/example/src/screens/CashAppScreen.tsx
+++ b/example/src/screens/CashAppScreen.tsx
@@ -1,4 +1,3 @@
-import type { BillingDetails } from '@stripe/stripe-react-native';
 import React, { useState } from 'react';
 import { Alert, StyleSheet, TextInput } from 'react-native';
 import {
@@ -10,7 +9,7 @@ import PaymentScreen from '../components/PaymentScreen';
 import { API_URL } from '../Config';
 import { colors } from '../colors';
 
-export default function PayPalScreen() {
+export default function CashAppScreen() {
   const [email, setEmail] = useState('');
   const { confirmPayment, loading: loadingPayment } = useConfirmPayment();
   const { confirmSetupIntent, loading: loadingSetup } = useConfirmSetupIntent();
@@ -23,8 +22,8 @@ export default function PayPalScreen() {
       },
       body: JSON.stringify({
         email,
-        currency: 'gbp',
-        payment_method_types: ['paypal'],
+        currency: 'usd',
+        payment_method_types: ['cashapp'],
       }),
     });
     const { clientSecret, error } = await response.json();
@@ -42,16 +41,8 @@ export default function PayPalScreen() {
       return;
     }
 
-    const billingDetails: BillingDetails = {
-      name: 'John Doe',
-      email,
-    };
-
     const { error, paymentIntent } = await confirmPayment(clientSecret, {
-      paymentMethodType: 'PayPal',
-      paymentMethodData: {
-        billingDetails,
-      },
+      paymentMethodType: 'CashApp',
     });
 
     if (error) {
@@ -76,23 +67,9 @@ export default function PayPalScreen() {
       return;
     }
 
-    const { error, setupIntent } = await confirmSetupIntent(
-      clientSecret,
-      {
-        paymentMethodType: 'PayPal',
-        paymentMethodData: {
-          mandateData: {
-            customerAcceptance: {
-              online: {
-                ipAddress: '1.1.1.1',
-                userAgent: 'my-agent',
-              },
-            },
-          },
-        },
-      },
-      { setupFutureUsage: 'OffSession' }
-    );
+    const { error, setupIntent } = await confirmSetupIntent(clientSecret, {
+      paymentMethodType: 'CashApp',
+    });
 
     if (error) {
       Alert.alert(`Error code: ${error.code}`, error.message);
@@ -104,7 +81,7 @@ export default function PayPalScreen() {
   };
 
   return (
-    <PaymentScreen paymentMethod="paypal">
+    <PaymentScreen paymentMethod="cashapp">
       <TextInput
         placeholder="E-mail"
         autoCapitalize="none"

--- a/example/src/screens/HomeScreen.tsx
+++ b/example/src/screens/HomeScreen.tsx
@@ -369,6 +369,14 @@ export default function HomeScreen() {
           </View>
           <View style={styles.buttonContainer}>
             <Button
+              title="CashApp"
+              onPress={() => {
+                navigation.navigate('CashAppScreen');
+              }}
+            />
+          </View>
+          <View style={styles.buttonContainer}>
+            <Button
               title="WeChat Pay"
               onPress={() => {
                 // navigation.navigate('WeChatPaymentScreen');

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -3858,10 +3858,17 @@ pump@^3.0.0:
     end-of-stream "^1.1.0"
     once "^1.3.1"
 
-qs@6.11.0, qs@^6.10.3:
+qs@6.11.0:
   version "6.11.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.11.0.tgz#fd0d963446f7a65e1367e01abd85429453f0c37a"
   integrity sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==
+  dependencies:
+    side-channel "^1.0.4"
+
+qs@^6.11.0:
+  version "6.11.1"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.11.1.tgz#6c29dff97f0c0060765911ba65cbc9764186109f"
+  integrity sha512-0wsrzgTz/kAVIeuxSjnpGC56rzYtr6JT/2BwEvMaPhFIoYa1aGO8LbzuU1R0uUYQkLpWBTOj0l/CLAJB64J6nQ==
   dependencies:
     side-channel "^1.0.4"
 
@@ -4518,13 +4525,13 @@ strip-eof@^1.0.0:
   resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
   integrity sha512-7FCwGGmx8mD5xQd3RPUvnSpUXHM3BWuzjtpD4TXsfcZ9EL4azvVVUscFYwD9nx8Kh+uCBC00XBtAykoMHwTh8Q==
 
-stripe@^9.0.0:
-  version "9.16.0"
-  resolved "https://registry.yarnpkg.com/stripe/-/stripe-9.16.0.tgz#94c24549c91fced457b9e3259e8a1a1bdb6dbd0e"
-  integrity sha512-Dn8K+jSoQcXjxCobRI4HXUdHjOXsiF/KszK49fJnkbeCFjZ3EZxLG2JiM/CX+Hcq27NBDtv/Sxhvy+HhTmvyaQ==
+stripe@^11.0.0:
+  version "11.14.0"
+  resolved "https://registry.yarnpkg.com/stripe/-/stripe-11.14.0.tgz#3e755921f69267a2a653e61d8ac37fe853740421"
+  integrity sha512-EqIMCKkfkewf3eLJo0fopDy/EN2UF6q7L3NEycwThjZRUj8HFz3BpcEDjCITfNJ04ozrAmZNqFaiW46YG4KUtw==
   dependencies:
     "@types/node" ">=8.1.0"
-    qs "^6.10.3"
+    qs "^6.11.0"
 
 sudo-prompt@^9.0.0:
   version "9.2.1"

--- a/ios/Mappers.swift
+++ b/ios/Mappers.swift
@@ -292,6 +292,7 @@ class Mappers {
         case STPPaymentMethodType.USBankAccount: return "USBankAccount"
         case STPPaymentMethodType.payPal: return "PayPal"
         case STPPaymentMethodType.affirm: return "Affirm"
+        case STPPaymentMethodType.cashApp: return "CashApp"
         case STPPaymentMethodType.unknown: return "Unknown"
         default: return "Unknown"
         }
@@ -322,6 +323,7 @@ class Mappers {
             case "USBankAccount": return STPPaymentMethodType.USBankAccount
             case "PayPal": return STPPaymentMethodType.payPal
             case "Affirm": return STPPaymentMethodType.affirm
+            case "CashApp": return STPPaymentMethodType.cashApp
             default: return STPPaymentMethodType.unknown
             }
         }

--- a/ios/PaymentMethodFactory.swift
+++ b/ios/PaymentMethodFactory.swift
@@ -55,6 +55,8 @@ class PaymentMethodFactory {
                 return try createPayPalPaymentMethodParams()
             case STPPaymentMethodType.affirm:
                 return try createAffirmPaymentMethodParams()
+            case STPPaymentMethodType.cashApp:
+                return try createCashAppPaymentMethodParams()
 //            case STPPaymentMethodType.weChatPay:
 //                return try createWeChatPayPaymentMethodParams()
             default:
@@ -105,6 +107,8 @@ class PaymentMethodFactory {
             case STPPaymentMethodType.payPal:
                 return nil
             case STPPaymentMethodType.affirm:
+                return nil
+            case STPPaymentMethodType.cashApp:
                 return nil
             default:
                 throw PaymentMethodError.paymentNotSupported
@@ -368,6 +372,26 @@ class PaymentMethodFactory {
     private func createAffirmPaymentMethodParams() throws -> STPPaymentMethodParams {
         let params = STPPaymentMethodAffirmParams()
         return STPPaymentMethodParams(affirm: params, metadata: nil)
+    }
+    
+    private func createCashAppPaymentMethodParams() throws -> STPPaymentMethodParams {
+        let params = STPPaymentMethodCashAppParams()
+        return STPPaymentMethodParams(cashApp: params, billingDetails: billingDetailsParams, metadata: nil)
+    }
+
+    func createMandateData() -> STPMandateDataParams? {
+        if let mandateParams = paymentMethodData?["mandateData"] as? NSDictionary {
+            if let customerAcceptanceParams = mandateParams["customerAcceptance"] as? NSDictionary {
+                let mandate = STPMandateDataParams.init(customerAcceptance: STPMandateCustomerAcceptanceParams.init())
+                
+                mandate.customerAcceptance.type = .online
+                if let onlineParams = customerAcceptanceParams["online"] as? NSDictionary {
+                    mandate.customerAcceptance.onlineParams = .init(ipAddress: onlineParams["ipAddress"] as? String ?? "", userAgent: onlineParams["userAgent"] as? String ?? "")
+                }
+                return mandate
+            }
+        }
+        return nil
     }
 }
 

--- a/ios/StripeSdk.swift
+++ b/ios/StripeSdk.swift
@@ -240,11 +240,6 @@ class StripeSdk: RCTEventEmitter, STPBankSelectionViewControllerDelegate, UIAdap
             return
         }
 
-        if (paymentMethodType == .payPal) {
-            resolve(Errors.createError(ErrorType.Failed, "PayPal is not yet supported through SetupIntents."))
-            return
-        }
-
         var err: NSDictionary? = nil
         let setupIntentParams: STPSetupIntentConfirmParams = {
             // If payment method data is not supplied, assume payment method was attached through via collectBankAccount
@@ -260,6 +255,7 @@ class StripeSdk: RCTEventEmitter, STPBankSelectionViewControllerDelegate, UIAdap
                     do {
                         let paymentMethodParams = try factory.createParams(paymentMethodType: paymentMethodType)
                         parameters.paymentMethodParams = paymentMethodParams
+                        parameters.mandateData = factory.createMandateData()
                     } catch  {
                         err = Errors.createError(ErrorType.Failed, error as NSError?)
                     }
@@ -881,6 +877,7 @@ class StripeSdk: RCTEventEmitter, STPBankSelectionViewControllerDelegate, UIAdap
                         let paymentMethodOptions = try factory.createOptions(paymentMethodType: paymentMethodType)
                         parameters.paymentMethodParams = paymentMethodParams
                         parameters.paymentMethodOptions = paymentMethodOptions
+                        parameters.mandateData = factory.createMandateData()
                     } catch  {
                         err = Errors.createError(ErrorType.Failed, error as NSError?)
                     }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "release": "./scripts/publish",
     "example": "yarn --cwd example",
     "pods": "cd example && npx pod-install --quiet",
+    "update-pods": "cd example/ios && pod update Stripe StripeApplePay StripeFinancialConnections StripePayments StripePaymentSheet StripePaymentsUI StripeCore StripeUICore",
     "bootstrap": "yarn example && yarn && yarn pods",
     "bootstrap-no-pods": "yarn example && yarn",
     "docs": "yarn typedoc ./src/index.tsx --out ./docs/api-reference --tsconfig ./tsconfig.json --readme none --sort source-order",

--- a/src/types/PaymentIntent.ts
+++ b/src/types/PaymentIntent.ts
@@ -1,9 +1,10 @@
 import type { StripeError } from '.';
-import type { Address } from './Common';
+import type { Address, BillingDetails } from './Common';
 import type { Result as PaymentMethodResult } from './PaymentMethod';
 import type { NextAction } from './NextAction';
 import type * as PaymentMethod from './PaymentMethod';
-
+import type { FormDetails } from './components/AuBECSDebitFormComponent';
+import type { BankAcccountHolderType, BankAcccountType } from './Token';
 export interface Result {
   id: string;
   amount: number;
@@ -26,7 +27,27 @@ export interface Result {
   nextAction: NextAction | null;
 }
 
-export type ConfirmParams = PaymentMethod.CreateParams;
+export type ConfirmParams =
+  | CardParams
+  | IdealParams
+  | OxxoParams
+  | P24Params
+  | AlipayParams
+  | GiropayParams
+  | SepaParams
+  | EpsParams
+  | AuBecsDebitParams
+  | SofortParams
+  | GrabPayParams
+  | FPXParams
+  | AfterpayClearpayParams
+  | KlarnaParams
+  // | WeChatPayParams
+  | BancontactParams
+  | USBankAccountParams
+  | PayPalParams
+  | AffirmParams
+  | CashAppParams;
 
 export type ConfirmOptions = PaymentMethod.ConfirmOptions;
 
@@ -54,3 +75,206 @@ export enum Status {
   RequiresCapture = 'RequiresCapture',
   Unknown = 'Unknown',
 }
+
+export type MandateData = {
+  customerAcceptance: {
+    online: {
+      ipAddress: string;
+      userAgent: string;
+    };
+  };
+};
+
+export type CardParams =
+  | {
+      paymentMethodType: 'Card';
+      paymentMethodData?: {
+        token?: string;
+        billingDetails?: BillingDetails;
+        mandateData?: MandateData;
+      };
+    }
+  | {
+      paymentMethodType: 'Card';
+      paymentMethodData: {
+        paymentMethodId: string;
+        cvc?: string;
+        billingDetails?: BillingDetails;
+        mandateData?: MandateData;
+      };
+    };
+
+export interface IdealParams {
+  paymentMethodType: 'Ideal';
+  paymentMethodData?: {
+    bankName?: string;
+    billingDetails?: BillingDetails;
+    mandateData?: MandateData;
+  };
+}
+
+export interface FPXParams {
+  paymentMethodType: 'Fpx';
+  paymentMethodData?: { testOfflineBank?: boolean; mandateData?: MandateData };
+}
+
+export interface AlipayParams {
+  paymentMethodType: 'Alipay';
+  paymentMethodData?: {
+    mandateData?: MandateData;
+  };
+}
+
+export interface OxxoParams {
+  paymentMethodType: 'Oxxo';
+  paymentMethodData: {
+    billingDetails: BillingDetails;
+    mandateData?: MandateData;
+  };
+}
+
+export interface SofortParams {
+  paymentMethodType: 'Sofort';
+  paymentMethodData: {
+    country: string;
+    billingDetails: BillingDetails;
+    mandateData?: MandateData;
+  };
+}
+export interface GrabPayParams {
+  paymentMethodType: 'GrabPay';
+  paymentMethodData?: {
+    billingDetails?: BillingDetails;
+    mandateData?: MandateData;
+  };
+}
+
+export interface BancontactParams {
+  paymentMethodType: 'Bancontact';
+  paymentMethodData: {
+    billingDetails: BillingDetails;
+    mandateData?: MandateData;
+  };
+}
+
+export interface SepaParams {
+  paymentMethodType: 'SepaDebit';
+  paymentMethodData: {
+    iban: string;
+    billingDetails: BillingDetails;
+    mandateData?: MandateData;
+  };
+}
+
+export interface GiropayParams {
+  paymentMethodType: 'Giropay';
+  paymentMethodData: {
+    billingDetails: BillingDetails;
+    mandateData?: MandateData;
+  };
+}
+
+export interface AfterpayClearpayParams {
+  paymentMethodType: 'AfterpayClearpay';
+  paymentMethodData: {
+    shippingDetails: BillingDetails;
+    billingDetails: BillingDetails;
+    mandateData?: MandateData;
+  };
+}
+
+export type KlarnaParams = {
+  paymentMethodType: 'Klarna';
+  paymentMethodData: {
+    billingDetails: Pick<Required<BillingDetails>, 'email'> & {
+      address: Pick<Required<Address>, 'country'>;
+    } & BillingDetails;
+    shippingDetails?: BillingDetails;
+    mandateData?: MandateData;
+  };
+};
+
+export interface EpsParams {
+  paymentMethodType: 'Eps';
+  paymentMethodData: {
+    billingDetails: BillingDetails;
+    mandateData?: MandateData;
+  };
+}
+
+export interface P24Params {
+  paymentMethodType: 'P24';
+  paymentMethodData: {
+    billingDetails: BillingDetails;
+    mandateData?: MandateData;
+  };
+}
+
+export interface WeChatPayParams {
+  paymentMethodType: 'WeChatPay';
+  paymentMethodData: {
+    appId: string;
+    billingDetails?: BillingDetails;
+    mandateData?: MandateData;
+  };
+}
+
+export interface AuBecsDebitParams {
+  paymentMethodType: 'AuBecsDebit';
+  paymentMethodData: { formDetails: FormDetails; mandateData?: MandateData };
+}
+
+export type AffirmParams = {
+  paymentMethodType: 'Affirm';
+  paymentMethodData?: {
+    /** Affirm requires that shipping is present for the payment to succeed because it significantly helps with loan approval rates. Shipping details can either be provided here or via the Payment Intent- https://stripe.com/docs/api/payment_intents/create#create_payment_intent-shipping. */
+    shippingDetails?: BillingDetails;
+    billingDetails?: BillingDetails;
+    mandateData?: MandateData;
+  };
+};
+
+/**
+ * If paymentMethodData is null, it is assumed that the bank account details have already been attached
+ * via `collectBankAccountForPayment` or `collectBankAccountForSetup`.
+ */
+export type USBankAccountParams = {
+  paymentMethodType: 'USBankAccount';
+  paymentMethodData?: {
+    billingDetails: Pick<Required<BillingDetails>, 'name'> & BillingDetails;
+    accountNumber: string;
+    routingNumber: string;
+    /** Defaults to Individual */
+    accountHolderType?: BankAcccountHolderType;
+    /** Defaults to Checking */
+    accountType?: BankAcccountType;
+    mandateData?: MandateData;
+  };
+};
+
+export type PayPalParams = {
+  paymentMethodType: 'PayPal';
+  paymentMethodData?: {
+    billingDetails?: BillingDetails;
+    mandateData?: MandateData;
+  };
+};
+
+export type CashAppParams = {
+  paymentMethodType: 'CashApp';
+  paymentMethodData?: {
+    billingDetails?: BillingDetails;
+    mandateData?: MandateData;
+  };
+};
+
+export type CollectBankAccountParams = {
+  paymentMethodType: 'USBankAccount';
+  paymentMethodData: {
+    billingDetails: {
+      name: string;
+      email?: string;
+    };
+    mandateData?: MandateData;
+  };
+};

--- a/src/types/PaymentMethod.ts
+++ b/src/types/PaymentMethod.ts
@@ -43,7 +43,8 @@ export type CreateParams =
   | BancontactParams
   | USBankAccountParams
   | PayPalParams
-  | AffirmParams;
+  | AffirmParams
+  | CashAppParams;
 
 export type ConfirmParams = CreateParams;
 
@@ -205,6 +206,13 @@ export type USBankAccountParams = {
 
 export type PayPalParams = {
   paymentMethodType: 'PayPal';
+  paymentMethodData?: {
+    billingDetails?: BillingDetails;
+  };
+};
+
+export type CashAppParams = {
+  paymentMethodType: 'CashApp';
   paymentMethodData?: {
     billingDetails?: BillingDetails;
   };

--- a/src/types/SetupIntent.ts
+++ b/src/types/SetupIntent.ts
@@ -1,5 +1,9 @@
 import type { Type } from './PaymentMethod';
-import type { LastPaymentError } from './PaymentIntent';
+import type {
+  LastPaymentError,
+  ConfirmParams as PaymentIntentConfirmParams,
+  ConfirmOptions as PaymentIntentConfirmOptions,
+} from './PaymentIntent';
 import type { NextAction } from './NextAction';
 import type * as PaymentMethod from './PaymentMethod';
 export interface Result {
@@ -19,26 +23,9 @@ export interface Result {
   nextAction: NextAction | null;
 }
 
-export type ConfirmParams =
-  | PaymentMethod.CardParams
-  | PaymentMethod.IdealParams
-  | PaymentMethod.OxxoParams
-  | PaymentMethod.P24Params
-  | PaymentMethod.AlipayParams
-  | PaymentMethod.GiropayParams
-  | PaymentMethod.SepaParams
-  | PaymentMethod.EpsParams
-  | PaymentMethod.AuBecsDebitParams
-  | PaymentMethod.SofortParams
-  | PaymentMethod.GrabPayParams
-  | PaymentMethod.FPXParams
-  | PaymentMethod.AfterpayClearpayParams
-  | PaymentMethod.KlarnaParams
-  | PaymentMethod.BancontactParams
-  | PaymentMethod.USBankAccountParams;
-// TODO: Change the above back to PaymentMethod.CreateParams when PayPal is supported through SetupIntents
+export type ConfirmParams = PaymentIntentConfirmParams;
 
-export type ConfirmOptions = {};
+export type ConfirmOptions = PaymentIntentConfirmOptions;
 
 export type FutureUsage =
   | 'Unknown'

--- a/stripe-react-native.podspec
+++ b/stripe-react-native.podspec
@@ -1,7 +1,7 @@
 require 'json'
 
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
-stripe_version = '~> 23.4.0'
+stripe_version = '~> 23.5.0'
 
 Pod::Spec.new do |s|
   s.name         = 'stripe-react-native'


### PR DESCRIPTION
## Summary
adds cashapp and paypal payment methods to payment sheet and to the API bindings, and adds the option to pass MandateData via SDK


## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [ ] I tested this manually
- [x] I added automated tests

## Documentation

Select one: 
- [x] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
