### PR TITLE
Add link to Expo dependency definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ npm install @stripe/stripe-react-native
 
 > [Find Expo's full documentation here](https://docs.expo.io/versions/latest/sdk/stripe/).
 
-Each Expo SDK version requires a specific `stripe-react-native` version. See the [CHANGELOG](./CHANGELOG.md) for a mapping of versions. To install the correct version for your Expo SDK version run:
+Each Expo SDK version requires a specific `stripe-react-native` version, as specified in `bundledNativeModules.json` [here](https://github.com/expo/expo/blob/main/packages/expo/bundledNativeModules.json). See the [CHANGELOG](./CHANGELOG.md) for a mapping of versions. To install the correct version for your Expo SDK version run:
 
 ```sh
 expo install @stripe/stripe-react-native


### PR DESCRIPTION


## Summary
Add direct link to Expo's `bundledNativeModules.json` to determine specific SRN version in README's Expo section. See version for individual Expo versions by switching branch/tags.

## Motivation
Avoid having to re-search and find `bundledNativeModules.json` each time a feature/version dependency question comes up.

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [ ] I tested this manually
- [ ] I added automated tests

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
