### PR TITLE
feat: add billingDetailsCollectionConfiguration to payment sheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+- Added `billingDetailsCollectionConfiguration` to `initPaymentSheet` parameters. Use this to configure the collection of email, phone, name, or address in the Payment Sheet. [#1361](https://github.com/stripe/stripe-react-native/pull/1361)
+
 ### Fixes
 
 - Updated Google Pay button asset to match Google's most recent branding guidelines. [#1343](https://github.com/stripe/stripe-react-native/pull/1343)

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,2 +1,2 @@
 StripeSdk_kotlinVersion=1.8.0
-StripeSdk_stripeVersion=[20.20.0, 20.22.0[
+StripeSdk_stripeVersion=20.23.+

--- a/android/src/main/java/com/reactnativestripesdk/PaymentSheetFragment.kt
+++ b/android/src/main/java/com/reactnativestripesdk/PaymentSheetFragment.kt
@@ -64,6 +64,7 @@ class PaymentSheetFragment(
     val googlePayConfig = buildGooglePayConfig(arguments?.getBundle("googlePay"))
     val allowsDelayedPaymentMethods = arguments?.getBoolean("allowsDelayedPaymentMethods")
     val billingDetailsBundle = arguments?.getBundle("defaultBillingDetails")
+    val billingConfigParams = arguments?.getBundle("billingDetailsCollectionConfiguration")
     paymentIntentClientSecret = arguments?.getString("paymentIntentClientSecret").orEmpty()
     setupIntentClientSecret = arguments?.getString("setupIntentClientSecret").orEmpty()
     val appearance = try {
@@ -119,6 +120,15 @@ class PaymentSheetFragment(
       }
     }
 
+    val billingDetailsConfig = PaymentSheet.BillingDetailsCollectionConfiguration(
+      name = mapToCollectionMode(billingConfigParams?.getString("name")),
+      phone = mapToCollectionMode(billingConfigParams?.getString("phone")),
+      email = mapToCollectionMode(billingConfigParams?.getString("email")),
+      address = mapToAddressCollectionMode(billingConfigParams?.getString("address")),
+      attachDefaultsToPaymentMethod = billingConfigParams?.getBoolean("attachDefaultsToPaymentMethod")
+        ?: false
+    )
+
     var defaultBillingDetails: PaymentSheet.BillingDetails? = null
     if (billingDetailsBundle != null) {
       val addressBundle = billingDetailsBundle.getBundle("address")
@@ -147,7 +157,8 @@ class PaymentSheetFragment(
       googlePay = googlePayConfig,
       appearance = appearance,
       shippingDetails = shippingDetails,
-      primaryButtonLabel = primaryButtonLabel
+      primaryButtonLabel = primaryButtonLabel,
+      billingDetailsCollectionConfiguration = billingDetailsConfig
     )
 
     if (arguments?.getBoolean("customFlow") == true) {
@@ -299,4 +310,22 @@ fun getBase64FromBitmap(bitmap: Bitmap?): String? {
   bitmap.compress(Bitmap.CompressFormat.PNG, 100, stream)
   val imageBytes: ByteArray = stream.toByteArray()
   return Base64.encodeToString(imageBytes, Base64.DEFAULT)
+}
+
+fun mapToCollectionMode(str: String?): PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode {
+  return when (str) {
+    "automatic" -> PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Automatic
+    "never" -> PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Never
+    "always" -> PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always
+    else -> PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Automatic
+  }
+}
+
+fun mapToAddressCollectionMode(str: String?): PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode {
+  return when (str) {
+    "automatic" -> PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic
+    "never" -> PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Never
+    "full" -> PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full
+    else -> PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic
+  }
 }

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -368,50 +368,50 @@ PODS:
     - React-Core
     - React-RCTImage
   - SocketRocket (0.6.0)
-  - Stripe (23.5.0):
-    - StripeApplePay (= 23.5.0)
-    - StripeCore (= 23.5.0)
-    - StripePayments (= 23.5.0)
-    - StripePaymentsUI (= 23.5.0)
-    - StripeUICore (= 23.5.0)
+  - Stripe (23.6.0):
+    - StripeApplePay (= 23.6.0)
+    - StripeCore (= 23.6.0)
+    - StripePayments (= 23.6.0)
+    - StripePaymentsUI (= 23.6.0)
+    - StripeUICore (= 23.6.0)
   - stripe-react-native (0.26.0):
     - React-Core
-    - Stripe (~> 23.5.0)
-    - StripeApplePay (~> 23.5.0)
-    - StripeFinancialConnections (~> 23.5.0)
-    - StripePayments (~> 23.5.0)
-    - StripePaymentSheet (~> 23.5.0)
-    - StripePaymentsUI (~> 23.5.0)
+    - Stripe (= 23.6.0)
+    - StripeApplePay (= 23.6.0)
+    - StripeFinancialConnections (= 23.6.0)
+    - StripePayments (= 23.6.0)
+    - StripePaymentSheet (= 23.6.0)
+    - StripePaymentsUI (= 23.6.0)
   - stripe-react-native/Tests (0.26.0):
     - React-Core
-    - Stripe (~> 23.5.0)
-    - StripeApplePay (~> 23.5.0)
-    - StripeFinancialConnections (~> 23.5.0)
-    - StripePayments (~> 23.5.0)
-    - StripePaymentSheet (~> 23.5.0)
-    - StripePaymentsUI (~> 23.5.0)
-  - StripeApplePay (23.5.0):
-    - StripeCore (= 23.5.0)
-  - StripeCore (23.5.0)
-  - StripeFinancialConnections (23.5.0):
-    - StripeCore (= 23.5.0)
-    - StripeUICore (= 23.5.0)
-  - StripePayments (23.5.0):
-    - StripeCore (= 23.5.0)
-    - StripePayments/Stripe3DS2 (= 23.5.0)
-  - StripePayments/Stripe3DS2 (23.5.0):
-    - StripeCore (= 23.5.0)
-  - StripePaymentSheet (23.5.0):
-    - StripeApplePay (= 23.5.0)
-    - StripeCore (= 23.5.0)
-    - StripePayments (= 23.5.0)
-    - StripePaymentsUI (= 23.5.0)
-  - StripePaymentsUI (23.5.0):
-    - StripeCore (= 23.5.0)
-    - StripePayments (= 23.5.0)
-    - StripeUICore (= 23.5.0)
-  - StripeUICore (23.5.0):
-    - StripeCore (= 23.5.0)
+    - Stripe (= 23.6.0)
+    - StripeApplePay (= 23.6.0)
+    - StripeFinancialConnections (= 23.6.0)
+    - StripePayments (= 23.6.0)
+    - StripePaymentSheet (= 23.6.0)
+    - StripePaymentsUI (= 23.6.0)
+  - StripeApplePay (23.6.0):
+    - StripeCore (= 23.6.0)
+  - StripeCore (23.6.0)
+  - StripeFinancialConnections (23.6.0):
+    - StripeCore (= 23.6.0)
+    - StripeUICore (= 23.6.0)
+  - StripePayments (23.6.0):
+    - StripeCore (= 23.6.0)
+    - StripePayments/Stripe3DS2 (= 23.6.0)
+  - StripePayments/Stripe3DS2 (23.6.0):
+    - StripeCore (= 23.6.0)
+  - StripePaymentSheet (23.6.0):
+    - StripeApplePay (= 23.6.0)
+    - StripeCore (= 23.6.0)
+    - StripePayments (= 23.6.0)
+    - StripePaymentsUI (= 23.6.0)
+  - StripePaymentsUI (23.6.0):
+    - StripeCore (= 23.6.0)
+    - StripePayments (= 23.6.0)
+    - StripeUICore (= 23.6.0)
+  - StripeUICore (23.6.0):
+    - StripeCore (= 23.6.0)
   - Yoga (1.14.0)
   - YogaKit (1.18.1):
     - Yoga (~> 1.14)
@@ -636,15 +636,15 @@ SPEC CHECKSUMS:
   RNCPicker: 0bf8ef8f7800524f32d2bb2a8bcadd53eda0ecd1
   RNScreens: 34cc502acf1b916c582c60003dc3089fa01dc66d
   SocketRocket: fccef3f9c5cedea1353a9ef6ada904fde10d6608
-  Stripe: 52dea7bd3ef1a679af8406915724b30017713ae9
-  stripe-react-native: 23f5586ac954f54c5723c08be4f1a65d97f797eb
-  StripeApplePay: e17b49bd1b44817325fcd3c2400b2b21f2462a9a
-  StripeCore: 8cfb64927054f378af165629d2522894d03bd8fc
-  StripeFinancialConnections: 607d63237ec9304b42507d3fd4b4a754f01d41e1
-  StripePayments: 99c899c85eec727e35ecbccb76e21eb42aeb680b
-  StripePaymentSheet: a6f0116067fec8b3fe8ca583db9efc019725e4ac
-  StripePaymentsUI: e832ad4db17c3e2b82a69efbd86aea354d1cd77a
-  StripeUICore: e2c0f925b7446fb7bf73314bd2435dadb1d4057c
+  Stripe: 097f76ce332ff7dcb8a29ec2a8379bb4f34aa14d
+  stripe-react-native: 331225716a96961089b71ca105847e11f81fc99f
+  StripeApplePay: 484761d4760ddb8af8c1510b8735cd9aee94515f
+  StripeCore: 0e83ad26d508e5a8e9eb04d6ddd3cbb08a3f7816
+  StripeFinancialConnections: eb303783458a7e5bd4380cbbf0a6cf44246473f4
+  StripePayments: cdd5222052d541f4daf1d84515f0b9cd18720534
+  StripePaymentSheet: 835aabcac7946d6b6b341055d021428b96894b70
+  StripePaymentsUI: 835b9422f86ceb2ca02b4146db9d3f7bf1acb0d9
+  StripeUICore: 81bac0f54df659ab7c5dd4f5a57719a5fecdcdc9
   Yoga: 0b84a956f7393ef1f37f3bb213c516184e4a689d
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 

--- a/ios/StripeSdk+PaymentSheet.swift
+++ b/ios/StripeSdk+PaymentSheet.swift
@@ -47,6 +47,14 @@ extension StripeSdk {
         if let allowsDelayedPaymentMethods = params["allowsDelayedPaymentMethods"] as? Bool {
             configuration.allowsDelayedPaymentMethods = allowsDelayedPaymentMethods
         }
+        
+        if let billingConfigParams = params["billingDetailsCollectionConfiguration"] as? [String: Any?] {
+            configuration.billingDetailsCollectionConfiguration.name = StripeSdk.mapToCollectionMode(str: billingConfigParams["name"] as? String)
+            configuration.billingDetailsCollectionConfiguration.phone = StripeSdk.mapToCollectionMode(str: billingConfigParams["phone"] as? String)
+            configuration.billingDetailsCollectionConfiguration.email = StripeSdk.mapToCollectionMode(str: billingConfigParams["email"] as? String)
+            configuration.billingDetailsCollectionConfiguration.address = StripeSdk.mapToAddressCollectionMode(str: billingConfigParams["address"] as? String)
+            configuration.billingDetailsCollectionConfiguration.attachDefaultsToPaymentMethod = billingConfigParams["attachDefaultsToPaymentMethod"] as? Bool == true
+        }
 
         if let defaultBillingDetails = params["defaultBillingDetails"] as? [String: Any?] {
             configuration.defaultBillingDetails.name = defaultBillingDetails["name"] as? String
@@ -163,4 +171,31 @@ extension StripeSdk {
             }
         })
     }
+    
+    private static func mapToCollectionMode(str: String?) -> PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode {
+        switch str {
+        case "automatic":
+            return .automatic
+        case "never":
+            return .never
+        case "always":
+            return .always
+        default:
+            return .automatic
+        }
+    }
+    
+    private static func mapToAddressCollectionMode(str: String?) -> PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode {
+        switch str {
+        case "automatic":
+            return .automatic
+        case "never":
+            return .never
+        case "full":
+            return .full
+        default:
+            return .automatic
+        }
+    }
 }
+

--- a/src/types/PaymentSheet.ts
+++ b/src/types/PaymentSheet.ts
@@ -25,6 +25,8 @@ export type SetupParams = ClientSecretParams & {
   style?: 'alwaysLight' | 'alwaysDark' | 'automatic';
   /** A URL that redirects back to your app that PaymentSheet can use to auto-dismiss web views used for additional authentication, e.g. 3DS2 */
   returnURL?: string;
+  /** Configuration for how billing details are collected during checkout. */
+  billingDetailsCollectionConfiguration?: BillingDetailsCollectionConfiguration;
   /** PaymentSheet pre-populates the billing fields that are displayed in the Payment Sheet (only country and postal code, as of this version) with the values provided. */
   defaultBillingDetails?: BillingDetails;
   /**
@@ -262,3 +264,34 @@ export type PresentOptions = {
    */
   timeout?: number;
 };
+
+export type BillingDetailsCollectionConfiguration = {
+  /** How to collect the name field. Defaults to `CollectionMode.automatic`. */
+  name?: CollectionMode;
+  /** How to collect the phone field. Defaults to `CollectionMode.automatic`. */
+  phone?: CollectionMode;
+  /** How to collect the email field. Defaults to `CollectionMode.automatic`. */
+  email?: CollectionMode;
+  /** How to collect the billing address. Defaults to `CollectionMode.automatic`. */
+  address?: AddressCollectionMode;
+  /** Whether the values included in `Configuration.defaultBillingDetails` should be attached to the payment method, this includes fields that aren't displayed in the form. If `false` (the default), those values will only be used to prefill the corresponding fields in the form. */
+  attachDefaultsToPaymentMethod?: Boolean;
+};
+
+export enum CollectionMode {
+  /** The field may or may not be collected depending on the Payment Method's requirements. */
+  AUTOMATIC = 'automatic',
+  /** The field will never be collected. If this field is required by the Payment Method, you must provide it as part of `defaultBillingDetails`. */
+  NEVER = 'never',
+  /** The field will always be collected, even if it isn't required for the Payment Method. */
+  ALWAYS = 'always',
+}
+
+export enum AddressCollectionMode {
+  /** Only the fields required by the Payment Method will be collected, which may be none. */
+  AUTOMATIC = 'automatic',
+  /** Billing address will never be collected. If the Payment Method requires a billing address, you must provide it as part of `defaultBillingDetails`. */
+  NEVER = 'never',
+  /** Collect the full billing address, regardless of the Payment Method's requirements. */
+  FULL = 'full',
+}

--- a/stripe-react-native.podspec
+++ b/stripe-react-native.podspec
@@ -1,7 +1,7 @@
 require 'json'
 
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
-stripe_version = '~> 23.5.0'
+stripe_version = '23.6.0'
 
 Pod::Spec.new do |s|
   s.name         = 'stripe-react-native'


### PR DESCRIPTION
## Summary

allow merchants to set how they'd like to collect billing details in payment sheet

## Motivation
closes https://github.com/stripe/stripe-react-native/issues/1034
## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one: 
- [x] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
