### PR TITLE
fix: Finding main view controller on iOS

### DIFF
--- a/ios/StripeSdk.swift
+++ b/ios/StripeSdk.swift
@@ -197,7 +197,9 @@ class StripeSdk: RCTEventEmitter, STPBankSelectionViewControllerDelegate, UIAdap
             }
         }
         DispatchQueue.main.async {
-            paymentSheetViewController = UIApplication.shared.delegate?.window??.rootViewController ?? UIViewController()
+            paymentSheetViewController = UIApplication.shared.delegate?.window??.rootViewController ?? UIApplication.shared.windows.first(where: {
+                $0.isKeyWindow
+            })?.rootViewController ?? UIViewController()
             if let paymentSheetFlowController = self.paymentSheetFlowController {
                 paymentSheetFlowController.presentPaymentOptions(from: findViewControllerPresenter(from: paymentSheetViewController!)
                 ) {


### PR DESCRIPTION
In a situation when `rootViewController` is not set by the application, the main view controller is not found, resulting in error:

  Attempt to present <STP_Internal_BottomSheetViewController> on <UIViewController> (from <UIViewController>) whose view is not in the window hierarchy.

which then prevents the Stripe bottom sheet from showing. Blocking the payment flow.

To prevent this, a fallback is added to traverse the windows hierarchy and find the first one that has `isKeyWindow` set to `true`.

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
