### PR TITLE
Update build.gradle with namespace

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,6 +27,11 @@ def getExtOrIntegerDefault(name) {
 }
 
 android {
+  def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
+  if (agpVersion.tokenize('.')[0].toInteger() >= 7) {
+    namespace "com.reactnativestripesdk"
+  }
+  
   compileSdkVersion getExtOrIntegerDefault('compileSdkVersion')
   defaultConfig {
     minSdkVersion 21


### PR DESCRIPTION
This commit adds support for RN 0.73 android builds

## Summary
Add namespace to android section of build.gradle, this is a requirement for Gradle 8 which is the default for RN 0.73+. It's wrapped in a version check for backwards compatability.

## Motivation
Android won't build without it

## Testing
- [ x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [ x] This PR does not result in any developer-facing changes.
