### PR TITLE
Update example app to use two activities

### DIFF
--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -15,6 +15,13 @@
       <meta-data
         android:name="com.google.android.gms.wallet.api.enabled"
         android:value="true" />
+      <activity android:name=".LaunchActivity" android:exported="true">
+        <intent-filter>
+          <action android:name="android.intent.action.MAIN" />
+          <category android:name="android.intent.category.LAUNCHER" />
+        </intent-filter>
+      </activity>
+
       <activity
         android:name=".MainActivity"
         android:label="@string/app_name"
@@ -22,11 +29,6 @@
         android:launchMode="singleTask"
         android:windowSoftInputMode="adjustResize"
         android:exported="true">
-        <intent-filter>
-            <action android:name="android.intent.action.MAIN" />
-            <category android:name="android.intent.category.LAUNCHER" />
-        </intent-filter>
-
         <intent-filter>
           <action android:name="android.intent.action.VIEW" />
           <category android:name="android.intent.category.DEFAULT" />

--- a/example/android/app/src/main/java/com/example/reactnativestripesdk/LaunchActivity.java
+++ b/example/android/app/src/main/java/com/example/reactnativestripesdk/LaunchActivity.java
@@ -1,0 +1,20 @@
+package com.example.reactnativestripesdk;
+
+import android.os.Bundle;
+import android.app.Activity;
+import android.content.Intent;
+
+public class LaunchActivity extends Activity {
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    MainApplication application = (MainApplication) getApplication();
+    // check that MainActivity is not started yet
+    if (!application.isActivityInBackStack(MainActivity.class)) {
+      Intent intent = new Intent(this, MainActivity.class);
+      startActivity(intent);
+    }
+    finish();
+  }
+}

--- a/example/android/app/src/main/java/com/example/reactnativestripesdk/MainActivity.java
+++ b/example/android/app/src/main/java/com/example/reactnativestripesdk/MainActivity.java
@@ -15,6 +15,18 @@ public class MainActivity extends ReactActivity {
     return "main";
   }
 
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    ((MainApplication) getApplication()).addActivityToStack(this.getClass());
+  }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    ((MainApplication) getApplication()).removeActivityFromStack(this.getClass());
+  }
+
   /**
    * Returns the instance of the {@link ReactActivityDelegate}. There the RootView is created and
    * you can specify the rendered you wish to use (Fabric or the older renderer).

--- a/example/android/app/src/main/java/com/example/reactnativestripesdk/MainApplication.java
+++ b/example/android/app/src/main/java/com/example/reactnativestripesdk/MainApplication.java
@@ -12,6 +12,7 @@ import com.facebook.soloader.SoLoader;
 import com.example.reactnativestripesdk.newarchitecture.MainApplicationReactNativeHost;
 import java.lang.reflect.InvocationTargetException;
 import java.util.List;
+import java.util.ArrayList;
 import com.reactnativestripesdk.StripeSdkPackage;
 
 public class MainApplication extends Application implements ReactApplication {
@@ -58,6 +59,20 @@ public class MainApplication extends Application implements ReactApplication {
     ReactFeatureFlags.useTurboModules = BuildConfig.IS_NEW_ARCHITECTURE_ENABLED;
     SoLoader.init(this, /* native exopackage */ false);
     initializeFlipper(this, getReactNativeHost().getReactInstanceManager()); // Remove this line if you don't want Flipper enabled
+  }
+
+  private ArrayList<Class> runningActivities = new ArrayList<>();
+
+  public void addActivityToStack (Class cls) {
+    if (!runningActivities.contains(cls)) runningActivities.add(cls);
+  }
+
+  public void removeActivityFromStack (Class cls) {
+    if (runningActivities.contains(cls)) runningActivities.remove(cls);
+  }
+
+  public boolean isActivityInBackStack (Class cls) {
+    return runningActivities.contains(cls);
   }
 
   /**


### PR DESCRIPTION
Using singleTask in an Android application for the activity that has an intent-filter on the LAUNCHER, means that any activities running on top of this activity will disappear when the app's icon is pressed again from the launcher.

This is a problem, because when confirming a SetupIntent or PaymentIntent, Stripe may need to present a web browser (its own activity) for verification with a customer's bank or similar, and the user may even need to leave this web browser activity temporarily to navigate to their bank's own application. If the user is not careful when navigating back to the original app, and taps the app's icon from the launcher, the app will open to its original activity, and the web browser is gone. Instead, the user will need to navigate back only using Android's app switcher, which will correctly bring you back into the open web browser activity.

The change in this commit side-steps this issue by splitting the example application into two acitivites. One that is only responsible for launching the application, and a second activity that actually represents the react native application, and will be started by the first activity, ensuring to only start it once.

This fixes #355.

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [ ] I tested this manually
- [ ] I added automated tests

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
