### PR TITLE
fix: send shippingContact with createPaymentMethod

### DIFF
--- a/src/functions.ts
+++ b/src/functions.ts
@@ -195,15 +195,14 @@ export const presentApplePay = async (
   }
 
   try {
-    const { paymentMethod, error } = await NativeStripeSdk.presentApplePay(
-      params
-    );
+    const { paymentMethod, shippingContact, error } =
+      await NativeStripeSdk.presentApplePay(params);
     if (error) {
       return {
         error,
       };
     }
-    return { paymentMethod: paymentMethod! };
+    return { paymentMethod: paymentMethod!, shippingContact };
   } catch (error: any) {
     return {
       error,
@@ -831,7 +830,7 @@ export const createPlatformPayPaymentMethod = async (
   params: PlatformPay.PaymentMethodParams
 ): Promise<PlatformPay.PaymentMethodResult> => {
   try {
-    const { error, paymentMethod } =
+    const { error, paymentMethod, shippingContact } =
       (await NativeStripeSdk.createPlatformPayPaymentMethod(
         params,
         false
@@ -843,6 +842,7 @@ export const createPlatformPayPaymentMethod = async (
     }
     return {
       paymentMethod: paymentMethod!,
+      shippingContact: shippingContact,
     };
   } catch (error: any) {
     return {

--- a/src/types/PlatformPay.ts
+++ b/src/types/PlatformPay.ts
@@ -367,10 +367,12 @@ export type IsGooglePaySupportedParams = IsSupportedParams;
 export type PaymentMethodResult =
   | {
       paymentMethod: PaymentMethod;
+      shippingContact?: ShippingContact;
       error?: undefined;
     }
   | {
       paymentMethod?: undefined;
+      shippingContact?: ShippingContact;
       error: StripeError<PlatformPayError>;
     };
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -167,10 +167,12 @@ export type ConfirmPaymentSheetPaymentResult = {
 export type ApplePayResult =
   | {
       paymentMethod: PaymentMethod.Result;
+      shippingContact?: ApplePay.ShippingContact;
       error?: undefined;
     }
   | {
       paymentMethod?: undefined;
+      shippingContact?: ApplePay.ShippingContact;
       error: StripeError<ApplePayError>;
     };
 


### PR DESCRIPTION
## Summary
`createPlatformPayPaymentMethod` wasn't returning the `shippingContact` information which contains the address. 

this modifies both `createPlatformPayPaymentMethod` and `presentApplePay` to pass along the `shippingContact`

## Motivation
both `createPlatformPayPaymentMethod & presentApplePay` allow **confirming** the `paymentIntent` **after** the user has passed the biometric auth during apple pay, which allows getting the full address (that contains the `street`), this is useful for setting options on the server before the `paymentIntent` is confirmed with `confirmApplePayPayment || stripe.confirmPayment`
___
In our case we run hooks that trigger on `paymentIntentConfirm` which block setting the address after the fact (for security of an order) which is a problem on `confirmPlatformPayPayment` since it confirms without setting an address (a bug on `StripeApplePay` Pod. but even if that were fixed, it sets the address during confirmation which causes the same problem with the hook on our use case

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one: 
- [x] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
