### PR TITLE
Release v0.38.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.38.4 - 2024-08-02
+
 **Fixes**
 
 - Fixed an issue on Android where `allowsRemovalOfLastSavedPaymentMethod` would default to `false` if not provided.


### PR DESCRIPTION
- [X] Ensure the CHANGELOG is up to date with all relevant commits since the last release
- [X] Add the version number for this release & the date to the CHANGELOG, underneath "## Unreleased" 
  - e.g. "## 1.2.3 - 2022-02-14"
- [X] Update the README if necessary (this is only required when there are breaking changes in the release, such as dropping support for an iOS || Android version)
