### PR TITLE
fix: existingPaymentMethodRequired on android's isPlatformPaySupported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Fixes
 
 - Fixed the type of `created` on `Token.Result` on Android (was a number, should be a string). [#1369](https://github.com/stripe/stripe-react-native/pull/1369)
+- Fixed `isPlatformPaySupported` not respecting `existingPaymentMethodRequired` or `testEnv` on Android. [#1374](https://github.com/stripe/stripe-react-native/pull/1374)
 
 ## 0.27.0 - 2023-04-21
 

--- a/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
+++ b/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
@@ -528,10 +528,11 @@ class StripeSdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJ
 
   @ReactMethod
   fun isPlatformPaySupported(params: ReadableMap?, promise: Promise) {
+    val googlePayParams = params?.getMap("googlePay")
     val fragment = GooglePayPaymentMethodLauncherFragment(
       reactApplicationContext,
-      getBooleanOrFalse(params, "testEnv"),
-      getBooleanOrFalse(params, "existingPaymentMethodRequired"),
+      getBooleanOrFalse(googlePayParams, "testEnv"),
+      getBooleanOrFalse(googlePayParams, "existingPaymentMethodRequired"),
       promise
     )
 


### PR DESCRIPTION
## Summary
we weren't taking out the `googlePay` object before

## Motivation
closes https://github.com/stripe/stripe-react-native/issues/1371

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
