### PR TITLE
feat: add isThreeDSecureSupported on CardResult type

### DIFF
--- a/android/src/main/java/com/reactnativestripesdk/utils/Mappers.kt
+++ b/android/src/main/java/com/reactnativestripesdk/utils/Mappers.kt
@@ -346,8 +346,8 @@ internal fun mapFromPaymentMethod(paymentMethod: PaymentMethod): WritableMap {
     it.putString("fingerprint", paymentMethod.card?.fingerprint)
     it.putString("preferredNetwork", paymentMethod.card?.networks?.preferred)
     it.putArray("availableNetworks", paymentMethod.card?.networks?.available?.toList() as? ReadableArray)
-    it.putMap("threeDSecureUsage", WritableNativeMap().also {
-      it.putBoolean("isSupported", paymentMethod.card?.threeDSecureUsage?.isSupported ?: false)
+    it.putMap("threeDSecureUsage", WritableNativeMap().also { threeDSecureUsageMap ->
+      threeDSecureUsageMap.putBoolean("isSupported", paymentMethod.card?.threeDSecureUsage?.isSupported ?: false)
     })
   })
   pm.putMap("SepaDebit", WritableNativeMap().also {

--- a/android/src/main/java/com/reactnativestripesdk/utils/Mappers.kt
+++ b/android/src/main/java/com/reactnativestripesdk/utils/Mappers.kt
@@ -346,6 +346,7 @@ internal fun mapFromPaymentMethod(paymentMethod: PaymentMethod): WritableMap {
     it.putString("fingerprint", paymentMethod.card?.fingerprint)
     it.putString("preferredNetwork", paymentMethod.card?.networks?.preferred)
     it.putArray("availableNetworks", paymentMethod.card?.networks?.available?.toList() as? ReadableArray)
+    it.putBoolean("isThreeDSecureSupported", paymentMethod.card?.threeDSecureUsage?.isSupported ?: false)
   })
   pm.putMap("SepaDebit", WritableNativeMap().also {
     it.putString("bankCode", paymentMethod.sepaDebit?.bankCode)

--- a/android/src/main/java/com/reactnativestripesdk/utils/Mappers.kt
+++ b/android/src/main/java/com/reactnativestripesdk/utils/Mappers.kt
@@ -346,7 +346,9 @@ internal fun mapFromPaymentMethod(paymentMethod: PaymentMethod): WritableMap {
     it.putString("fingerprint", paymentMethod.card?.fingerprint)
     it.putString("preferredNetwork", paymentMethod.card?.networks?.preferred)
     it.putArray("availableNetworks", paymentMethod.card?.networks?.available?.toList() as? ReadableArray)
-    it.putBoolean("isThreeDSecureSupported", paymentMethod.card?.threeDSecureUsage?.isSupported ?: false)
+    it.putMap("threeDSecureUsage", WritableNativeMap().also {
+      it.putBoolean("isSupported", paymentMethod.card?.threeDSecureUsage?.isSupported ?: false)
+    })
   })
   pm.putMap("SepaDebit", WritableNativeMap().also {
     it.putString("bankCode", paymentMethod.sepaDebit?.bankCode)

--- a/ios/Mappers.swift
+++ b/ios/Mappers.swift
@@ -612,7 +612,9 @@ class Mappers {
             "last4": paymentMethod.card?.last4 ?? NSNull(),
             "preferredNetwork": paymentMethod.card?.networks?.preferred ?? NSNull(),
             "availableNetworks": paymentMethod.card?.networks?.available ?? NSNull(),
-            "isThreeDSecureSupported": paymentMethod.card?.threeDSecureUsage?.supported ?? false,
+            "threeDSecureUsage": [
+              "isSupported": paymentMethod.card?.threeDSecureUsage?.supported ?? false
+            ],
         ]
 
         let sepaDebit: NSDictionary = [

--- a/ios/Mappers.swift
+++ b/ios/Mappers.swift
@@ -187,7 +187,7 @@ class Mappers {
             "isPending": shippingMethod.type == .pending,
             "label": shippingMethod.label
         ]
-        
+
         if #available(iOS 15.0, *) {
             if let dateComponentsRange = shippingMethod.dateComponentsRange {
                 method.setObject(
@@ -612,8 +612,9 @@ class Mappers {
             "last4": paymentMethod.card?.last4 ?? NSNull(),
             "preferredNetwork": paymentMethod.card?.networks?.preferred ?? NSNull(),
             "availableNetworks": paymentMethod.card?.networks?.available ?? NSNull(),
+            "isThreeDSecureSupported": paymentMethod.card?.threeDSecureUsage?.supported ?? false,
         ]
-        
+
         let sepaDebit: NSDictionary = [
             "bankCode": paymentMethod.sepaDebit?.bankCode ?? NSNull(),
             "country": paymentMethod.sepaDebit?.country ?? NSNull(),
@@ -950,7 +951,7 @@ class Mappers {
         }
         return nil
     }
-    
+
     class func convertDateToUnixTimestampSeconds(date: Date?) -> String? {
         if let date = date {
             let value = date.timeIntervalSince1970

--- a/src/types/PaymentMethod.ts
+++ b/src/types/PaymentMethod.ts
@@ -240,6 +240,7 @@ export interface CardResult {
   last4?: string;
   preferredNetwork?: string;
   availableNetworks?: Array<string>;
+  isThreeDSecureSupported?: boolean;
 }
 
 export interface FpxResult {

--- a/src/types/PaymentMethod.ts
+++ b/src/types/PaymentMethod.ts
@@ -240,7 +240,11 @@ export interface CardResult {
   last4?: string;
   preferredNetwork?: string;
   availableNetworks?: Array<string>;
-  isThreeDSecureSupported?: boolean;
+  threeDSecureUsage?: ThreeDSecureUsage;
+}
+
+export interface ThreeDSecureUsage {
+  isSupported?: boolean;
 }
 
 export interface FpxResult {


### PR DESCRIPTION
## Summary
Added `isThreeDSecureSupported` to the `CardResult` type.

This field uses `threeDSecureUsage` to indicate whether the card supports 3DS or not.

## Motivation
Native SDK has this information, but the bridge does not pass this data to the RN package.

This information can be useful to improve the user experience by indicating to the user that a validation from their bank may be required `isThreeDSecureSupported` is `true`.

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [X] I tested this manually
- [ ] I added automated tests

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [X] This PR does not result in any developer-facing changes.
