### PR TITLE
[ios] add support for removeSavedPaymentMethodMessage for payment sheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ## Unreleased
 
-## 0.31.0 - 2023-09-08
+**Features**
+
+- [PaymentSheet] Added the `removeSavedPaymentMethodMessage` field to `initPaymentSheet` to display a custom message when a saved payment method is removed. iOS Only. [#1498](https://github.com/stripe/stripe-react-native/pull/1498)
+
+## 0.31.1 - 2023-09-08
 
 **Features**
 

--- a/example/src/screens/PaymentsUICompleteScreen.tsx
+++ b/example/src/screens/PaymentsUICompleteScreen.tsx
@@ -110,6 +110,7 @@ export default function PaymentsUICompleteScreen() {
       allowsDelayedPaymentMethods: true,
       appearance,
       primaryButtonLabel: 'purchase!',
+      removeSavedPaymentMethodMessage: 'remove this payment method?',
     });
     if (!error) {
       setPaymentSheetEnabled(true);

--- a/ios/StripeSdk+PaymentSheet.swift
+++ b/ios/StripeSdk+PaymentSheet.swift
@@ -50,6 +50,10 @@ extension StripeSdk {
             configuration.allowsDelayedPaymentMethods = allowsDelayedPaymentMethods
         }
         
+        if let removeSavedPaymentMethodMessage = params["removeSavedPaymentMethodMessage"] as? String {
+            configuration.removeSavedPaymentMethodMessage = removeSavedPaymentMethodMessage
+        }
+        
         if let billingConfigParams = params["billingDetailsCollectionConfiguration"] as? [String: Any?] {
             configuration.billingDetailsCollectionConfiguration.name = StripeSdk.mapToCollectionMode(str: billingConfigParams["name"] as? String)
             configuration.billingDetailsCollectionConfiguration.phone = StripeSdk.mapToCollectionMode(str: billingConfigParams["phone"] as? String)

--- a/src/types/PaymentSheet.ts
+++ b/src/types/PaymentSheet.ts
@@ -50,6 +50,8 @@ export type SetupParams = IntentParams & {
   appearance?: AppearanceParams;
   /** The label to use for the primary button. If not set, Payment Sheet will display suitable default labels for payment and setup intents. */
   primaryButtonLabel?: string;
+  /** Optional configuration to display a custom message when a saved payment method is removed. iOS only. */
+  removeSavedPaymentMethodMessage?: string;
 };
 
 export type IntentParams =


### PR DESCRIPTION
## Summary

 Optional configuration to display a custom message when a saved payment method is removed. iOS only.


## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one: 
- [x] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
