### PR TITLE
fix: phone number on ShippingContact is a string

### DIFF
--- a/src/types/ApplePay.ts
+++ b/src/types/ApplePay.ts
@@ -55,7 +55,7 @@ interface ContactName {
 export interface ShippingContact {
   emailAddress?: string;
   name: ContactName;
-  phoneNumber?: number;
+  phoneNumber?: string;
   postalAddress: PostalAddress;
 }
 


### PR DESCRIPTION
## Summary
`phoneNumber` type on `ShippingContact` for ApplePay is a `string` not a `number`

## Motivation
Native mappers `mapFromShippingContact` give the phone number as a `string` but TS type is a `number` which is wrong.

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [X] I tested this manually
- [ ] I added automated tests

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [X] This PR does not result in any developer-facing changes.
