### PR TITLE
Add extra field to the shipping details

### DIFF
--- a/android/src/main/java/com/reactnativestripesdk/utils/Mappers.kt
+++ b/android/src/main/java/com/reactnativestripesdk/utils/Mappers.kt
@@ -607,6 +607,9 @@ internal fun mapToShippingDetails(shippingDetails: ReadableMap?): ConfirmPayment
 
   return ConfirmPaymentIntentParams.Shipping(
     name = getValOr(shippingDetails, "name") ?: "",
+    phone = getValOr(shippingDetails, "phone") ?: "",
+    trackingNumber = getValOr(shippingDetails, "trackingNumber") ?: "",
+    carrier = getValOr(shippingDetails, "carrier") ?: "",
     address = address
   )
 }

--- a/ios/Mappers.swift
+++ b/ios/Mappers.swift
@@ -548,6 +548,11 @@ class Mappers {
 
         let shipping = STPPaymentIntentShippingDetailsParams(address: shippingAddress, name: shippingDetails["name"] as? String ?? "")
 
+        // add the phone number, trackingNumber and carrie if available in the shipping details
+        shipping.phone = shippingDetails["phone"] as? String ?? ""
+        shipping.trackingNumber = shippingDetails["trackingNumber"] as? String ?? ""
+        shipping.carrier = shippingDetails["carrier"] as? String ?? ""
+
         return shipping
     }
 


### PR DESCRIPTION
added the phone number, tracking number and carrier  to the shipping details if data is available

this fixes #1548

## Summary
Added to the mappers the trackingNumber, carrier and phone number to the shipping details

## Motivation

This will help to have more complete data in the stripe's dashboard, as mentioned in the following issue

https://github.com/stripe/stripe-react-native/issues/1548


Android Change

File - stripe-react-native/android/src/main/java/com/reactnativestripesdk/utils/Mappers.kt
Line - 608

```kotlin
  return ConfirmPaymentIntentParams.Shipping(
    name = getValOr(shippingDetails, "name") ?: "",
    phone = getValOr(shippingDetails, "phone") ?: "",
    trackingNumber = getValOr(shippingDetails, "trackingNumber") ?: "",
    carrier = getValOr(shippingDetails, "carrier") ?: "",
    address = address
  )
```

iOS Change

File -  stripe-react-native/ios/Mappers.swift
Line - 551
```swift
        // add the phone number, trackingNumber and carrie if available in the shipping details
        shipping.phone = shippingDetails["phone"] as? String ?? ""
        shipping.trackingNumber = shippingDetails["trackingNumber"] as? String ?? ""
        shipping.carrier = shippingDetails["carrier"] as? String ?? ""
```


## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [X] I tested this manually
- [ ] I added automated tests

![image](https://github.com/user-attachments/assets/7cf5ca38-b19c-43a0-8e6d-11aa68f27004)


## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [X] This PR does not result in any developer-facing changes.
