### PR TITLE
breaking change: upgrade native libraries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+**Breaking changes**
+
+- Your `compileSdkVersion` (in `android/build.gradle`) now must be at least 34. Changing your `compileSdkVersion` does not change runtime behavior.
+
+**Fixes**
+
+- Fixed an issue on Android where the SDK was unable to follow URL redirects in some cases.
+- Fixed an issue on Android where Google Pay & Link were not saved as default payment methods in PaymentSheet.
+
 ## 0.36.0 - 2024-02-02
 
 **Features**

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ to your `app.json` file, where `merchantIdentifier` is the Apple merchant ID obt
 #### Android
 
 - Android 5.0 (API level 21) and above
-  - Your `compileSdkVersion` must be `33`. See [this issue](https://github.com/stripe/stripe-react-native/issues/812) for potential workarounds.
+  - Your `compileSdkVersion` must be `34`. See [this issue](https://github.com/stripe/stripe-react-native/issues/812) for potential workarounds.
 - Android gradle plugin 4.x and above
 
 _Components_
@@ -198,7 +198,7 @@ function App() {
     initStripe({
       publishableKey: publishableKey,
       merchantIdentifier: 'merchant.identifier',
-      urlScheme: "your-url-scheme",
+      urlScheme: 'your-url-scheme',
     });
   }, []);
 }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,3 +1,3 @@
 StripeSdk_kotlinVersion=1.8.0
 # Keep StripeSdk_stripeVersion in sync with https://github.com/stripe/stripe-identity-react-native/blob/main/android/gradle.properties
-StripeSdk_stripeVersion=20.36.+
+StripeSdk_stripeVersion=20.37.+

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     ext {
         buildToolsVersion = "30.0.3"
         minSdkVersion = 21
-        compileSdkVersion = 33
+        compileSdkVersion = 34
         targetSdkVersion = 31
         if (System.properties['os.arch'] == "aarch64") {
             // For M1 Users we need to use the NDK 24 which added support for aarch64

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -360,54 +360,54 @@ PODS:
     - React-Core
   - RNCPicker (2.4.8):
     - React-Core
-  - RNScreens (3.18.2):
+  - RNScreens (3.29.0):
     - React-Core
     - React-RCTImage
   - SocketRocket (0.6.0)
-  - Stripe (23.21.1):
-    - StripeApplePay (= 23.21.1)
-    - StripeCore (= 23.21.1)
-    - StripePayments (= 23.21.1)
-    - StripePaymentsUI (= 23.21.1)
-    - StripeUICore (= 23.21.1)
-  - stripe-react-native (0.35.1):
+  - Stripe (23.22.0):
+    - StripeApplePay (= 23.22.0)
+    - StripeCore (= 23.22.0)
+    - StripePayments (= 23.22.0)
+    - StripePaymentsUI (= 23.22.0)
+    - StripeUICore (= 23.22.0)
+  - stripe-react-native (0.36.0):
     - React-Core
-    - Stripe (~> 23.21.0)
-    - StripeApplePay (~> 23.21.0)
-    - StripeFinancialConnections (~> 23.21.0)
-    - StripePayments (~> 23.21.0)
-    - StripePaymentSheet (~> 23.21.0)
-    - StripePaymentsUI (~> 23.21.0)
-  - stripe-react-native/Tests (0.35.1):
+    - Stripe (~> 23.22.0)
+    - StripeApplePay (~> 23.22.0)
+    - StripeFinancialConnections (~> 23.22.0)
+    - StripePayments (~> 23.22.0)
+    - StripePaymentSheet (~> 23.22.0)
+    - StripePaymentsUI (~> 23.22.0)
+  - stripe-react-native/Tests (0.36.0):
     - React-Core
-    - Stripe (~> 23.21.0)
-    - StripeApplePay (~> 23.21.0)
-    - StripeFinancialConnections (~> 23.21.0)
-    - StripePayments (~> 23.21.0)
-    - StripePaymentSheet (~> 23.21.0)
-    - StripePaymentsUI (~> 23.21.0)
-  - StripeApplePay (23.21.1):
-    - StripeCore (= 23.21.1)
-  - StripeCore (23.21.1)
-  - StripeFinancialConnections (23.21.1):
-    - StripeCore (= 23.21.1)
-    - StripeUICore (= 23.21.1)
-  - StripePayments (23.21.1):
-    - StripeCore (= 23.21.1)
-    - StripePayments/Stripe3DS2 (= 23.21.1)
-  - StripePayments/Stripe3DS2 (23.21.1):
-    - StripeCore (= 23.21.1)
-  - StripePaymentSheet (23.21.1):
-    - StripeApplePay (= 23.21.1)
-    - StripeCore (= 23.21.1)
-    - StripePayments (= 23.21.1)
-    - StripePaymentsUI (= 23.21.1)
-  - StripePaymentsUI (23.21.1):
-    - StripeCore (= 23.21.1)
-    - StripePayments (= 23.21.1)
-    - StripeUICore (= 23.21.1)
-  - StripeUICore (23.21.1):
-    - StripeCore (= 23.21.1)
+    - Stripe (~> 23.22.0)
+    - StripeApplePay (~> 23.22.0)
+    - StripeFinancialConnections (~> 23.22.0)
+    - StripePayments (~> 23.22.0)
+    - StripePaymentSheet (~> 23.22.0)
+    - StripePaymentsUI (~> 23.22.0)
+  - StripeApplePay (23.22.0):
+    - StripeCore (= 23.22.0)
+  - StripeCore (23.22.0)
+  - StripeFinancialConnections (23.22.0):
+    - StripeCore (= 23.22.0)
+    - StripeUICore (= 23.22.0)
+  - StripePayments (23.22.0):
+    - StripeCore (= 23.22.0)
+    - StripePayments/Stripe3DS2 (= 23.22.0)
+  - StripePayments/Stripe3DS2 (23.22.0):
+    - StripeCore (= 23.22.0)
+  - StripePaymentSheet (23.22.0):
+    - StripeApplePay (= 23.22.0)
+    - StripeCore (= 23.22.0)
+    - StripePayments (= 23.22.0)
+    - StripePaymentsUI (= 23.22.0)
+  - StripePaymentsUI (23.22.0):
+    - StripeCore (= 23.22.0)
+    - StripePayments (= 23.22.0)
+    - StripeUICore (= 23.22.0)
+  - StripeUICore (23.22.0):
+    - StripeCore (= 23.22.0)
   - Yoga (1.14.0)
   - YogaKit (1.18.1):
     - Yoga (~> 1.14)
@@ -626,17 +626,17 @@ SPEC CHECKSUMS:
   ReactCommon: fac40473e2c4117522384027ab33ad0cb6717dc5
   RNCMaskedView: bc0170f389056201c82a55e242e5d90070e18e5a
   RNCPicker: 0bf8ef8f7800524f32d2bb2a8bcadd53eda0ecd1
-  RNScreens: 34cc502acf1b916c582c60003dc3089fa01dc66d
+  RNScreens: fa9b582d85ae5d62c91c66003b5278458fed7aaa
   SocketRocket: fccef3f9c5cedea1353a9ef6ada904fde10d6608
-  Stripe: d55e7338dabc599eddeee3b09eacd5c13457e1a2
-  stripe-react-native: 7ce5a0451633125e69dae95dd601e6f678ff447e
-  StripeApplePay: 48973391091a96e30e6ef6b9b331dbaa31449dcb
-  StripeCore: 2ad2bf779ed5b34c1af0800d8304222d3a98440f
-  StripeFinancialConnections: d75c000ffe2f09b14f9aebf02a571d91658ae73b
-  StripePayments: 9961532054e6d4176f54d681cab876cefe60de14
-  StripePaymentSheet: 2ef84d80a938e8c6c59ba0639007b4108d0a6bfb
-  StripePaymentsUI: 1f8addf41697d0f298fd8a15e4edf3999fbc66bc
-  StripeUICore: 95c5235db01a2d90b5bb72c85a804eaed4e64f17
+  Stripe: 34d71a65c3741627c366d72d51b481704a3e2fc7
+  stripe-react-native: b6f4ffbc393974c98c2f8b2ae5c253fee92e7a22
+  StripeApplePay: a31936b6901a55ec1cccd6a6f2176731d4d3f13f
+  StripeCore: f404f471435b55f9984023ec2962a0d58d72ef6d
+  StripeFinancialConnections: e977adc59dabedd0b807b5c025770381ed401d3a
+  StripePayments: 5d3f5f4064347559bd2bba04448e808c92f2fb89
+  StripePaymentSheet: 4d367fb96e3005077259ccde28c1e362ae472dd4
+  StripePaymentsUI: 3e67ffc17d10ef2b0e1538867934a644a1dd6fc6
+  StripeUICore: 2e512d3fd27045ca4a899acdef1ed66dcf935d83
   Yoga: 7a4d48cfb35dfa542151e615fa73c1a0d88caf21
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 

--- a/example/package.json
+++ b/example/package.json
@@ -18,7 +18,7 @@
     "react": "18.0.0",
     "react-native": "0.69.9",
     "react-native-safe-area-context": "^4.2.4",
-    "react-native-screens": "^3.13.1"
+    "react-native-screens": "^3.22.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.12.1",

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -3945,10 +3945,10 @@ react-native-safe-area-context@^4.2.4:
   resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-4.4.1.tgz#239c60b8a9a80eac70a38a822b04c0f1d15ffc01"
   integrity sha512-N9XTjiuD73ZpVlejHrUWIFZc+6Z14co1K/p1IFMkImU7+avD69F3y+lhkqA2hN/+vljdZrBSiOwXPkuo43nFQA==
 
-react-native-screens@^3.13.1:
-  version "3.18.2"
-  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-3.18.2.tgz#d7ab2d145258d3db9fa630fa5379dc4474117866"
-  integrity sha512-ANUEuvMUlsYJ1QKukEhzhfrvOUO9BVH9Nzg+6eWxpn3cfD/O83yPBOF8Mx6x5H/2+sMy+VS5x/chWOOo/U7QJw==
+react-native-screens@^3.22.0:
+  version "3.29.0"
+  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-3.29.0.tgz#1dee0326defbc1d4ef4e68287abb32a8e6b76b29"
+  integrity sha512-yB1GoAMamFAcYf4ku94uBPn0/ani9QG7NdI98beJ5cet2YFESYYzuEIuU+kt+CNRcO8qqKeugxlfgAa3HyTqlg==
   dependencies:
     react-freeze "^1.0.0"
     warn-once "^0.1.0"

--- a/stripe-react-native.podspec
+++ b/stripe-react-native.podspec
@@ -2,7 +2,7 @@ require 'json'
 
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 # Keep stripe_version in sync with https://github.com/stripe/stripe-identity-react-native/blob/main/stripe-identity-react-native.podspec
-stripe_version = '~> 23.21.0'
+stripe_version = '~> 23.22.0'
 
 Pod::Spec.new do |s|
   s.name         = 'stripe-react-native'


### PR DESCRIPTION
## Summary

Upgrades native library versions:

ios: 23.21.* -> 23.22.*
android: 20.36.* -> 20.37.*

The android upgrade requires a bump to `compileSdkVersion`, which is the breaking change


## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a link to the relevant issue, a code snippet, or an example project that demonstrates the bug. -->

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [ ] I tested this manually
- [ ] I added automated tests

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
