### PR TITLE
Fix crash when starting up Google Pay

### DIFF
--- a/android/src/main/java/com/reactnativestripesdk/GooglePayLauncherFragment.kt
+++ b/android/src/main/java/com/reactnativestripesdk/GooglePayLauncherFragment.kt
@@ -49,7 +49,7 @@ class GooglePayLauncherFragment : Fragment() {
     this.mode = mode
     this.callback = callback
     this.currencyCode = googlePayParams.getString("currencyCode") ?: "USD"
-    this.amount = googlePayParams.getInt("amount")
+    this.amount = getIntOrNull(googlePayParams, "amount")
     this.label = googlePayParams.getString("label")
     this.configuration = GooglePayLauncher.Config(
       environment = if (googlePayParams.getBoolean("testEnv")) GooglePayEnvironment.Test else GooglePayEnvironment.Production,

--- a/src/types/PlatformPay.ts
+++ b/src/types/PlatformPay.ts
@@ -195,7 +195,7 @@ export type GooglePayBaseParams = {
   };
   /** An optional label to display with the amount. Google Pay may or may not display this label depending on its own internal logic. Defaults to a generic label if none is provided. */
   label?: string;
-  /** An optional amount to display for setup intents. Google Pay may or may not display this amount depending on its own internal logic. Defaults to 0 if none is provided. */
+  /** An optional amount to display for setup intents. Google Pay may or may not display this amount depending on its own internal logic. Defaults to 0 if none is provided. Provide this value in the currency’s smallest unit. */
   amount?: number;
 };
 


### PR DESCRIPTION
## Summary

For some reason React Native crashes when calling `getInt` if the key doesn't exist (but not when calling `get` on the rest of the types)

## Motivation

fixes https://github.com/stripe/stripe-react-native/issues/1436#issuecomment-1740487382

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
