### PR TITLE
fix: include payment method in return from confirmPlatformPayPayment/confirmPlatformPaySetupIntent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@
   - PayNow
   - PromptPay
 
+**Fixes**
+
+- Fixed an issue on iOS where the value for the `paymentMethod` field on the returned `paymentIntent` object from `confirmPlatformPayPayment` and the returned `setupIntent` object from `confirmPlatformPaySetupIntent` would be null.
+
 ## 0.32.0 - 2023-09-15
 
 **Features**

--- a/ios/ApplePayViewController.swift
+++ b/ios/ApplePayViewController.swift
@@ -165,6 +165,7 @@ extension StripeSdk : PKPaymentAuthorizationViewControllerDelegate, STPApplePayC
         paymentInformation: PKPayment,
         completion: @escaping STPIntentClientSecretCompletionBlock
     ) {
+        self.confirmApplePayPaymentMethod = paymentMethod
         if let clientSecret = self.confirmApplePayPaymentClientSecret {
             completion(clientSecret, nil)
         } else if let clientSecret = self.confirmApplePaySetupClientSecret {
@@ -207,10 +208,15 @@ extension StripeSdk : PKPaymentAuthorizationViewControllerDelegate, STPApplePayC
                         }
 
                         if let paymentIntent = paymentIntent {
-                            resolve(Mappers.createResult("paymentIntent", Mappers.mapFromPaymentIntent(paymentIntent: paymentIntent)))
+                            let result = Mappers.mapFromPaymentIntent(paymentIntent: paymentIntent)
+                            if (paymentIntent.paymentMethod == nil) {
+                                result.setValue(Mappers.mapFromPaymentMethod(self.confirmApplePayPaymentMethod), forKey: "paymentMethod")
+                            }
+                            resolve(Mappers.createResult("paymentIntent", result))
                         } else {
                             resolve(Mappers.createResult("paymentIntent", nil))
                         }
+                        self.confirmApplePayPaymentMethod = nil
                     }
                 } else if let clientSecret = self.confirmApplePaySetupClientSecret {
                     STPAPIClient.shared.retrieveSetupIntent(withClientSecret: clientSecret) { (setupIntent, error) in
@@ -224,10 +230,15 @@ extension StripeSdk : PKPaymentAuthorizationViewControllerDelegate, STPApplePayC
                         }
 
                         if let setupIntent = setupIntent {
-                            resolve(Mappers.createResult("setupIntent", Mappers.mapFromSetupIntent(setupIntent: setupIntent)))
+                            let result = Mappers.mapFromSetupIntent(setupIntent: setupIntent)
+                            if (setupIntent.paymentMethod == nil) {
+                                result.setValue(Mappers.mapFromPaymentMethod(self.confirmApplePayPaymentMethod), forKey: "paymentMethod")
+                            }
+                            resolve(Mappers.createResult("setupIntent", result))
                         } else {
                             resolve(Mappers.createResult("setupIntent", nil))
                         }
+                        self.confirmApplePayPaymentMethod = nil
                     }
                 }
             }

--- a/ios/StripeSdk.swift
+++ b/ios/StripeSdk.swift
@@ -22,6 +22,7 @@ class StripeSdk: RCTEventEmitter, STPBankSelectionViewControllerDelegate, UIAdap
     var confirmApplePayResolver: RCTPromiseResolveBlock? = nil
     var confirmApplePayPaymentClientSecret: String? = nil
     var confirmApplePaySetupClientSecret: String? = nil
+    var confirmApplePayPaymentMethod: STPPaymentMethod? = nil
     
     var applePaymentAuthorizationController: PKPaymentAuthorizationViewController? = nil
     var createPlatformPayPaymentMethodResolver: RCTPromiseResolveBlock? = nil


### PR DESCRIPTION


## Summary

This is `null` from stripe-ios, so we need to intercept the value earlier and save it, then set the key/value pair manually before resolving the promise

## Motivation
fixes https://github.com/stripe/stripe-react-native/issues/1499

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
