### PR TITLE
Allow underscores in font names on Android for PaymentSheet appearance

### DIFF
--- a/android/src/main/java/com/reactnativestripesdk/PaymentSheetAppearance.kt
+++ b/android/src/main/java/com/reactnativestripesdk/PaymentSheetAppearance.kt
@@ -163,7 +163,7 @@ private fun getFontResId(bundle: Bundle?, key: String, defaultValue: Int?, conte
           ?: throw PaymentSheetAppearanceException("$fontErrorPrefix expected String for font.$key, but received null.")
   if (Regex("[^a-z0-9_]").containsMatchIn(fontFileName)) {
     throw PaymentSheetAppearanceException(
-      "$fontErrorPrefix appearance.font.$key should only contain lowercase alphanumeric characters on Android, but received '$fontFileName'. This value must match the filename in android/app/src/main/res/font"
+      "$fontErrorPrefix appearance.font.$key should only contain lowercase alphanumeric characters and underscores on Android, but received '$fontFileName'. This value must match the filename in android/app/src/main/res/font"
     )
   }
 

--- a/android/src/main/java/com/reactnativestripesdk/PaymentSheetAppearance.kt
+++ b/android/src/main/java/com/reactnativestripesdk/PaymentSheetAppearance.kt
@@ -161,7 +161,7 @@ private fun getFontResId(bundle: Bundle?, key: String, defaultValue: Int?, conte
 
   val fontFileName = bundle.getString(key)
           ?: throw PaymentSheetAppearanceException("$fontErrorPrefix expected String for font.$key, but received null.")
-  if (Regex("[^a-z0-9]").containsMatchIn(fontFileName)) {
+  if (Regex("[^a-z0-9_]").containsMatchIn(fontFileName)) {
     throw PaymentSheetAppearanceException(
       "$fontErrorPrefix appearance.font.$key should only contain lowercase alphanumeric characters on Android, but received '$fontFileName'. This value must match the filename in android/app/src/main/res/font"
     )


### PR DESCRIPTION
## Summary
Changed regex expression to allow for underscores in fonts on Android as well, and updated the error to reflect this.

## Motivation

See #1636 

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one: 
- [x] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
