### PR TITLE
Stripe React Native Release v0.29.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.29.0 - 2023-07-13
+
 ### Breaking changes
 
 - The Apple Pay and Google Pay APIs, which are deprecated and were replaced with the [Platform Pay API](https://github.com/stripe/stripe-react-native/blob/master/docs/Platform-Pay-Migration.md) last year, have been removed. [#1424](https://github.com/stripe/stripe-react-native/pull/1424)


### PR DESCRIPTION

- [X] Ensure the CHANGELOG is up to date with all relevant commits since the last release
- [X] Add the version number for this release & the date to the CHANGELOG, underneath "## Unreleased" 
  - e.g. "## 1.2.3 - 2022-02-14"
- [X] Update the README if necessary (this is only required when there are breaking changes in the release, such as dropping support for an iOS || Android version)