### PR TITLE
fix: RN 73 compatibility

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,6 +27,10 @@ def getExtOrIntegerDefault(name) {
 }
 
 android {
+  def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
+  if (agpVersion.tokenize('.')[0].toInteger() >= 7) {
+    namespace "com.stripe.reactnative"
+  }
   compileSdkVersion getExtOrIntegerDefault('compileSdkVersion')
   defaultConfig {
     minSdkVersion 21

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -28,7 +28,7 @@ def getExtOrIntegerDefault(name) {
 
 android {
   def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
-  if (agpVersion.tokenize('.')[0].toInteger() >= 7) {
+  if (agpVersion.tokenize('.')[0].toInteger() >= 8) {
     namespace "com.stripe.reactnative"
   }
   compileSdkVersion getExtOrIntegerDefault('compileSdkVersion')

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,3 +1,2 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.reactnativestripesdk">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 </manifest>


### PR DESCRIPTION
## Summary
Add new mandatory `android.namespace` config.

## Motivation
https://github.com/react-native-community/discussions-and-proposals/issues/671

## Testing
App builds with RN 73 and AGP 8

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
