### PR TITLE
chore: upgrade stripe ios to 24.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 **Fixes**
 
-- Updated `stripe-ios` to 24.1.\*
+- Updated `stripe-ios` to 24.2.\*
 
 ## 0.40.0 - 2024-11-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+**Fixes**
+
+- Updated `stripe-ios` to 24.1.\*
+
 ## 0.40.0 - 2024-11-19
 
 **Breaking changes**
@@ -24,8 +28,8 @@
 
 **Fixes**
 
-* Updated `stripe-ios` to 23.30.\*
-* Updated `stripe-android` to 20.52.\*
+- Updated `stripe-ios` to 23.30.\*
+- Updated `stripe-android` to 20.52.\*
 
 ## 0.38.6 - 2024-09-04
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -299,50 +299,50 @@ PODS:
   - RNScreens (3.29.0):
     - React-Core
     - React-RCTImage
-  - Stripe (23.32.0):
-    - StripeApplePay (= 23.32.0)
-    - StripeCore (= 23.32.0)
-    - StripePayments (= 23.32.0)
-    - StripePaymentsUI (= 23.32.0)
-    - StripeUICore (= 23.32.0)
-  - stripe-react-native (0.38.6):
+  - Stripe (24.1.0):
+    - StripeApplePay (= 24.1.0)
+    - StripeCore (= 24.1.0)
+    - StripePayments (= 24.1.0)
+    - StripePaymentsUI (= 24.1.0)
+    - StripeUICore (= 24.1.0)
+  - stripe-react-native (0.40.0):
     - React-Core
-    - Stripe (~> 23.32.0)
-    - StripeApplePay (~> 23.32.0)
-    - StripeFinancialConnections (~> 23.32.0)
-    - StripePayments (~> 23.32.0)
-    - StripePaymentSheet (~> 23.32.0)
-    - StripePaymentsUI (~> 23.32.0)
-  - stripe-react-native/Tests (0.38.6):
+    - Stripe (~> 24.1.0)
+    - StripeApplePay (~> 24.1.0)
+    - StripeFinancialConnections (~> 24.1.0)
+    - StripePayments (~> 24.1.0)
+    - StripePaymentSheet (~> 24.1.0)
+    - StripePaymentsUI (~> 24.1.0)
+  - stripe-react-native/Tests (0.40.0):
     - React-Core
-    - Stripe (~> 23.32.0)
-    - StripeApplePay (~> 23.32.0)
-    - StripeFinancialConnections (~> 23.32.0)
-    - StripePayments (~> 23.32.0)
-    - StripePaymentSheet (~> 23.32.0)
-    - StripePaymentsUI (~> 23.32.0)
-  - StripeApplePay (23.32.0):
-    - StripeCore (= 23.32.0)
-  - StripeCore (23.32.0)
-  - StripeFinancialConnections (23.32.0):
-    - StripeCore (= 23.32.0)
-    - StripeUICore (= 23.32.0)
-  - StripePayments (23.32.0):
-    - StripeCore (= 23.32.0)
-    - StripePayments/Stripe3DS2 (= 23.32.0)
-  - StripePayments/Stripe3DS2 (23.32.0):
-    - StripeCore (= 23.32.0)
-  - StripePaymentSheet (23.32.0):
-    - StripeApplePay (= 23.32.0)
-    - StripeCore (= 23.32.0)
-    - StripePayments (= 23.32.0)
-    - StripePaymentsUI (= 23.32.0)
-  - StripePaymentsUI (23.32.0):
-    - StripeCore (= 23.32.0)
-    - StripePayments (= 23.32.0)
-    - StripeUICore (= 23.32.0)
-  - StripeUICore (23.32.0):
-    - StripeCore (= 23.32.0)
+    - Stripe (~> 24.1.0)
+    - StripeApplePay (~> 24.1.0)
+    - StripeFinancialConnections (~> 24.1.0)
+    - StripePayments (~> 24.1.0)
+    - StripePaymentSheet (~> 24.1.0)
+    - StripePaymentsUI (~> 24.1.0)
+  - StripeApplePay (24.1.0):
+    - StripeCore (= 24.1.0)
+  - StripeCore (24.1.0)
+  - StripeFinancialConnections (24.1.0):
+    - StripeCore (= 24.1.0)
+    - StripeUICore (= 24.1.0)
+  - StripePayments (24.1.0):
+    - StripeCore (= 24.1.0)
+    - StripePayments/Stripe3DS2 (= 24.1.0)
+  - StripePayments/Stripe3DS2 (24.1.0):
+    - StripeCore (= 24.1.0)
+  - StripePaymentSheet (24.1.0):
+    - StripeApplePay (= 24.1.0)
+    - StripeCore (= 24.1.0)
+    - StripePayments (= 24.1.0)
+    - StripePaymentsUI (= 24.1.0)
+  - StripePaymentsUI (24.1.0):
+    - StripeCore (= 24.1.0)
+    - StripePayments (= 24.1.0)
+    - StripeUICore (= 24.1.0)
+  - StripeUICore (24.1.0):
+    - StripeCore (= 24.1.0)
   - Yoga (1.14.0)
 
 DEPENDENCIES:
@@ -511,15 +511,15 @@ SPEC CHECKSUMS:
   RNCMaskedView: bc0170f389056201c82a55e242e5d90070e18e5a
   RNCPicker: 0bf8ef8f7800524f32d2bb2a8bcadd53eda0ecd1
   RNScreens: fa9b582d85ae5d62c91c66003b5278458fed7aaa
-  Stripe: d546a79759fb2b0983076d2551096b91d032693a
-  stripe-react-native: f72717815a4eba2b584518cc16aa86c844e97fc2
-  StripeApplePay: fd4aeaa8af1ebbfe5e38390ef7b4607f66494f80
-  StripeCore: 4999b0c234127b28b9e656caa558ba4406ce58b3
-  StripeFinancialConnections: 4e50d2395e74c7637f84fc9d89fa5740b8240f49
-  StripePayments: a1260c9fecdb8640462c1fe70c4e2e17df2ab3a8
-  StripePaymentSheet: 155d402ee01447002d23c982e905ce06e6d7ef66
-  StripePaymentsUI: 2084d4398cb4869b13dd9eac43a00481476b152f
-  StripeUICore: 2c115cc8498f3badc19b4a41b3b1fdac0ae21d41
+  Stripe: d6adb6dd944fccd0683d64a5bf9ec5cb11b18450
+  stripe-react-native: 121afd456bb3e25192e9afb33717e647d70f0844
+  StripeApplePay: e4fa6abea8a8ddbde9c8fafa96130a2ea09b57bb
+  StripeCore: 160aca8e55250349a11fde890e6d2b9e05f8d1b9
+  StripeFinancialConnections: b09ea62bc9a6078fe4f6059cfd7581a86bdc4001
+  StripePayments: a73b1f2aaf25329e86a48e657d2113534aab766a
+  StripePaymentSheet: aad046a1c7da0e3707e9c08e7d84208950af6f32
+  StripePaymentsUI: b0549b8e460f9963d07f39a9aace4106f6bd66d4
+  StripeUICore: b53e458e9ecb5992a8e986174cfa55935bc44ff4
   Yoga: 8a90b50af67eaa9fe94fd03e550bfeab06096873
 
 PODFILE CHECKSUM: 7b4a5e954edfeed0967520f79be9e773f07d8266

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -299,50 +299,50 @@ PODS:
   - RNScreens (3.29.0):
     - React-Core
     - React-RCTImage
-  - Stripe (24.1.0):
-    - StripeApplePay (= 24.1.0)
-    - StripeCore (= 24.1.0)
-    - StripePayments (= 24.1.0)
-    - StripePaymentsUI (= 24.1.0)
-    - StripeUICore (= 24.1.0)
+  - Stripe (24.2.0):
+    - StripeApplePay (= 24.2.0)
+    - StripeCore (= 24.2.0)
+    - StripePayments (= 24.2.0)
+    - StripePaymentsUI (= 24.2.0)
+    - StripeUICore (= 24.2.0)
   - stripe-react-native (0.40.0):
     - React-Core
-    - Stripe (~> 24.1.0)
-    - StripeApplePay (~> 24.1.0)
-    - StripeFinancialConnections (~> 24.1.0)
-    - StripePayments (~> 24.1.0)
-    - StripePaymentSheet (~> 24.1.0)
-    - StripePaymentsUI (~> 24.1.0)
+    - Stripe (~> 24.2.0)
+    - StripeApplePay (~> 24.2.0)
+    - StripeFinancialConnections (~> 24.2.0)
+    - StripePayments (~> 24.2.0)
+    - StripePaymentSheet (~> 24.2.0)
+    - StripePaymentsUI (~> 24.2.0)
   - stripe-react-native/Tests (0.40.0):
     - React-Core
-    - Stripe (~> 24.1.0)
-    - StripeApplePay (~> 24.1.0)
-    - StripeFinancialConnections (~> 24.1.0)
-    - StripePayments (~> 24.1.0)
-    - StripePaymentSheet (~> 24.1.0)
-    - StripePaymentsUI (~> 24.1.0)
-  - StripeApplePay (24.1.0):
-    - StripeCore (= 24.1.0)
-  - StripeCore (24.1.0)
-  - StripeFinancialConnections (24.1.0):
-    - StripeCore (= 24.1.0)
-    - StripeUICore (= 24.1.0)
-  - StripePayments (24.1.0):
-    - StripeCore (= 24.1.0)
-    - StripePayments/Stripe3DS2 (= 24.1.0)
-  - StripePayments/Stripe3DS2 (24.1.0):
-    - StripeCore (= 24.1.0)
-  - StripePaymentSheet (24.1.0):
-    - StripeApplePay (= 24.1.0)
-    - StripeCore (= 24.1.0)
-    - StripePayments (= 24.1.0)
-    - StripePaymentsUI (= 24.1.0)
-  - StripePaymentsUI (24.1.0):
-    - StripeCore (= 24.1.0)
-    - StripePayments (= 24.1.0)
-    - StripeUICore (= 24.1.0)
-  - StripeUICore (24.1.0):
-    - StripeCore (= 24.1.0)
+    - Stripe (~> 24.2.0)
+    - StripeApplePay (~> 24.2.0)
+    - StripeFinancialConnections (~> 24.2.0)
+    - StripePayments (~> 24.2.0)
+    - StripePaymentSheet (~> 24.2.0)
+    - StripePaymentsUI (~> 24.2.0)
+  - StripeApplePay (24.2.0):
+    - StripeCore (= 24.2.0)
+  - StripeCore (24.2.0)
+  - StripeFinancialConnections (24.2.0):
+    - StripeCore (= 24.2.0)
+    - StripeUICore (= 24.2.0)
+  - StripePayments (24.2.0):
+    - StripeCore (= 24.2.0)
+    - StripePayments/Stripe3DS2 (= 24.2.0)
+  - StripePayments/Stripe3DS2 (24.2.0):
+    - StripeCore (= 24.2.0)
+  - StripePaymentSheet (24.2.0):
+    - StripeApplePay (= 24.2.0)
+    - StripeCore (= 24.2.0)
+    - StripePayments (= 24.2.0)
+    - StripePaymentsUI (= 24.2.0)
+  - StripePaymentsUI (24.2.0):
+    - StripeCore (= 24.2.0)
+    - StripePayments (= 24.2.0)
+    - StripeUICore (= 24.2.0)
+  - StripeUICore (24.2.0):
+    - StripeCore (= 24.2.0)
   - Yoga (1.14.0)
 
 DEPENDENCIES:
@@ -481,21 +481,21 @@ SPEC CHECKSUMS:
   FBReactNativeSpec: 76d7b03876b0ad0b86bc5c84d23af8e64db8e096
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: 3d02b25ca00c2d456734d0bcff864cbc62f6ae1a
-  RCT-Folly: b9d9fe1fc70114b751c076104e52f3b1b5e5a95a
+  RCT-Folly: ba26c9ca44b1fb56915c3efd9ce618472addc544
   RCTRequired: b9e53f0512019150020156fa0dacd6583ab838be
   RCTTypeSafety: 04b72202bef8302802610dee70bb9407a245b64c
   React: 59288a7ca8104eb8002f01378606fe42eeabf4b5
   React-bridging: b042b8c217f04e568409786de5f221793be49c31
   React-callinvoker: c7b83d582112e2d5a049dc46abf4c64d871b5c45
   React-Codegen: 5747238d0446e3ab1deb967e749a2bfde6a5c866
-  React-Core: d8e1250039d47112513757038d9d9f9b638565c6
+  React-Core: c501478ad5c850b0f0ff26d1009e9410c37ed23a
   React-CoreModules: 63cceb0040ec2b43a258113193be91f934b37f1b
-  React-cxxreact: 429404aac55d8bffca77328002452fc7fa8b29e8
-  React-jsi: a8f60feb519ac00085eb9a39d20eaa65c96b51ea
-  React-jsiexecutor: ce0b9aa647bdf94126eb2ee1f235d329eb8c0aec
+  React-cxxreact: 87a2b40a905744886c7d3e42a9634eea44ca7524
+  React-jsi: 629f62632b96f0c16d6ee81a5dc21f240b7fe5fc
+  React-jsiexecutor: e10273ade1e0dd53d3123b3dff47ea698bb7e7bd
   React-jsinspector: f275698149311abc8c32ebb97797d6b97c44adde
-  React-logger: da69d7f1c9501c78cd60776d52a60d7fa5e4d9c2
-  react-native-safe-area-context: 99b24a0c5acd0d5dcac2b1a7f18c49ea317be99a
+  React-logger: 4ef8a0325da47f55082a73ac68fac2dc6039356c
+  react-native-safe-area-context: 41ffdebd233eddeef75576749f0cf153e83a0681
   React-perflogger: 5ade0a1627352f1647d283e78331819bb46cceae
   React-RCTActionSheet: 8e94f1e46e09c7035b81fe56c0ed8d78f3ccd340
   React-RCTAnimation: bf2af72f03cf16528db9a830be69fa04b341a1b7
@@ -507,21 +507,21 @@ SPEC CHECKSUMS:
   React-RCTText: ed34088172126f84130eea859d62fedca0dd7975
   React-RCTVibration: c9cd9f21bbcb3b9c6deedbb66f13e373f57dd795
   React-runtimeexecutor: ea78653fbc68bd6f2d3f5e7e311bc5a9dc8bfeca
-  ReactCommon: f4bb9e5209ea5c3c6ab25e100895119e58d6e50a
-  RNCMaskedView: bc0170f389056201c82a55e242e5d90070e18e5a
-  RNCPicker: 0bf8ef8f7800524f32d2bb2a8bcadd53eda0ecd1
-  RNScreens: fa9b582d85ae5d62c91c66003b5278458fed7aaa
-  Stripe: d6adb6dd944fccd0683d64a5bf9ec5cb11b18450
-  stripe-react-native: 121afd456bb3e25192e9afb33717e647d70f0844
-  StripeApplePay: e4fa6abea8a8ddbde9c8fafa96130a2ea09b57bb
-  StripeCore: 160aca8e55250349a11fde890e6d2b9e05f8d1b9
-  StripeFinancialConnections: b09ea62bc9a6078fe4f6059cfd7581a86bdc4001
-  StripePayments: a73b1f2aaf25329e86a48e657d2113534aab766a
-  StripePaymentSheet: aad046a1c7da0e3707e9c08e7d84208950af6f32
-  StripePaymentsUI: b0549b8e460f9963d07f39a9aace4106f6bd66d4
-  StripeUICore: b53e458e9ecb5992a8e986174cfa55935bc44ff4
+  ReactCommon: 8f32a72413ab8d62d515bcfe66c22d5321ccfbfd
+  RNCMaskedView: 90a18f1e65b81985232eb6f5ea594300a4b6a09f
+  RNCPicker: a04f825ecc28764441425987e78946032850102d
+  RNScreens: 0de8f71eb41623a2e72ab802f89d1ee2495eb57d
+  Stripe: be805dc0e80a7299de7b10ecbe01ce81412654c8
+  stripe-react-native: 0fe72bc955b7c31cae9485cea43f59e2e07b4227
+  StripeApplePay: 5233ecff535bb0772785d2d18d02b39ec24ecb71
+  StripeCore: e2f70fcaa82e5a9d44d18fe4534358384cdf4821
+  StripeFinancialConnections: 8c8e2273552d4567ec381ee2b0ff1745b8e11ab6
+  StripePayments: beb97f8061066532744ceaa03e59009c9716332e
+  StripePaymentSheet: 0d8ed5270037b1da3eb107c9876cec67b8b1fe43
+  StripePaymentsUI: 6486d8b86bf49b8932506807a8692ce16e9f109d
+  StripeUICore: b59aa9c9e202b6a03a556c3519eff578274f7598
   Yoga: 8a90b50af67eaa9fe94fd03e550bfeab06096873
 
 PODFILE CHECKSUM: 7b4a5e954edfeed0967520f79be9e773f07d8266
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.16.2

--- a/stripe-react-native.podspec
+++ b/stripe-react-native.podspec
@@ -2,7 +2,7 @@ require 'json'
 
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 # Keep stripe_version in sync with https://github.com/stripe/stripe-identity-react-native/blob/main/stripe-identity-react-native.podspec
-stripe_version = '~> 24.1.0'
+stripe_version = '~> 24.2.0'
 
 Pod::Spec.new do |s|
   s.name         = 'stripe-react-native'

--- a/stripe-react-native.podspec
+++ b/stripe-react-native.podspec
@@ -2,7 +2,7 @@ require 'json'
 
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 # Keep stripe_version in sync with https://github.com/stripe/stripe-identity-react-native/blob/main/stripe-identity-react-native.podspec
-stripe_version = '~> 23.32.0'
+stripe_version = '~> 24.1.0'
 
 Pod::Spec.new do |s|
   s.name         = 'stripe-react-native'


### PR DESCRIPTION
## Summary

wysiwyg

matches https://github.com/stripe/stripe-identity-react-native/pull/176