### PR TITLE
test: fix mock for useStripe

### DIFF
--- a/jest/mock.js
+++ b/jest/mock.js
@@ -186,5 +186,5 @@ module.exports = {
   GooglePayButton: () => 'GooglePayButton',
   AddToWalletButton: () => 'AddToWalletButton',
   PlatformPayButton: () => 'PlatformPayButton',
-  useStripe: jest.fn(() => mockHooks),
+  useStripe: jest.fn(() => mockFunctions),
 };


### PR DESCRIPTION
## Summary

change `useStripe` mock to return functions rather than other hooks

## Motivation

My unit test failed on the mock provided from this repo.

In reality `useStripe` doesn't return 100% all functions listed in the `mockFunctions` object, but using a superset for the mock should still be fine as TS won't allow calling the functions which are not in the declared in the return value type of `useStripe`. Returning hooks definitely is not what happens in `useStripe`.

## Testing
- [x] I tested this manually
- [ ] I added automated tests 

No need for automated tests

## Documentation

- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
