### PR TITLE
Bump native sdks for both iOS and Android

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,3 +1,3 @@
 StripeSdk_kotlinVersion=1.8.0
 # Keep StripeSdk_stripeVersion in sync with https://github.com/stripe/stripe-identity-react-native/blob/main/android/gradle.properties
-StripeSdk_stripeVersion=20.39.+
+StripeSdk_stripeVersion=20.40.+

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -364,50 +364,50 @@ PODS:
     - React-Core
     - React-RCTImage
   - SocketRocket (0.6.0)
-  - Stripe (23.25.0):
-    - StripeApplePay (= 23.25.0)
-    - StripeCore (= 23.25.0)
-    - StripePayments (= 23.25.0)
-    - StripePaymentsUI (= 23.25.0)
-    - StripeUICore (= 23.25.0)
-  - stripe-react-native (0.37.0):
+  - Stripe (23.26.0):
+    - StripeApplePay (= 23.26.0)
+    - StripeCore (= 23.26.0)
+    - StripePayments (= 23.26.0)
+    - StripePaymentsUI (= 23.26.0)
+    - StripeUICore (= 23.26.0)
+  - stripe-react-native (0.37.1):
     - React-Core
-    - Stripe (~> 23.25.0)
-    - StripeApplePay (~> 23.25.0)
-    - StripeFinancialConnections (~> 23.25.0)
-    - StripePayments (~> 23.25.0)
-    - StripePaymentSheet (~> 23.25.0)
-    - StripePaymentsUI (~> 23.25.0)
-  - stripe-react-native/Tests (0.37.0):
+    - Stripe (~> 23.26.0)
+    - StripeApplePay (~> 23.26.0)
+    - StripeFinancialConnections (~> 23.26.0)
+    - StripePayments (~> 23.26.0)
+    - StripePaymentSheet (~> 23.26.0)
+    - StripePaymentsUI (~> 23.26.0)
+  - stripe-react-native/Tests (0.37.1):
     - React-Core
-    - Stripe (~> 23.25.0)
-    - StripeApplePay (~> 23.25.0)
-    - StripeFinancialConnections (~> 23.25.0)
-    - StripePayments (~> 23.25.0)
-    - StripePaymentSheet (~> 23.25.0)
-    - StripePaymentsUI (~> 23.25.0)
-  - StripeApplePay (23.25.0):
-    - StripeCore (= 23.25.0)
-  - StripeCore (23.25.0)
-  - StripeFinancialConnections (23.25.0):
-    - StripeCore (= 23.25.0)
-    - StripeUICore (= 23.25.0)
-  - StripePayments (23.25.0):
-    - StripeCore (= 23.25.0)
-    - StripePayments/Stripe3DS2 (= 23.25.0)
-  - StripePayments/Stripe3DS2 (23.25.0):
-    - StripeCore (= 23.25.0)
-  - StripePaymentSheet (23.25.0):
-    - StripeApplePay (= 23.25.0)
-    - StripeCore (= 23.25.0)
-    - StripePayments (= 23.25.0)
-    - StripePaymentsUI (= 23.25.0)
-  - StripePaymentsUI (23.25.0):
-    - StripeCore (= 23.25.0)
-    - StripePayments (= 23.25.0)
-    - StripeUICore (= 23.25.0)
-  - StripeUICore (23.25.0):
-    - StripeCore (= 23.25.0)
+    - Stripe (~> 23.26.0)
+    - StripeApplePay (~> 23.26.0)
+    - StripeFinancialConnections (~> 23.26.0)
+    - StripePayments (~> 23.26.0)
+    - StripePaymentSheet (~> 23.26.0)
+    - StripePaymentsUI (~> 23.26.0)
+  - StripeApplePay (23.26.0):
+    - StripeCore (= 23.26.0)
+  - StripeCore (23.26.0)
+  - StripeFinancialConnections (23.26.0):
+    - StripeCore (= 23.26.0)
+    - StripeUICore (= 23.26.0)
+  - StripePayments (23.26.0):
+    - StripeCore (= 23.26.0)
+    - StripePayments/Stripe3DS2 (= 23.26.0)
+  - StripePayments/Stripe3DS2 (23.26.0):
+    - StripeCore (= 23.26.0)
+  - StripePaymentSheet (23.26.0):
+    - StripeApplePay (= 23.26.0)
+    - StripeCore (= 23.26.0)
+    - StripePayments (= 23.26.0)
+    - StripePaymentsUI (= 23.26.0)
+  - StripePaymentsUI (23.26.0):
+    - StripeCore (= 23.26.0)
+    - StripePayments (= 23.26.0)
+    - StripeUICore (= 23.26.0)
+  - StripeUICore (23.26.0):
+    - StripeCore (= 23.26.0)
   - Yoga (1.14.0)
   - YogaKit (1.18.1):
     - Yoga (~> 1.14)
@@ -628,18 +628,18 @@ SPEC CHECKSUMS:
   RNCPicker: 0bf8ef8f7800524f32d2bb2a8bcadd53eda0ecd1
   RNScreens: fa9b582d85ae5d62c91c66003b5278458fed7aaa
   SocketRocket: fccef3f9c5cedea1353a9ef6ada904fde10d6608
-  Stripe: d8a4f4255574813bb077e48775bf2e66356b229c
-  stripe-react-native: 3df1226f4b2c79d7448a88cd6ffa4adf6d1c36dc
-  StripeApplePay: 41d9e6b3f485a2dcf6e7f2ce25e10b52c7051bea
-  StripeCore: de53391538a1cc6cd91df270033b9699bcbb14da
-  StripeFinancialConnections: 69da02b3e19b284663825f475883695ff8d5bb33
-  StripePayments: 97b732289e00a14742541635c9dc46c575b6d464
-  StripePaymentSheet: 5ef36e5aa2055f8c4c1c137e80acada281bba529
-  StripePaymentsUI: d814fd67f4a4e0a26656d7a6854b671c38a5e68b
-  StripeUICore: 67342fb2a003fd67fa42d59304085b9b71e8e1c2
+  Stripe: e6f816be5a573f7ef45b82d9d843130154fd0269
+  stripe-react-native: 6e0f5e2a397c2875ea72288d4d1e5b84f7bc22f2
+  StripeApplePay: d6ef43f2bf834463e1dcaaf4a61c681aec04990e
+  StripeCore: c38075c1b083ee36d6f867d4133f78ecf623d6dc
+  StripeFinancialConnections: 346c6200ffac9bd3fe80bfe7e17795125f9b7379
+  StripePayments: ade58825c7d75d78a212c5db37e23b05387fb6ba
+  StripePaymentSheet: b7cab74c10a5a4b225f948e225dda427a6899e08
+  StripePaymentsUI: 1f0cbac9145149fbbb87e27660af0d3be91aae98
+  StripeUICore: d6803286f1e2b80c62c320b304503c87bf65de3c
   Yoga: 7a4d48cfb35dfa542151e615fa73c1a0d88caf21
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
 PODFILE CHECKSUM: d98ea981c14c48ddbbd4f2d6bcf130927b15a93f
 
-COCOAPODS: 1.11.3
+COCOAPODS: 1.15.2

--- a/example/ios/StripeSdkExample.xcodeproj/project.pbxproj
+++ b/example/ios/StripeSdkExample.xcodeproj/project.pbxproj
@@ -262,26 +262,26 @@
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-StripeSdkExample/Pods-StripeSdkExample-resources.sh",
 				"${PODS_CONFIGURATION_BUILD_DIR}/React-Core/AccessibilityResources.bundle",
-				"${PODS_CONFIGURATION_BUILD_DIR}/Stripe/Stripe.bundle",
-				"${PODS_CONFIGURATION_BUILD_DIR}/StripeCore/StripeCore.bundle",
-				"${PODS_CONFIGURATION_BUILD_DIR}/StripeFinancialConnections/StripeFinancialConnections.bundle",
-				"${PODS_CONFIGURATION_BUILD_DIR}/StripePaymentSheet/StripePaymentSheet.bundle",
-				"${PODS_CONFIGURATION_BUILD_DIR}/StripePayments/StripePayments.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/Stripe/StripeBundle.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/StripeCore/StripeCoreBundle.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/StripeFinancialConnections/StripeFinancialConnectionsBundle.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/StripePaymentSheet/StripePaymentSheetBundle.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/StripePayments/StripePaymentsBundle.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/StripePayments/Stripe3DS2.bundle",
-				"${PODS_CONFIGURATION_BUILD_DIR}/StripePaymentsUI/StripePaymentsUI.bundle",
-				"${PODS_CONFIGURATION_BUILD_DIR}/StripeUICore/StripeUICore.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/StripePaymentsUI/StripePaymentsUIBundle.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/StripeUICore/StripeUICoreBundle.bundle",
 			);
 			name = "[CP] Copy Pods Resources";
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/AccessibilityResources.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/Stripe.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/StripeCore.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/StripeFinancialConnections.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/StripePaymentSheet.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/StripePayments.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/StripeBundle.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/StripeCoreBundle.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/StripeFinancialConnectionsBundle.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/StripePaymentSheetBundle.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/StripePaymentsBundle.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/Stripe3DS2.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/StripePaymentsUI.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/StripeUICore.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/StripePaymentsUIBundle.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/StripeUICoreBundle.bundle",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/stripe-react-native.podspec
+++ b/stripe-react-native.podspec
@@ -2,7 +2,7 @@ require 'json'
 
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 # Keep stripe_version in sync with https://github.com/stripe/stripe-identity-react-native/blob/main/stripe-identity-react-native.podspec
-stripe_version = '~> 23.25.0'
+stripe_version = '~> 23.26.0'
 
 Pod::Spec.new do |s|
   s.name         = 'stripe-react-native'


### PR DESCRIPTION
## Summary
Android: from 20.39.+ to 20.40.+
iOS: from ~> 23.25.0 to ~> 23.26.0
