### PR TITLE
fix: resolve resource ID for AddToWalletButton in release mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Fixes
 
 - Fixed the type of `created` on `Token.Result` on Android (was a number, should be a string). [#1369](https://github.com/stripe/stripe-react-native/pull/1369)
+- Fixed `AddToWalletButton` not properly resolving the `androidAssetSource` in release mode. [#1373](https://github.com/stripe/stripe-react-native/pull/1373)
 
 ## 0.27.0 - 2023-04-21
 

--- a/android/src/main/java/com/reactnativestripesdk/pushprovisioning/AddToWalletButtonView.kt
+++ b/android/src/main/java/com/reactnativestripesdk/pushprovisioning/AddToWalletButtonView.kt
@@ -5,6 +5,7 @@ import android.graphics.Color
 import android.graphics.drawable.Drawable
 import android.graphics.drawable.RippleDrawable
 import android.view.MotionEvent
+import android.webkit.URLUtil
 import androidx.appcompat.widget.AppCompatImageView
 import com.bumptech.glide.RequestManager
 import com.bumptech.glide.load.DataSource
@@ -27,7 +28,7 @@ class AddToWalletButtonView(private val context: ThemedReactContext, private val
   private var token: ReadableMap? = null
 
   private var eventDispatcher: EventDispatcher? = context.getNativeModule(UIManagerModule::class.java)?.eventDispatcher
-  private var loadedSource: GlideUrl? = null
+  private var loadedSource: Any? = null
   private var heightOverride: Int = 0
   private var widthOverride: Int = 0
 
@@ -66,7 +67,7 @@ class AddToWalletButtonView(private val context: ThemedReactContext, private val
   }
 
   fun onAfterUpdateTransaction() {
-    val sourceToLoad = createUrlFromSourceMap(sourceMap)
+    val sourceToLoad = getUrlOrResourceId(sourceMap)
     if (sourceToLoad == null) {
       requestManager.clear(this)
       setImageDrawable(null)
@@ -99,9 +100,17 @@ class AddToWalletButtonView(private val context: ThemedReactContext, private val
     }
   }
 
-  private fun createUrlFromSourceMap(sourceMap: ReadableMap?): GlideUrl? {
-    val uriKey = sourceMap?.getString("uri")
-    return uriKey?.let { GlideUrl(uriKey) }
+  private fun getUrlOrResourceId(sourceMap: ReadableMap?): Any? {
+    sourceMap?.getString("uri")?.let {
+      return if (URLUtil.isValidUrl(it)) {
+        // Debug mode, Image.resolveAssetSource resolves to local http:// URL
+        GlideUrl(it)
+      } else {
+        // Release mode, Image.resolveAssetSource resolves to a drawable resource
+        context.resources.getIdentifier(it, "drawable", context.packageName)
+      }
+    }
+    return null
   }
 
   override fun onSizeChanged(w: Int, h: Int, oldw: Int, oldh: Int) {


### PR DESCRIPTION
## Summary

`createUrlFromSourceMap` is now `getUrlOrResourceId` and will get the GlideUrl if the uri is a valid url, otherwise it will assume we're running in release mode and react-native has given us a resource string from `resolveAssetSource`

## Motivation

AddToWalletButton wouldn't show up in release on android if you used `Image.resolveAssetSource`

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
