### PR TITLE
chore: update android dependency to 20.47.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Fixes**
 
 - Fixed `preferredNetworks` prop on CardForm on iOS not always being applied
+- Updated `stripe-android` to 20.47.3
 
 ## 0.38.0 - 2024-05-24
 

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,3 +1,3 @@
 StripeSdk_kotlinVersion=1.8.0
 # Keep StripeSdk_stripeVersion in sync with https://github.com/stripe/stripe-identity-react-native/blob/main/android/gradle.properties
-StripeSdk_stripeVersion=20.44.+
+StripeSdk_stripeVersion=20.47.3


### PR DESCRIPTION
## Summary

updated stripe-android from 20.44.+ to 20.47.3