### PR TITLE
fix: return both last four types from google tokenized cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+**Features**
+
+- `canAddCardToWallet` now returns the `fpanLastFour` and `dpanLastFour` in the `GooglePayCardToken` type. The `cardLastFour` field (which is now superseded by `fpanLastFour`) is deprecated.
+
 **Fixes**
 
 - Fixed an error on Android where `AddressSheet` would throw an error if submitted with the keyboard open. [#1462](https://github.com/stripe/stripe-react-native/pull/1462)

--- a/android/src/main/java/com/reactnativestripesdk/pushprovisioning/TapAndPayProxy.kt
+++ b/android/src/main/java/com/reactnativestripesdk/pushprovisioning/TapAndPayProxy.kt
@@ -91,9 +91,16 @@ object TapAndPayProxy {
         result.putString(
           "id",
           tokenInfoClass.getMethod("getIssuerTokenId").invoke(it) as String)
+        val fpan = tokenInfoClass.getMethod("getFpanLastFour").invoke(it) as String
         result.putString(
           "cardLastFour",
-          tokenInfoClass.getMethod("getFpanLastFour").invoke(it) as String)
+          fpan)
+        result.putString(
+          "fpanLastFour",
+          fpan)
+        result.putString(
+          "dpanLastFour",
+          tokenInfoClass.getMethod("getDpanLastFour").invoke(it) as String)
         result.putString(
           "issuer",
           tokenInfoClass.getMethod("getIssuerName").invoke(it) as String)

--- a/src/types/PushProvisioning.ts
+++ b/src/types/PushProvisioning.ts
@@ -1,12 +1,20 @@
 import type { StripeError, GooglePayError } from './Errors';
 
 export type GooglePayCardToken = {
+  /** The token reference ID. */
   id: string;
-  cardLastFour: string;
+  /** Last four digits of the FPAN */
+  fpanLastFour: string;
+  /** Last four digits of the DPAN */
+  dpanLastFour: string;
   network: number;
   serviceProvider: number;
+  /** The name of the issuer. */
   issuer: string;
+  /** The GooglePayCardTokenStatus. */
   status: GooglePayCardTokenStatus;
+  /** Deprecated. Use fpanLastFour or dpanLastFour. */
+  cardLastFour: string;
 };
 
 export enum GooglePayCardTokenStatus {


### PR DESCRIPTION
fixes https://github.com/stripe/stripe-react-native/issues/1453

`canAddCardToWallet` now returns the `fpanLastFour` and `dpanLastFour` in the `GooglePayCardToken` type. The `cardLastFour` field (which is now superseded by `fpanLastFour`) is deprecated.