### PR TITLE
fix: prevent null in street name

### DIFF
--- a/android/src/main/java/com/reactnativestripesdk/utils/Mappers.kt
+++ b/android/src/main/java/com/reactnativestripesdk/utils/Mappers.kt
@@ -904,7 +904,12 @@ internal fun mapFromShippingContact(googlePayResult: GooglePayResult): WritableM
   postalAddress.putString("country", googlePayResult.shippingInformation?.address?.country)
   postalAddress.putString("postalCode", googlePayResult.shippingInformation?.address?.postalCode)
   postalAddress.putString("state", googlePayResult.shippingInformation?.address?.state)
-  postalAddress.putString("street", googlePayResult.shippingInformation?.address?.line1 + "\n" + googlePayResult.shippingInformation?.address?.line2)
+  val line1: String? = googlePayResult.shippingInformation?.address?.line1
+  val line2: String? = googlePayResult.shippingInformation?.address?.line2
+  val street =
+    (if (line1 != null) "$line1" else "") +
+    (if (line2 != null) "\n$line2" else "")
+  postalAddress.putString("street", street)
   postalAddress.putString("isoCountryCode", googlePayResult.shippingInformation?.address?.country)
   map.putMap("postalAddress", postalAddress)
   return map


### PR DESCRIPTION
## Summary
Handle case where `line2` is null to not display `null` during the concatenation.

There are many cases to do this in Kotlin, let me know if you prefer something else ;)

## Motivation
I want to get a street address with the right formatting.

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [X] I tested this manually
- [ ] I added automated tests

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.

fixes: https://github.com/stripe/stripe-react-native/issues/1520
