### PR TITLE
fix: better docs for requiredShippingAddressFields

### DIFF
--- a/src/components/PlatformPayButton.tsx
+++ b/src/components/PlatformPayButton.tsx
@@ -42,7 +42,8 @@ export interface Props extends AccessibilityProps {
     shippingMethod: ShippingMethod;
   }) => void;
   /**
-   * This callback is triggered whenever the user selects a shipping contact in the Apple Pay sheet.
+   * This callback is triggered whenever the user selects a shipping contact in the Apple Pay sheet IF
+   * ContactField.PostalAddress was included in the requiredShippingAddressFields array.
    * It receives one parameter: an `event` object with a `shippingContact` field. You MUST
    * update the Apple Pay sheet in your callback using the updatePlatformPaySheet function, otherwise the
    * Apple Pay sheet will hang and the payment flow will automatically cancel.

--- a/src/types/PlatformPay.ts
+++ b/src/types/PlatformPay.ts
@@ -55,7 +55,7 @@ export type ApplePayBaseParams = {
   additionalEnabledNetworks?: Array<string>;
   /** The list of items that describe a purchase. For example: total, tax, discount, and grand total. */
   cartItems: Array<CartSummaryItem>;
-  /** The list of fields that you need for a shipping contact in order to process the transaction. If provided, you must implement the PlatformPayButton component's `onShippingContactSelected` callback and call `updatePlatformPaySheet` from there.*/
+  /** The list of fields that you need for a shipping contact in order to process the transaction. If you include ContactField.PostalAddress in this array, you must implement the PlatformPayButton component's `onShippingContactSelected` callback and call `updatePlatformPaySheet` from there.*/
   requiredShippingAddressFields?: Array<ContactField>;
   /** The list of fields that you need for a billing contact in order to process the transaction. */
   requiredBillingContactFields?: Array<ContactField>;


### PR DESCRIPTION
## Summary

onShippingContactSelected only gets fired when PlatformPay.ContactField.PostalAddress is included in requiredShippingAddressFields. I believe this is due to apple's [redaction behavior](https://developer.apple.com/documentation/apple_pay_on_the_web/applepaypayment/1916097-shippingcontact), but there is no confirmation of that in the official [PKPaymentAuthorizationViewController docs](https://developer.apple.com/documentation/passkit/pkpaymentauthorizationviewcontrollerdelegate/2865761-paymentauthorizationviewcontroll)
