### PR TITLE
feat: support for Account token (only with phone attribute for Company business type)

### DIFF
--- a/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
+++ b/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
@@ -292,8 +292,51 @@ class StripeSdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJ
       "Pii" -> {
         createTokenFromPii(params, promise)
       }
+      "Account" -> {
+        createTokenFromAccount(params, promise)
+      }
       else -> {
-        promise.resolve(createError(CreateTokenErrorType.Failed.toString(), "$type type is not supported yet"))
+        promise.resolve(createError(CreateTokenErrorType.Failed.toString(), "$type type is not toto supported yet"))
+      }
+    }
+  }
+
+  private fun createTokenFromAccount(params: ReadableMap, promise: Promise) {
+    val businessType = getValOr(params, "businessType", null)
+    if (businessType == null) {
+      promise.resolve(createError(CreateTokenErrorType.Failed.toString(), "You must provide businessType"))
+      return
+    }
+
+    /*val businessTypeParams = null
+    when (businessType) {
+      "Company" -> {
+        promise.resolve(createError(CreateTokenErrorType.Failed.toString(), "Company businessType is not implemented yet"))
+        return
+      }
+      "Individual" -> {
+      }
+      else -> {
+        promise.resolve(createError(CreateTokenErrorType.Failed.toString(), "$businessType businessType is not supported yet"))
+        return
+      }
+    }*/
+
+    val individualData = getMapOrNull(params, "individual")
+    val accountParams = AccountParams.create(
+      tosShownAndAccepted = getBooleanOrFalse(params, "tosShownAndAccepted"),
+      individual = AccountParams.BusinessTypeParams.Individual.Builder()
+        .setFirstName(getValOr(individualData, "firstName", null))
+        .setLastName(getValOr(individualData, "lastName", null))
+        .setEmail(getValOr(individualData, "email", null))
+        .build()
+    )
+    CoroutineScope(Dispatchers.IO).launch {
+      runCatching {
+        val token = stripe.createAccountToken(accountParams, null, stripeAccountId)
+        promise.resolve(createResult("token", mapFromToken(token)))
+      }.onFailure {
+        promise.resolve(createError(CreateTokenErrorType.Failed.toString(), it.message))
       }
     }
   }

--- a/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
+++ b/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
@@ -296,39 +296,23 @@ class StripeSdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJ
         createTokenFromAccount(params, promise)
       }
       else -> {
-        promise.resolve(createError(CreateTokenErrorType.Failed.toString(), "$type type is not toto supported yet"))
+        promise.resolve(createError(CreateTokenErrorType.Failed.toString(), "$type type is not supported yet"))
       }
     }
   }
 
   private fun createTokenFromAccount(params: ReadableMap, promise: Promise) {
     val businessType = getValOr(params, "businessType", null)
-    if (businessType == null) {
-      promise.resolve(createError(CreateTokenErrorType.Failed.toString(), "You must provide businessType"))
+    if (businessType != "Company") {
+      promise.resolve(createError(CreateTokenErrorType.Failed.toString(), "businessType currently only accepts the Company account type"))
       return
     }
 
-    /*val businessTypeParams = null
-    when (businessType) {
-      "Company" -> {
-        promise.resolve(createError(CreateTokenErrorType.Failed.toString(), "Company businessType is not implemented yet"))
-        return
-      }
-      "Individual" -> {
-      }
-      else -> {
-        promise.resolve(createError(CreateTokenErrorType.Failed.toString(), "$businessType businessType is not supported yet"))
-        return
-      }
-    }*/
-
-    val individualData = getMapOrNull(params, "individual")
+    val companyData = getMapOrNull(params, "company")
     val accountParams = AccountParams.create(
       tosShownAndAccepted = getBooleanOrFalse(params, "tosShownAndAccepted"),
-      individual = AccountParams.BusinessTypeParams.Individual.Builder()
-        .setFirstName(getValOr(individualData, "firstName", null))
-        .setLastName(getValOr(individualData, "lastName", null))
-        .setEmail(getValOr(individualData, "email", null))
+      company = AccountParams.BusinessTypeParams.Company.Builder()
+        .setPhone(getValOr(companyData, "phone", null))
         .build()
     )
     CoroutineScope(Dispatchers.IO).launch {

--- a/example/src/screens/CreateTokenScreen.tsx
+++ b/example/src/screens/CreateTokenScreen.tsx
@@ -54,6 +54,13 @@ export default function CreateTokenScreen() {
         title="Create a token from a card"
         accessibilityLabel="Create a token from a card"
       />
+      <Text style={styles.or}>OR</Text>
+      <Button
+        variant="primary"
+        onPress={() => _createToken('Account')}
+        title="Create a token from an account"
+        accessibilityLabel="Create a token from an account"
+      />
     </PaymentScreen>
   );
 }
@@ -78,6 +85,16 @@ function buildTestTokenParams(type: Token.Type): Token.CreateParams {
         routingNumber: '110000000', // Routing number is REQUIRED for US bank accounts
         country: 'US',
         currency: 'usd',
+      };
+    case 'Account':
+      return {
+        type: 'Account',
+        businessType: 'Individual',
+        individual: {
+          firstName: 'Jane',
+          lastName: 'Doe',
+        },
+        tosShownAndAccepted: true,
       };
     default:
       throw new Error(`Unsupported token type`);

--- a/example/src/screens/CreateTokenScreen.tsx
+++ b/example/src/screens/CreateTokenScreen.tsx
@@ -89,10 +89,9 @@ function buildTestTokenParams(type: Token.Type): Token.CreateParams {
     case 'Account':
       return {
         type: 'Account',
-        businessType: 'Individual',
-        individual: {
-          firstName: 'Jane',
-          lastName: 'Doe',
+        businessType: 'Company',
+        company: {
+          phone: '00000000'
         },
         tosShownAndAccepted: true,
       };

--- a/ios/StripeSdk.swift
+++ b/ios/StripeSdk.swift
@@ -589,6 +589,8 @@ class StripeSdk: RCTEventEmitter, STPBankSelectionViewControllerDelegate, UIAdap
             createTokenFromCard(params: params, resolver: resolve, rejecter: reject)
         case "Pii":
             createTokenFromPii(params: params, resolver: resolve, rejecter: reject)
+        case "Account":
+            createTokenFromAccount(params: params, resolver: resolve, rejecter: reject)
         default:
             resolve(Errors.createError(ErrorType.Failed, type + " type is not supported yet"))
         }
@@ -669,6 +671,37 @@ class StripeSdk: RCTEventEmitter, STPBankSelectionViewControllerDelegate, UIAdap
         cardSourceParams.currency = params["currency"] as? String
 
         STPAPIClient.shared.createToken(withCard: cardSourceParams) { token, error in
+            if let token = token {
+                resolve(Mappers.createResult("token", Mappers.mapFromToken(token: token)))
+            } else {
+                resolve(Errors.createError(ErrorType.Failed, error as NSError?))
+            }
+        }
+    }
+
+    func createTokenFromAccount(
+        params: NSDictionary,
+        resolver resolve: @escaping RCTPromiseResolveBlock,
+        rejecter reject: @escaping RCTPromiseRejectBlock
+    ) -> Void {
+        let businessType = params["businessType"] as? String
+        if (businessType != "Company") {
+            resolve(Errors.createError(ErrorType.Failed, "businessType currently only accepts the Company account type."))
+            return
+        }
+
+        let tosShownAndAccepted = params["tosShownAndAccepted"] as? Bool ?? false
+        let phone = params["phone"] as? String
+
+        let connectAccountCompanyParams = STPConnectAccountCompanyParams()
+        connectAccountCompanyParams.phone = phone
+
+        guard let accountParams = STPConnectAccountParams(tosShownAndAccepted: tosShownAndAccepted, company: connectAccountCompanyParams) else {
+            resolve(Errors.createError(ErrorType.Failed, "tosShownAndAccepted parameter must be true"))
+            return
+        }
+
+        STPAPIClient.shared.createToken(withConnectAccount: accountParams) { token, error in
             if let token = token {
                 resolve(Mappers.createResult("token", Mappers.mapFromToken(token: token)))
             } else {

--- a/src/types/Token.ts
+++ b/src/types/Token.ts
@@ -71,7 +71,8 @@ export interface Card {
 export type CreateParams =
   | CreateCardTokenParams
   | CreateBankAccountTokenParams
-  | CreatePiiTokenParams;
+  | CreatePiiTokenParams
+  | CreateAccountTokenParams;
 
 /** Creates a single-use token that represents a credit card’s details. Use this in combination with either the CardField or CardForm components. This token can be used in place of a credit card object with any API method. See https://stripe.com/docs/api/tokens/create_card*/
 export type CreateCardTokenParams = {
@@ -102,3 +103,19 @@ export type CreatePiiTokenParams = {
   /** The user's personal ID number */
   personalId: string;
 };
+
+export type AccountBusinessType = 'Company' | 'Individual';
+
+/** Creates a single-use token that wraps a user’s legal entity information. See https://stripe.com/docs/api/tokens/create_account */
+export type CreateAccountTokenParams = {
+  type: 'Account';
+  businessType: AccountBusinessType;
+  individual?: AccountIndividual;
+  tosShownAndAccepted?: boolean;
+};
+
+export type AccountIndividual = {
+  email?: string;
+  firstName?: string;
+  lastName?: string;
+}

--- a/src/types/Token.ts
+++ b/src/types/Token.ts
@@ -110,12 +110,10 @@ export type AccountBusinessType = 'Company' | 'Individual';
 export type CreateAccountTokenParams = {
   type: 'Account';
   businessType: AccountBusinessType;
-  individual?: AccountIndividual;
+  company?: AccountCompany;
   tosShownAndAccepted?: boolean;
 };
 
-export type AccountIndividual = {
-  email?: string;
-  firstName?: string;
-  lastName?: string;
+export type AccountCompany = {
+  phone?: string;
 }


### PR DESCRIPTION
## Summary
This PR add partial support for creating Account Token. Only "compagny" is supported as businessType with phone attribute and TOS params.

## Motivation
As requested in #842 connected accounts need an Account Token to initiate a Connect OnBoarding form.

Actually it is only a work around to onboard my users with stripe-react-native. I'm not sure I will have time to finish the full implementation with all attributes and Individual business type

## Testing
- [x] I tested this manually
- [ ] I added automated tests

Note: tested with example app for initiate with Individual but not in final version with Company

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
