### PR TITLE
fix: created should be string on android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+## Fixes
+
+- Fixed the type of `created` on `Token.Result` on Android (was a number, should be a string). [#1369](https://github.com/stripe/stripe-react-native/pull/1369)
 
 ## 0.27.0 - 2023-04-21
 

--- a/android/src/main/java/com/reactnativestripesdk/utils/Mappers.kt
+++ b/android/src/main/java/com/reactnativestripesdk/utils/Mappers.kt
@@ -314,7 +314,7 @@ internal fun mapFromCard(card: Card?): WritableMap? {
 internal fun mapFromToken(token: Token): WritableMap {
   val tokenMap: WritableMap = WritableNativeMap()
   tokenMap.putString("id", token.id)
-  tokenMap.putDouble("created", token.created.time.toDouble())
+  tokenMap.putString("created", token.created.time.toString())
   tokenMap.putString("type", mapTokenType(token.type))
   tokenMap.putBoolean("livemode", token.livemode)
   tokenMap.putMap("bankAccount", mapFromBankAccount(token.bankAccount))


### PR DESCRIPTION
## Summary
match TS types

## Motivation
fixes https://github.com/stripe/stripe-react-native/issues/1365

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [] I added automated tests

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
