### PR TITLE
breaking: remove Constants.API_VERSION.ISSUING in favor of getIssuingApiVersion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+**Breaking changes**
+
+- `Constants.API_VERSIONS.ISSUING` has been removed, please use the asynchronous `getIssuingApiVersion` method instead. This should improve app startup time.
+
 **Features**
 
 - `createPlatformPayPaymentMethod` and `createPlatformPayToken` now also include an optional `shippingContact` field in their results. [#1500](https://github.com/stripe/stripe-react-native/pull/1500)

--- a/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
+++ b/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
@@ -126,9 +126,15 @@ class StripeSdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJ
     hashMapOf(
       "API_VERSIONS" to hashMapOf(
         "CORE" to ApiVersion.API_VERSION_CODE,
-        "ISSUING" to PushProvisioningProxy.getApiVersion(),
       )
     )
+
+  @ReactMethod
+  fun getIssuingApiVersion(promise: Promise) {
+    promise.resolve(
+      PushProvisioningProxy.getApiVersion()
+    )
+  }
 
   @ReactMethod
   fun initialise(params: ReadableMap, promise: Promise) {

--- a/example/src/screens/ApplePayScreen.tsx
+++ b/example/src/screens/ApplePayScreen.tsx
@@ -3,7 +3,7 @@ import { Alert, StyleSheet, Text, View } from 'react-native';
 import {
   PlatformPay,
   AddToWalletButton,
-  Constants,
+  getIssuingApiVersion,
   canAddCardToWallet,
   PlatformPayButton,
   usePlatformPay,
@@ -194,13 +194,14 @@ export default function ApplePayScreen() {
   };
 
   const fetchEphemeralKey = async () => {
+    const issuingApiVersion = await getIssuingApiVersion();
     const response = await fetch(`${API_URL}/ephemeral-key`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({
-        apiVersion: Constants.API_VERSIONS.ISSUING,
+        apiVersion: issuingApiVersion,
         issuingCardId: TEST_CARD_ID,
       }),
     });

--- a/example/src/screens/GooglePayScreen.tsx
+++ b/example/src/screens/GooglePayScreen.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import {
   AddToWalletButton,
-  Constants,
   canAddCardToWallet,
   createPlatformPayPaymentMethod,
   createPlatformPayToken,
@@ -10,6 +9,7 @@ import {
   isPlatformPaySupported,
   PlatformPay,
   PlatformPayButton,
+  getIssuingApiVersion,
 } from '@stripe/stripe-react-native';
 import PaymentScreen from '../components/PaymentScreen';
 import { API_URL } from '../Config';
@@ -183,13 +183,14 @@ export default function GooglePayScreen() {
   };
 
   const fetchEphemeralKey = async () => {
+    const issuingApiVersion = await getIssuingApiVersion();
     const response = await fetch(`${API_URL}/ephemeral-key`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({
-        apiVersion: Constants.API_VERSIONS.ISSUING,
+        apiVersion: issuingApiVersion,
         issuingCardId: LIVE_CARD_ID,
       }),
     });

--- a/ios/StripeSdk.m
+++ b/ios/StripeSdk.m
@@ -164,6 +164,10 @@ RCT_EXTERN_METHOD(
                   rejecter: (RCTPromiseRejectBlock)reject
                   )
 RCT_EXTERN_METHOD(
+                  getIssuingApiVersion:(RCTPromiseResolveBlock)resolve
+                  rejecter: (RCTPromiseRejectBlock)reject
+                  )
+RCT_EXTERN_METHOD(
                   isCardInWallet:(NSDictionary *)params
                   resolver: (RCTPromiseResolveBlock)resolve
                   rejecter: (RCTPromiseRejectBlock)reject

--- a/ios/StripeSdk.swift
+++ b/ios/StripeSdk.swift
@@ -81,9 +81,13 @@ class StripeSdk: RCTEventEmitter, STPBankSelectionViewControllerDelegate, UIAdap
         return [
             "API_VERSIONS": [
                 "CORE": STPAPIClient.apiVersion,
-                "ISSUING": STPAPIClient.apiVersion,
             ]
         ]
+    }
+    
+    @objc(getIssuingApiVersion:rejecter:)
+    func getIssuingApiVersion(resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) -> Void {
+        resolve(STPAPIClient.apiVersion)
     }
 
     @objc(initialise:resolver:rejecter:)

--- a/jest/mock.js
+++ b/jest/mock.js
@@ -108,6 +108,7 @@ const mockFunctions = {
     details: null,
     error: null,
   })),
+  getIssuingApiVersion: jest.fn(async () => ''),
   isCardInWallet: jest.fn(async () => ({
     isInWallet: false,
     token: {},

--- a/src/NativeStripeSdk.tsx
+++ b/src/NativeStripeSdk.tsx
@@ -86,10 +86,11 @@ type NativeStripeSdkType = {
     clientSecret: string,
     params: PaymentMethod.CollectBankAccountParams
   ): Promise<ConfirmSetupIntentResult | ConfirmPaymentResult>;
-  getConstants(): { API_VERSIONS: { CORE: string; ISSUING: string } };
+  getConstants(): { API_VERSIONS: { CORE: string } };
   canAddCardToWallet(
     params: CanAddCardToWalletParams
   ): Promise<CanAddCardToWalletResult>;
+  getIssuingApiVersion(): Promise<string>;
   isCardInWallet(params: {
     cardLastFour: string;
   }): Promise<IsCardInWalletResult>;

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -602,6 +602,15 @@ export const canAddCardToWallet = async (
   }
 };
 
+/**
+ * Get the supported Stripe API version for usage on your server with Issuing-related API calls.
+ * @returns A string representing the supported API version, or an empty string if
+ * the required push provisioning dependencies are not found.
+ */
+export const getIssuingApiVersion = async (): Promise<string> => {
+  return await NativeStripeSdk.getIssuingApiVersion();
+};
+
 /** @deprecated Please use `canAddCardToWallet` instead. */
 export const isCardInWallet = async (params: {
   cardLastFour: string;

--- a/src/hooks/usePlatformPay.tsx
+++ b/src/hooks/usePlatformPay.tsx
@@ -19,6 +19,7 @@ export function usePlatformPay() {
     dismissPlatformPay,
     updatePlatformPaySheet,
     canAddCardToWallet,
+    getIssuingApiVersion,
     openPlatformPaySetup,
   } = useStripe();
   const [loading, setLoading] = useState(false);
@@ -124,6 +125,15 @@ export function usePlatformPay() {
     [canAddCardToWallet]
   );
 
+  const _getIssuingApiVersion = useCallback(async (): Promise<string> => {
+    setLoading(true);
+
+    const result = await getIssuingApiVersion();
+    setLoading(false);
+
+    return result;
+  }, [getIssuingApiVersion]);
+
   const _openPlatformPaySetup = useCallback(async (): Promise<void> => {
     return openPlatformPaySetup();
   }, [openPlatformPaySetup]);
@@ -183,6 +193,12 @@ export function usePlatformPay() {
      * @returns A promise resolving to an object of type CanAddCardToWalletResult. Check the `canAddCard` field, if it's true, you should show the `<AddToWalletButton />`
      */
     canAddCardToWallet: _canAddCardToWallet,
+    /**
+     * Get the supported Stripe API version for usage on your server with Issuing-related API calls.
+     * @returns A string representing the supported API version, or an empty string if
+     * the required push provisioning dependencies are not found.
+     */
+    getIssuingApiVersion: _getIssuingApiVersion,
     /**
      * iOS only, this is a no-op on Android. Use this method to move users to the interface for adding credit cards.
      * This method transfers control to the Wallet app on iPhone or to the Settings

--- a/src/hooks/useStripe.tsx
+++ b/src/hooks/useStripe.tsx
@@ -48,6 +48,7 @@ import {
   verifyMicrodepositsForPayment,
   verifyMicrodepositsForSetup,
   canAddCardToWallet,
+  getIssuingApiVersion,
   collectBankAccountToken,
   collectFinancialConnectionsAccounts,
   resetPaymentSheetCustomer,
@@ -224,6 +225,10 @@ export function useStripe() {
     []
   );
 
+  const _getIssuingApiVersion = useCallback(async (): Promise<string> => {
+    return getIssuingApiVersion();
+  }, []);
+
   const _collectBankAccountToken = useCallback(
     async (clientSecret: string): Promise<FinancialConnections.TokenResult> => {
       return collectBankAccountToken(clientSecret);
@@ -333,6 +338,7 @@ export function useStripe() {
     verifyMicrodepositsForPayment: _verifyMicrodepositsForPayment,
     verifyMicrodepositsForSetup: _verifyMicrodepositsForSetup,
     canAddCardToWallet: _canAddCardToWallet,
+    getIssuingApiVersion: _getIssuingApiVersion,
     collectBankAccountToken: _collectBankAccountToken,
     collectFinancialConnectionsAccounts: _collectFinancialConnectionsAccounts,
     /**


### PR DESCRIPTION


## Summary
fixes https://github.com/stripe/stripe-react-native/issues/1477
## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
