### PR TITLE
fix: handle url callback android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## Fixes
+
+- Only call `handleURLCallback` on iOS. [#1423](https://github.com/stripe/stripe-react-native/pull/1423)
+
 ## 0.28.0 - 2023-06-16
 
 ## Features

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -346,7 +346,10 @@ export const createTokenForCVCUpdate = async (
 };
 
 export const handleURLCallback = async (url: string): Promise<boolean> => {
-  const stripeHandled = await NativeStripeSdk.handleURLCallback(url);
+  const stripeHandled =
+    Platform.OS === 'ios'
+      ? await NativeStripeSdk.handleURLCallback(url)
+      : false;
   return stripeHandled;
 };
 

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -345,6 +345,12 @@ export const createTokenForCVCUpdate = async (
   }
 };
 
+/**
+ * Call this method in your app whenever you receive a URL for a Stripe callback.
+ * For convenience, you can pass all URLs you receive to this method first, and
+ * check the return value to easily determine whether it is a callback URL that Stripe will handle
+ * or if your app should process it normally. This is iOS-only, and will always return false on Android.
+ */
 export const handleURLCallback = async (url: string): Promise<boolean> => {
   const stripeHandled =
     Platform.OS === 'ios'


### PR DESCRIPTION
## Summary

Only calls native method if we're on iOS

## Motivation

This only applies to iOS
