### PR TITLE
docs: Update Expo CLI command, docs link and other improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,15 +39,15 @@ npm install @stripe/stripe-react-native
 
 ### Expo
 
-> [Find Expo's full documentation here](https://docs.expo.io/versions/latest/sdk/stripe/).
+> [Find Expo's full documentation here](https://docs.expo.dev/versions/latest/sdk/stripe/).
 
 Each Expo SDK version requires a specific `stripe-react-native` version. See the [CHANGELOG](./CHANGELOG.md) for a mapping of versions. To install the correct version for your Expo SDK version run:
 
 ```sh
-expo install @stripe/stripe-react-native
+npx expo install @stripe/stripe-react-native
 ```
 
-Next, add:
+Next, add the config plugin to your `app.json` file:
 
 ```json
 {
@@ -66,7 +66,9 @@ Next, add:
 }
 ```
 
-to your `app.json` file, where `merchantIdentifier` is the Apple merchant ID obtained [here](https://stripe.com/docs/apple-pay?platform=react-native). Otherwise, Apple Pay will not work as expected. If you have multiple `merchantIdentifier`s, you can set them in an array.
+In the above code snippet:
+- `merchantIdentifier` is the Apple merchant ID obtained [here](https://stripe.com/docs/apple-pay?platform=react-native). Otherwise, Apple Pay will not work as expected. If you have multiple `merchantIdentifier`s, you can set them in an array.
+- `enableGooglePay` is a boolean to indicate whether the Google Pay is enabled or not.
 
 ### Requirements
 


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

Update Expo CLI command, docs link and other readability improvements to explain properties used in config plugin code snippet.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a link to the relevant issue, a code snippet, or an example project that demonstrates the bug. -->

Found that the command to install the library inside an Expo project referenced deprecated and removed Expo Global CLI. This PR updates the command to `npx expo install ...` since the latter refers to the latest Expo CLI, which doesn't require any global package installation.

Also:
- Updates the Expo docs link for the Stripe's React Native library reference
- Improve the readability around config plugin example

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
