### PR TITLE
fix: make allowsRemovalOfLastSavedPaymentMethod default to true on android

### DIFF
--- a/android/src/main/java/com/reactnativestripesdk/PaymentSheetFragment.kt
+++ b/android/src/main/java/com/reactnativestripesdk/PaymentSheetFragment.kt
@@ -70,7 +70,7 @@ class PaymentSheetFragment(
     val billingDetailsBundle = arguments?.getBundle("defaultBillingDetails")
     val billingConfigParams = arguments?.getBundle("billingDetailsCollectionConfiguration")
     val paymentMethodOrder = arguments?.getStringArrayList("paymentMethodOrder")
-    val allowsRemovalOfLastSavedPaymentMethod = arguments?.getBoolean("allowsRemovalOfLastSavedPaymentMethod", true)
+    val allowsRemovalOfLastSavedPaymentMethod = arguments?.getBoolean("allowsRemovalOfLastSavedPaymentMethod", true) ?: true
     paymentIntentClientSecret = arguments?.getString("paymentIntentClientSecret").orEmpty()
     setupIntentClientSecret = arguments?.getString("setupIntentClientSecret").orEmpty()
     intentConfiguration = try {

--- a/android/src/main/java/com/reactnativestripesdk/PaymentSheetFragment.kt
+++ b/android/src/main/java/com/reactnativestripesdk/PaymentSheetFragment.kt
@@ -70,7 +70,7 @@ class PaymentSheetFragment(
     val billingDetailsBundle = arguments?.getBundle("defaultBillingDetails")
     val billingConfigParams = arguments?.getBundle("billingDetailsCollectionConfiguration")
     val paymentMethodOrder = arguments?.getStringArrayList("paymentMethodOrder")
-    val allowsRemovalOfLastSavedPaymentMethod = arguments?.getBoolean("allowsRemovalOfLastSavedPaymentMethod")
+    val allowsRemovalOfLastSavedPaymentMethod = arguments?.getBoolean("allowsRemovalOfLastSavedPaymentMethod", true)
     paymentIntentClientSecret = arguments?.getString("paymentIntentClientSecret").orEmpty()
     setupIntentClientSecret = arguments?.getString("setupIntentClientSecret").orEmpty()
     intentConfiguration = try {
@@ -201,7 +201,7 @@ class PaymentSheetFragment(
       .shippingDetails(shippingDetails)
       .billingDetailsCollectionConfiguration(billingDetailsConfig)
       .preferredNetworks(mapToPreferredNetworks(arguments?.getIntegerArrayList("preferredNetworks")))
-      .allowsRemovalOfLastSavedPaymentMethod(allowsRemovalOfLastSavedPaymentMethod ?: true)
+      .allowsRemovalOfLastSavedPaymentMethod(allowsRemovalOfLastSavedPaymentMethod)
     primaryButtonLabel?.let {
       configurationBuilder.primaryButtonLabel(it)
     }

--- a/android/src/main/java/com/reactnativestripesdk/customersheet/CustomerSheetFragment.kt
+++ b/android/src/main/java/com/reactnativestripesdk/customersheet/CustomerSheetFragment.kt
@@ -68,7 +68,8 @@ class CustomerSheetFragment : Fragment() {
     val customerId = arguments?.getString("customerId")
     val customerEphemeralKeySecret = arguments?.getString("customerEphemeralKeySecret")
     val customerAdapterOverrideParams = arguments?.getBundle("customerAdapter")
-    val allowsRemovalOfLastSavedPaymentMethod = arguments?.getBoolean("allowsRemovalOfLastSavedPaymentMethod", true)
+    val allowsRemovalOfLastSavedPaymentMethod = arguments?.getBoolean("
+    ", true) ?: true
     val paymentMethodOrder = arguments?.getStringArrayList("paymentMethodOrder")
     if (customerId == null) {
       initPromise.resolve(createError(ErrorType.Failed.toString(), "You must provide a value for `customerId`"))

--- a/android/src/main/java/com/reactnativestripesdk/customersheet/CustomerSheetFragment.kt
+++ b/android/src/main/java/com/reactnativestripesdk/customersheet/CustomerSheetFragment.kt
@@ -68,8 +68,7 @@ class CustomerSheetFragment : Fragment() {
     val customerId = arguments?.getString("customerId")
     val customerEphemeralKeySecret = arguments?.getString("customerEphemeralKeySecret")
     val customerAdapterOverrideParams = arguments?.getBundle("customerAdapter")
-    val allowsRemovalOfLastSavedPaymentMethod = arguments?.getBoolean("
-    ", true) ?: true
+    val allowsRemovalOfLastSavedPaymentMethod = arguments?.getBoolean("allowsRemovalOfLastSavedPaymentMethod", true) ?: true
     val paymentMethodOrder = arguments?.getStringArrayList("paymentMethodOrder")
     if (customerId == null) {
       initPromise.resolve(createError(ErrorType.Failed.toString(), "You must provide a value for `customerId`"))

--- a/android/src/main/java/com/reactnativestripesdk/customersheet/CustomerSheetFragment.kt
+++ b/android/src/main/java/com/reactnativestripesdk/customersheet/CustomerSheetFragment.kt
@@ -68,7 +68,7 @@ class CustomerSheetFragment : Fragment() {
     val customerId = arguments?.getString("customerId")
     val customerEphemeralKeySecret = arguments?.getString("customerEphemeralKeySecret")
     val customerAdapterOverrideParams = arguments?.getBundle("customerAdapter")
-    val allowsRemovalOfLastSavedPaymentMethod = arguments?.getBoolean("allowsRemovalOfLastSavedPaymentMethod")
+    val allowsRemovalOfLastSavedPaymentMethod = arguments?.getBoolean("allowsRemovalOfLastSavedPaymentMethod", true)
     val paymentMethodOrder = arguments?.getStringArrayList("paymentMethodOrder")
     if (customerId == null) {
       initPromise.resolve(createError(ErrorType.Failed.toString(), "You must provide a value for `customerId`"))
@@ -91,7 +91,7 @@ class CustomerSheetFragment : Fragment() {
       .googlePayEnabled(googlePayEnabled)
       .headerTextForSelectionScreen(headerTextForSelectionScreen)
       .preferredNetworks(mapToPreferredNetworks(arguments?.getIntegerArrayList("preferredNetworks")))
-      .allowsRemovalOfLastSavedPaymentMethod(allowsRemovalOfLastSavedPaymentMethod ?: true)
+      .allowsRemovalOfLastSavedPaymentMethod(allowsRemovalOfLastSavedPaymentMethod)
 
     paymentMethodOrder?.let {
       configuration.paymentMethodOrder(it)


### PR DESCRIPTION
## Summary

`getBoolean` defaults to false if the key isn't present, but we need it to default to true

