### PR TITLE
use sendable struct instead of class

### DIFF
--- a/ios/StripeSdk.swift
+++ b/ios/StripeSdk.swift
@@ -129,7 +129,7 @@ class StripeSdk: RCTEventEmitter, UIAdaptivePresentationControllerDelegate {
     }
 
     @objc(intentCreationCallback:resolver:rejecter:)
-    func intentCreationCallback(result: NSDictionary, resolver resolve: @escaping RCTPromiseResolveBlock,
+    @MainActor func intentCreationCallback(result: NSDictionary, resolver resolve: @escaping RCTPromiseResolveBlock,
                           rejecter reject: @escaping RCTPromiseRejectBlock) -> Void  {
         guard let paymentSheetIntentCreationCallback = self.paymentSheetIntentCreationCallback else {
             resolve(Errors.createError(ErrorType.Failed, "No intent creation callback was set"))

--- a/ios/StripeSdk.swift
+++ b/ios/StripeSdk.swift
@@ -138,18 +138,18 @@ class StripeSdk: RCTEventEmitter, UIAdaptivePresentationControllerDelegate {
         if let clientSecret = result["clientSecret"] as? String {
             paymentSheetIntentCreationCallback(.success(clientSecret))
         } else {
-            class ConfirmationError: Error, LocalizedError {
-                private var errorMessage: String
-                init(errorMessage: String) {
-                    self.errorMessage = errorMessage
-                }
-                public var errorDescription: String? {
-                    return errorMessage
-                }
+          struct ConfirmationError: Error, LocalizedError {
+            private var errorMessage: String
+            init(errorMessage: String) {
+              self.errorMessage = errorMessage
             }
-            let errorParams = result["error"] as? NSDictionary
-            let error = ConfirmationError.init(errorMessage: errorParams?["localizedMessage"] as? String ?? "An unknown error occurred.")
-            paymentSheetIntentCreationCallback(.failure(error))
+            public var errorDescription: String? {
+              return errorMessage
+            }
+          }
+          let errorParams = result["error"] as? NSDictionary
+          let error = ConfirmationError.init(errorMessage: errorParams?["localizedMessage"] as? String ?? "An unknown error occurred.")
+          paymentSheetIntentCreationCallback(.failure(error))
         }
     }
 

--- a/ios/StripeSdk.swift
+++ b/ios/StripeSdk.swift
@@ -140,9 +140,6 @@ class StripeSdk: RCTEventEmitter, UIAdaptivePresentationControllerDelegate {
         } else {
           struct ConfirmationError: Error, LocalizedError {
             private var errorMessage: String
-            init(errorMessage: String) {
-              self.errorMessage = errorMessage
-            }
             public var errorDescription: String? {
               return errorMessage
             }

--- a/ios/StripeSdk.swift
+++ b/ios/StripeSdk.swift
@@ -140,6 +140,9 @@ class StripeSdk: RCTEventEmitter, UIAdaptivePresentationControllerDelegate {
         } else {
           struct ConfirmationError: Error, LocalizedError {
             private var errorMessage: String
+            init(errorMessage: String) {
+              self.errorMessage = errorMessage
+            }
             public var errorDescription: String? {
               return errorMessage
             }


### PR DESCRIPTION
## Summary

The problem here is that a call within the stripe-ios library to initialize a PKPaymentAuthorizationResult is passing the error that we pass in from RN, which conforms to this [class](https://stripe.sourcegraphcloud.com/stripe/stripe-react-native/-/blob/ios/StripeSdk.swift?L141-149), which is not "sendable". but PKPaymentAuthorizationResult expects that it is sendable. classes _can_ be made sendable, but we should just use a struct here

## Motivation
fixes https://github.com/stripe/stripe-react-native/issues/1748
## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
