### PR TITLE
fix: remove kotlin forEach call

### DIFF
--- a/android/src/main/java/com/reactnativestripesdk/utils/Mappers.kt
+++ b/android/src/main/java/com/reactnativestripesdk/utils/Mappers.kt
@@ -807,11 +807,8 @@ internal fun mapFromSetupIntentResult(setupIntent: SetupIntent): WritableMap {
     map.putMap("lastSetupError", setupError)
   }
 
-  setupIntent.paymentMethodTypes.forEach { code ->
-    val type: PaymentMethod.Type? = PaymentMethod.Type.values().find {
-      code == it.code
-    }
-    type?.let {
+  for (code in setupIntent.paymentMethodTypes) {
+    PaymentMethod.Type.fromCode(code)?.let {
       paymentMethodTypes.pushString(mapPaymentMethodType(it))
     }
   }


### PR DESCRIPTION
## Summary

Some combinations of gradle/kotlin end up erroneously throwing a lint error saying this requires a higher minimum API level, so best to just rely on a for loop instead

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
