### PR TITLE
fix: allow intentCreationCallback to use the latest callback value in Android

### DIFF
--- a/android/src/main/java/com/reactnativestripesdk/PaymentSheetFragment.kt
+++ b/android/src/main/java/com/reactnativestripesdk/PaymentSheetFragment.kt
@@ -43,7 +43,7 @@ class PaymentSheetFragment(
   private var confirmPromise: Promise? = null
   private var presentPromise: Promise? = null
   private var paymentSheetTimedOut = false
-  internal val paymentSheetIntentCreationCallback = CompletableDeferred<ReadableMap>()
+  internal var paymentSheetIntentCreationCallback = CompletableDeferred<ReadableMap>()
 
   override fun onCreateView(
     inflater: LayoutInflater,
@@ -148,6 +148,8 @@ class PaymentSheetFragment(
       stripeSdkModule.sendEvent(context, "onConfirmHandlerCallback", params)
 
       val resultFromJavascript = paymentSheetIntentCreationCallback.await()
+      // reset the completable
+      paymentSheetIntentCreationCallback = CompletableDeferred<ReadableMap>()
 
       return@CreateIntentCallback resultFromJavascript.getString("clientSecret")?.let {
         CreateIntentResult.Success(clientSecret = it)


### PR DESCRIPTION
## Summary
In the `confirmHandler`, you are supposed to be able to use the `intentCreationCallback` to either show an error or continue the flow by providing a `clientSecret`. However, on Android, after the first time you call `intentCreationCallback`, the payment sheet seems to be "stuck" on that error and doesn't allow you to update the error to a different one or take the success flow. It's caused because we never reset the completable internally, so it gets completed the first time the callback is called and then every subsequent time it is referenced it just gives that first value it was completed with.

## Motivation
You can see a repro for this

1. `git clone https://github.com/miduncan/stripe-react-native-fix.git`
2. `git checkout miduncan-repro`
3. start the android project and use the "Accept a Payment -> Prebuild UI (single step)" option which I modified to have the repro
4. Try to pay. You should see "Error 0" in the payment sheet
5. Keep clicking the pay button. You will always see "Error 0" in the PaymentSheet, even though in the LogCat logs you can see that the method is calling the callback with "Error 1", "Error 2", and so on

This is an issue because if you hit an error on the first try, you can never recover from it. You can't update the error or continue down the success flow. PaymentSheet needs to be closed and re-opened before you can do anything.

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
  - If you revert the latest commit in the `miduncan-repro` branch, you can see how the fix is working on that repro
- [ ] I added automated tests

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
