### PR TITLE
feat: allow ApplePayButtonNative usage with RN `onPress` opacity only

### DIFF
--- a/example/src/screens/ApplePayScreen.tsx
+++ b/example/src/screens/ApplePayScreen.tsx
@@ -333,6 +333,7 @@ export default function ApplePayScreen() {
           appearance={PlatformPay.ButtonStyle.WhiteOutline}
           borderRadius={4}
           disabled={!isApplePaySupported}
+          disabledNativeOnPressOpacity={true}
           style={styles.createPaymentMethodButton}
           onCouponCodeEntered={couponCodeListener}
           onShippingContactSelected={({ shippingContact }) => {

--- a/src/components/PlatformPayButton.tsx
+++ b/src/components/PlatformPayButton.tsx
@@ -32,6 +32,8 @@ export interface Props extends AccessibilityProps {
   onPress(): void;
   /** Set to `true` to disable the button from being pressed & apply a slight opacity to indicate that it is unpressable. Defaults to false. */
   disabled?: boolean;
+  /** Set to `true` to disable the native onPress opacity and use opacity from RN TouchableOpacity only. Defaults to false. */
+  disabledNativeOnPressOpacity?: boolean;
   /**
    * This callback is triggered whenever the user selects a shipping method in the Apple Pay sheet.
    * It receives one parameter: an `event` object with a `shippingMethod` field. You MUST
@@ -97,6 +99,7 @@ export function PlatformPayButton({
   appearance = ButtonStyle.Automatic,
   onPress,
   disabled,
+  disabledNativeOnPressOpacity,
   borderRadius,
   onShippingMethodSelected,
   onShippingContactSelected,
@@ -144,7 +147,6 @@ export function PlatformPayButton({
   return (
     <TouchableOpacity
       disabled={disabled}
-      activeOpacity={disabled ? 0.3 : 1}
       onPress={onPress}
       style={[disabled ? styles.disabled : styles.notDisabled, style]}
     >
@@ -153,7 +155,7 @@ export function PlatformPayButton({
           type={type}
           buttonStyle={appearance}
           borderRadius={borderRadius}
-          disabled={disabled}
+          disabled={disabledNativeOnPressOpacity}
           onShippingMethodSelectedAction={shippingMethodCallback}
           onShippingContactSelectedAction={shippingContactCallback}
           onCouponCodeEnteredAction={couponCodeCallback}


### PR DESCRIPTION
## Summary
Allow dev to use `PlatformPayButton` with opacity from RN TouchableOpacity and not from the native Apple Pay button.

## Motivation
The native opacity from Apple Pay button is not pretty.

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [X] I tested this manually
- [ ] I added automated tests

## Documentation

Select one: 
- [X] I have added relevant documentation for my changes.
- [X] This PR does not result in any developer-facing changes.

fixes: https://github.com/stripe/stripe-react-native/issues/1484
