### PR TITLE
Support events in Financial Connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@
 
 **Features**
 
-- Added ability to pass an `onEvent` listener to Financial Connections methods via a `params` argument.
+- Added ability to pass an `onEvent` listener to Financial Connections methods via a `params` argument. This includes the following methods, both when used directly or via `useStripe` or `useFinancialConnectionsSheet`:
+  - `collectBankAccountForPayment`
+  - `collectBankAccountForSetup`
+  - `collectBankAccountToken`
+  - `collectFinancialConnectionsAccounts`
 
 ## 0.41.0 - 2024-12-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## Unreleased
+
+**Features**
+
+- Added ability to pass an `onEvent` listener to Financial Connections methods via a `params` argument.
+
 ## 0.41.0 - 2024-12-19
 
 **Fixes**

--- a/android/src/main/java/com/reactnativestripesdk/utils/Mappers.kt
+++ b/android/src/main/java/com/reactnativestripesdk/utils/Mappers.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import android.os.Bundle
 import android.util.Log
 import com.facebook.react.bridge.*
+import com.stripe.android.financialconnections.analytics.FinancialConnectionsEvent
 import com.stripe.android.PaymentAuthConfig
 import com.stripe.android.model.*
 import com.stripe.android.model.StripeIntent.NextActionType
@@ -956,4 +957,49 @@ internal fun mapToPreferredNetworks(networksAsInts: ArrayList<Int>?): List<CardB
   return networksAsInts.mapNotNull {
     intToCardBrand[it]
   }
+}
+
+internal fun mapFromFinancialConnectionsEvent(event: FinancialConnectionsEvent): WritableMap {
+  return Arguments.createMap().apply {
+    putString("name", event.name.value)
+    putMap("metadata", event.metadata.toMap().toReadableMap())
+  }
+}
+
+private fun List<Any?>.toWritableArray(): WritableArray {
+  val writableArray = Arguments.createArray()
+
+  forEach { value ->
+    when (value) {
+      null -> writableArray.pushNull()
+      is Boolean -> writableArray.pushBoolean(value)
+      is Int -> writableArray.pushInt(value)
+      is Double -> writableArray.pushDouble(value)
+      is String -> writableArray.pushString(value)
+      is Map<*, *> -> writableArray.pushMap((value as Map<String, Any?>).toReadableMap())
+      is List<*> -> writableArray.pushArray((value as List<Any?>).toWritableArray())
+      else -> writableArray.pushString(value.toString())
+    }
+  }
+
+  return writableArray
+}
+
+private fun Map<String, Any?>.toReadableMap(): ReadableMap {
+  val writableMap = Arguments.createMap()
+
+  forEach { (key, value) ->
+    when (value) {
+      null -> writableMap.putNull(key)
+      is Boolean -> writableMap.putBoolean(key, value)
+      is Int -> writableMap.putInt(key, value)
+      is Double -> writableMap.putDouble(key, value)
+      is String -> writableMap.putString(key, value)
+      is Map<*, *> -> writableMap.putMap(key, (value as Map<String, Any?>).toReadableMap())
+      is List<*> -> writableMap.putArray(key, (value as List<Any?>).toWritableArray())
+      else -> writableMap.putString(key, value.toString())
+    }
+  }
+
+  return writableMap
 }

--- a/example/src/screens/ACHPaymentScreen.tsx
+++ b/example/src/screens/ACHPaymentScreen.tsx
@@ -6,6 +6,7 @@ import {
   verifyMicrodepositsForPayment,
   VerifyMicrodepositsParams,
   collectBankAccountForPayment,
+  FinancialConnections,
 } from '@stripe/stripe-react-native';
 import Button from '../components/Button';
 import PaymentScreen from '../components/PaymentScreen';
@@ -136,6 +137,11 @@ export default function ACHPaymentScreen() {
 
     setSecret(clientSecret);
 
+    const onEvent = (event: FinancialConnections.FinancialConnectionsEvent) => {
+      let value = JSON.stringify(event, null, 2);
+      console.log(`Received Financial Connections event: ${value}`);
+    };
+
     const { paymentIntent, error } = await collectBankAccountForPayment(
       clientSecret,
       {
@@ -146,6 +152,7 @@ export default function ACHPaymentScreen() {
             email,
           },
         },
+        onEvent: onEvent,
       }
     );
 

--- a/example/src/screens/CollectBankAccountScreen.tsx
+++ b/example/src/screens/CollectBankAccountScreen.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import { Alert } from 'react-native';
-import { useFinancialConnectionsSheet } from '@stripe/stripe-react-native';
+import {
+  FinancialConnections,
+  useFinancialConnectionsSheet,
+} from '@stripe/stripe-react-native';
 import Button from '../components/Button';
 import PaymentScreen from '../components/PaymentScreen';
 import { API_URL } from '../Config';
@@ -55,7 +58,10 @@ export default function CollectBankAccountScreen() {
 
   const handleCollectSessionPress = async () => {
     const { session, error } = await collectFinancialConnectionsAccounts(
-      clientSecret
+      clientSecret,
+      (event: FinancialConnections.FinancialConnectionsEvent) => {
+        console.log('Event received:', event);
+      }
     );
 
     if (error) {

--- a/example/src/screens/CollectBankAccountScreen.tsx
+++ b/example/src/screens/CollectBankAccountScreen.tsx
@@ -1,12 +1,10 @@
 import React from 'react';
 import { Alert } from 'react-native';
-import {
-  FinancialConnections,
-  useFinancialConnectionsSheet,
-} from '@stripe/stripe-react-native';
+import { useFinancialConnectionsSheet } from '@stripe/stripe-react-native';
 import Button from '../components/Button';
 import PaymentScreen from '../components/PaymentScreen';
 import { API_URL } from '../Config';
+import type { FinancialConnectionsEvent } from 'src/types/FinancialConnections';
 
 export default function CollectBankAccountScreen() {
   const [clientSecret, setClientSecret] = React.useState('');
@@ -37,7 +35,12 @@ export default function CollectBankAccountScreen() {
 
   const handleCollectTokenPress = async () => {
     const { session, token, error } = await collectBankAccountToken(
-      clientSecret
+      clientSecret,
+      {
+        onEvent: (event: FinancialConnectionsEvent) => {
+          console.log('Event received:', event);
+        },
+      }
     );
 
     if (error) {
@@ -59,8 +62,10 @@ export default function CollectBankAccountScreen() {
   const handleCollectSessionPress = async () => {
     const { session, error } = await collectFinancialConnectionsAccounts(
       clientSecret,
-      (event: FinancialConnections.FinancialConnectionsEvent) => {
-        console.log('Event received:', event);
+      {
+        onEvent: (event: FinancialConnectionsEvent) => {
+          console.log('Event received:', event);
+        },
       }
     );
 

--- a/ios/FinancialConnections.swift
+++ b/ios/FinancialConnections.swift
@@ -14,10 +14,16 @@ class FinancialConnections {
     internal static func present(
         withClientSecret: String,
         returnURL: String? = nil,
+        onEvent: ((FinancialConnectionsEvent) -> Void)? = nil,
         resolve: @escaping RCTPromiseResolveBlock
     ) -> Void {
         DispatchQueue.main.async {
-            FinancialConnectionsSheet(financialConnectionsSessionClientSecret: withClientSecret, returnURL: returnURL).present(
+            let financialConnectionsSheet = FinancialConnectionsSheet(
+              financialConnectionsSessionClientSecret: withClientSecret,
+              returnURL: returnURL
+            )
+            financialConnectionsSheet.onEvent = onEvent
+            financialConnectionsSheet.present(
               from: findViewControllerPresenter(from: UIApplication.shared.delegate?.window??.rootViewController ?? UIViewController()),
               completion: { result in
                   switch result {
@@ -35,10 +41,16 @@ class FinancialConnections {
     internal static func presentForToken(
         withClientSecret: String,
         returnURL: String? = nil,
+        onEvent: ((FinancialConnectionsEvent) -> Void)? = nil,
         resolve: @escaping RCTPromiseResolveBlock
     ) -> Void {
         DispatchQueue.main.async {
-            FinancialConnectionsSheet(financialConnectionsSessionClientSecret: withClientSecret, returnURL: returnURL).presentForToken(
+            let financialConnectionsSheet = FinancialConnectionsSheet(
+              financialConnectionsSessionClientSecret: withClientSecret,
+              returnURL: returnURL
+            )
+            financialConnectionsSheet.onEvent = onEvent
+            financialConnectionsSheet.presentForToken(
               from: findViewControllerPresenter(from: UIApplication.shared.delegate?.window??.rootViewController ?? UIViewController()),
               completion: { result in
                   switch result {

--- a/ios/Mappers.swift
+++ b/ios/Mappers.swift
@@ -1050,4 +1050,27 @@ class Mappers {
             return nil
         }
     }
+
+    class func financialConnectionsEventToMap(_ event: FinancialConnectionsEvent) -> [String: Any] {
+      var metadata: [String: Any] = [:]
+
+      if let manualEntry = event.metadata.manualEntry {
+        metadata["manualEntry"] = manualEntry
+      }
+
+      if let institutionName = event.metadata.institutionName {
+        metadata["institutionName"] = institutionName
+      }
+
+      if let errorCode = event.metadata.errorCode {
+        metadata["errorCode"] = errorCode.rawValue
+      }
+
+      let mappedEvent: [String: Any] = [
+        "name": event.name.rawValue,
+        "metadata": metadata
+      ]
+
+      return mappedEvent
+    }
 }

--- a/ios/StripeSdk.swift
+++ b/ios/StripeSdk.swift
@@ -733,9 +733,13 @@ class StripeSdk: RCTEventEmitter, UIAdaptivePresentationControllerDelegate {
           connectionsReturnURL = nil
         }
 
-        let onEvent: (FinancialConnectionsEvent) -> Void = { [weak self] event in
+        var onEvent: ((FinancialConnectionsEvent) -> Void)? = nil
+
+        if hasEventListeners {
+          onEvent = { [weak self] event in
             let mappedEvent = Mappers.financialConnectionsEventToMap(event)
             self?.sendEvent(withName: "onFinancialConnectionsEvent", body: mappedEvent)
+          }
         }
 
         if (isPaymentIntent) {
@@ -1049,12 +1053,16 @@ class StripeSdk: RCTEventEmitter, UIAdaptivePresentationControllerDelegate {
         } else {
             returnURL = nil
         }
-      
-        let onEvent: (FinancialConnectionsEvent) -> Void = { [weak self] event in
+
+        var onEvent: ((FinancialConnectionsEvent) -> Void)? = nil
+
+        if hasEventListeners {
+          onEvent = { [weak self] event in
             let mappedEvent = Mappers.financialConnectionsEventToMap(event)
             self?.sendEvent(withName: "onFinancialConnectionsEvent", body: mappedEvent)
+          }
         }
-      
+
         FinancialConnections.presentForToken(withClientSecret: clientSecret, returnURL: returnURL, onEvent: onEvent, resolve: resolve)
     }
 
@@ -1075,9 +1083,13 @@ class StripeSdk: RCTEventEmitter, UIAdaptivePresentationControllerDelegate {
             returnURL = nil
         }
 
-        let onEvent: (FinancialConnectionsEvent) -> Void = { [weak self] event in
+        var onEvent: ((FinancialConnectionsEvent) -> Void)? = nil
+
+        if hasEventListeners {
+          onEvent = { [weak self] event in
             let mappedEvent = Mappers.financialConnectionsEventToMap(event)
             self?.sendEvent(withName: "onFinancialConnectionsEvent", body: mappedEvent)
+          }
         }
 
         FinancialConnections.present(withClientSecret: clientSecret, returnURL: returnURL, onEvent: onEvent, resolve: resolve)

--- a/src/NativeStripeSdk.tsx
+++ b/src/NativeStripeSdk.tsx
@@ -84,7 +84,7 @@ type NativeStripeSdkType = {
   collectBankAccount(
     isPaymentIntent: boolean,
     clientSecret: string,
-    params: PaymentMethod.CollectBankAccountParams
+    params: Omit<PaymentMethod.CollectBankAccountParams, 'onEvent'>
   ): Promise<ConfirmSetupIntentResult | ConfirmPaymentResult>;
   getConstants(): { API_VERSIONS: { CORE: string; ISSUING: string } };
   canAddCardToWallet(

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -468,12 +468,18 @@ export const collectBankAccountForPayment = async (
   clientSecret: string,
   params: PaymentMethod.CollectBankAccountParams
 ): Promise<CollectBankAccountForPaymentResult> => {
+  const subscription =
+    params.onEvent &&
+    eventEmitter.addListener('onFinancialConnectionsEvent', params.onEvent);
+
   try {
     const { paymentIntent, error } = (await NativeStripeSdk.collectBankAccount(
       true,
       clientSecret,
       params
     )) as CollectBankAccountForPaymentResult;
+
+    subscription?.remove();
 
     if (error) {
       return {
@@ -484,6 +490,7 @@ export const collectBankAccountForPayment = async (
       paymentIntent: paymentIntent!,
     };
   } catch (error: any) {
+    subscription?.remove();
     return {
       error: createError(error),
     };
@@ -494,12 +501,18 @@ export const collectBankAccountForSetup = async (
   clientSecret: string,
   params: PaymentMethod.CollectBankAccountParams
 ): Promise<CollectBankAccountForSetupResult> => {
+  const subscription =
+    params.onEvent &&
+    eventEmitter.addListener('onFinancialConnectionsEvent', params.onEvent);
+
   try {
     const { setupIntent, error } = (await NativeStripeSdk.collectBankAccount(
       false,
       clientSecret,
       params
     )) as CollectBankAccountForSetupResult;
+
+    subscription?.remove();
 
     if (error) {
       return {
@@ -510,6 +523,7 @@ export const collectBankAccountForSetup = async (
       setupIntent: setupIntent!,
     };
   } catch (error: any) {
+    subscription?.remove();
     return {
       error: createError(error),
     };
@@ -520,14 +534,21 @@ export const collectBankAccountForSetup = async (
  * Use collectBankAccountToken in the [Add a Financial Connections Account to a US Custom Connect](https://stripe.com/docs/financial-connections/connect-payouts) account flow.
  * When called, it will load the Authentication Flow, an on-page modal UI which allows your user to securely link their external financial account for payouts.
  * @param {string} clientSecret The client_secret of the [Financial Connections Session](https://stripe.com/docs/api/financial_connections/session).
+ * @param onEvent An optional event listener to receive @type {FinancialConnectionEvent} for specific events during the process of a user connecting their financial accounts.
  * @returns A promise that resolves to an object containing either `session` and `token` fields, or an error field.
  */
 export const collectBankAccountToken = async (
-  clientSecret: string
+  clientSecret: string,
+  onEvent?: (event: FinancialConnections.FinancialConnectionsEvent) => void
 ): Promise<FinancialConnections.TokenResult> => {
+  const subscription =
+    onEvent && eventEmitter.addListener('onFinancialConnectionsEvent', onEvent);
+
   try {
     const { session, token, error } =
       await NativeStripeSdk.collectBankAccountToken(clientSecret);
+
+    subscription?.remove();
 
     if (error) {
       return {
@@ -539,6 +560,7 @@ export const collectBankAccountToken = async (
       token: token!,
     };
   } catch (error: any) {
+    subscription?.remove();
     return {
       error: createError(error),
     };
@@ -549,14 +571,21 @@ export const collectBankAccountToken = async (
  * Use collectFinancialConnectionsAccounts in the [Collect an account to build data-powered products](https://stripe.com/docs/financial-connections/other-data-powered-products) flow.
  * When called, it will load the Authentication Flow, an on-page modal UI which allows your user to securely link their external financial account.
  * @param {string} clientSecret The client_secret of the [Financial Connections Session](https://stripe.com/docs/api/financial_connections/session).
+ * @param onEvent An optional event listener to receive @type {FinancialConnectionEvent} for specific events during the process of a user connecting their financial accounts.
  * @returns A promise that resolves to an object containing either a `session` field, or an error field.
  */
 export const collectFinancialConnectionsAccounts = async (
-  clientSecret: string
+  clientSecret: string,
+  onEvent?: (event: FinancialConnections.FinancialConnectionsEvent) => void
 ): Promise<FinancialConnections.SessionResult> => {
+  const subscription =
+    onEvent && eventEmitter.addListener('onFinancialConnectionsEvent', onEvent);
+
   try {
     const { session, error } =
       await NativeStripeSdk.collectFinancialConnectionsAccounts(clientSecret);
+
+    subscription?.remove();
 
     if (error) {
       return {
@@ -567,6 +596,7 @@ export const collectFinancialConnectionsAccounts = async (
       session: session!,
     };
   } catch (error: any) {
+    subscription?.remove();
     return {
       error: createError(error),
     };

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -356,6 +356,7 @@ export const verifyMicrodepositsForSetup = async (
 const eventEmitter = new NativeEventEmitter(NativeModules.StripeSdk);
 let confirmHandlerCallback: EmitterSubscription | null = null;
 let orderTrackingCallbackListener: EmitterSubscription | null = null;
+let financialConnectionsEventListener: EmitterSubscription | null = null;
 
 export const initPaymentSheet = async (
   params: PaymentSheet.SetupParams
@@ -468,9 +469,14 @@ export const collectBankAccountForPayment = async (
   clientSecret: string,
   params: PaymentMethod.CollectBankAccountParams
 ): Promise<CollectBankAccountForPaymentResult> => {
-  const subscription =
-    params.onEvent &&
-    eventEmitter.addListener('onFinancialConnectionsEvent', params.onEvent);
+  financialConnectionsEventListener?.remove();
+
+  if (params.onEvent) {
+    financialConnectionsEventListener = eventEmitter.addListener(
+      'onFinancialConnectionsEvent',
+      params.onEvent
+    );
+  }
 
   try {
     const { paymentIntent, error } = (await NativeStripeSdk.collectBankAccount(
@@ -479,7 +485,7 @@ export const collectBankAccountForPayment = async (
       params
     )) as CollectBankAccountForPaymentResult;
 
-    subscription?.remove();
+    financialConnectionsEventListener?.remove();
 
     if (error) {
       return {
@@ -490,7 +496,7 @@ export const collectBankAccountForPayment = async (
       paymentIntent: paymentIntent!,
     };
   } catch (error: any) {
-    subscription?.remove();
+    financialConnectionsEventListener?.remove();
     return {
       error: createError(error),
     };
@@ -501,9 +507,14 @@ export const collectBankAccountForSetup = async (
   clientSecret: string,
   params: PaymentMethod.CollectBankAccountParams
 ): Promise<CollectBankAccountForSetupResult> => {
-  const subscription =
-    params.onEvent &&
-    eventEmitter.addListener('onFinancialConnectionsEvent', params.onEvent);
+  financialConnectionsEventListener?.remove();
+
+  if (params.onEvent) {
+    financialConnectionsEventListener = eventEmitter.addListener(
+      'onFinancialConnectionsEvent',
+      params.onEvent
+    );
+  }
 
   try {
     const { setupIntent, error } = (await NativeStripeSdk.collectBankAccount(
@@ -512,7 +523,7 @@ export const collectBankAccountForSetup = async (
       params
     )) as CollectBankAccountForSetupResult;
 
-    subscription?.remove();
+    financialConnectionsEventListener?.remove();
 
     if (error) {
       return {
@@ -523,7 +534,7 @@ export const collectBankAccountForSetup = async (
       setupIntent: setupIntent!,
     };
   } catch (error: any) {
-    subscription?.remove();
+    financialConnectionsEventListener?.remove();
     return {
       error: createError(error),
     };
@@ -541,14 +552,20 @@ export const collectBankAccountToken = async (
   clientSecret: string,
   onEvent?: (event: FinancialConnections.FinancialConnectionsEvent) => void
 ): Promise<FinancialConnections.TokenResult> => {
-  const subscription =
-    onEvent && eventEmitter.addListener('onFinancialConnectionsEvent', onEvent);
+  financialConnectionsEventListener?.remove();
+
+  if (onEvent) {
+    financialConnectionsEventListener = eventEmitter.addListener(
+      'onFinancialConnectionsEvent',
+      onEvent
+    );
+  }
 
   try {
     const { session, token, error } =
       await NativeStripeSdk.collectBankAccountToken(clientSecret);
 
-    subscription?.remove();
+    financialConnectionsEventListener?.remove();
 
     if (error) {
       return {
@@ -560,7 +577,7 @@ export const collectBankAccountToken = async (
       token: token!,
     };
   } catch (error: any) {
-    subscription?.remove();
+    financialConnectionsEventListener?.remove();
     return {
       error: createError(error),
     };
@@ -578,14 +595,20 @@ export const collectFinancialConnectionsAccounts = async (
   clientSecret: string,
   onEvent?: (event: FinancialConnections.FinancialConnectionsEvent) => void
 ): Promise<FinancialConnections.SessionResult> => {
-  const subscription =
-    onEvent && eventEmitter.addListener('onFinancialConnectionsEvent', onEvent);
+  financialConnectionsEventListener?.remove();
+
+  if (onEvent) {
+    financialConnectionsEventListener = eventEmitter.addListener(
+      'onFinancialConnectionsEvent',
+      onEvent
+    );
+  }
 
   try {
     const { session, error } =
       await NativeStripeSdk.collectFinancialConnectionsAccounts(clientSecret);
 
-    subscription?.remove();
+    financialConnectionsEventListener?.remove();
 
     if (error) {
       return {
@@ -596,7 +619,7 @@ export const collectFinancialConnectionsAccounts = async (
       session: session!,
     };
   } catch (error: any) {
-    subscription?.remove();
+    financialConnectionsEventListener?.remove();
     return {
       error: createError(error),
     };

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -547,7 +547,7 @@ export const collectBankAccountForSetup = async (
  * Use collectBankAccountToken in the [Add a Financial Connections Account to a US Custom Connect](https://stripe.com/docs/financial-connections/connect-payouts) account flow.
  * When called, it will load the Authentication Flow, an on-page modal UI which allows your user to securely link their external financial account for payouts.
  * @param {string} clientSecret The client_secret of the [Financial Connections Session](https://stripe.com/docs/api/financial_connections/session).
- * @param onEvent An optional event listener to receive @type {FinancialConnectionEvent} for specific events during the process of a user connecting their financial accounts.
+ * @param {CollectBankAccountTokenParams} params Optional parameters.
  * @returns A promise that resolves to an object containing either `session` and `token` fields, or an error field.
  */
 export const collectBankAccountToken = async (
@@ -590,7 +590,7 @@ export const collectBankAccountToken = async (
  * Use collectFinancialConnectionsAccounts in the [Collect an account to build data-powered products](https://stripe.com/docs/financial-connections/other-data-powered-products) flow.
  * When called, it will load the Authentication Flow, an on-page modal UI which allows your user to securely link their external financial account.
  * @param {string} clientSecret The client_secret of the [Financial Connections Session](https://stripe.com/docs/api/financial_connections/session).
- * @param onEvent An optional event listener to receive @type {FinancialConnectionEvent} for specific events during the process of a user connecting their financial accounts.
+ * @param {CollectFinancialConnectionsAccountsParams} params Optional parameters.
  * @returns A promise that resolves to an object containing either a `session` field, or an error field.
  */
 export const collectFinancialConnectionsAccounts = async (

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -38,6 +38,8 @@ import {
   NativeModules,
   EmitterSubscription,
 } from 'react-native';
+import type { CollectFinancialConnectionsAccountsParams } from './types/FinancialConnections';
+import type { CollectBankAccountTokenParams } from './types/PaymentMethod';
 
 export const createPaymentMethod = async (
   params: PaymentMethod.CreateParams,
@@ -550,14 +552,14 @@ export const collectBankAccountForSetup = async (
  */
 export const collectBankAccountToken = async (
   clientSecret: string,
-  onEvent?: (event: FinancialConnections.FinancialConnectionsEvent) => void
+  params: CollectBankAccountTokenParams = {}
 ): Promise<FinancialConnections.TokenResult> => {
   financialConnectionsEventListener?.remove();
 
-  if (onEvent) {
+  if (params.onEvent) {
     financialConnectionsEventListener = eventEmitter.addListener(
       'onFinancialConnectionsEvent',
-      onEvent
+      params.onEvent
     );
   }
 
@@ -593,14 +595,14 @@ export const collectBankAccountToken = async (
  */
 export const collectFinancialConnectionsAccounts = async (
   clientSecret: string,
-  onEvent?: (event: FinancialConnections.FinancialConnectionsEvent) => void
+  params: CollectFinancialConnectionsAccountsParams = {}
 ): Promise<FinancialConnections.SessionResult> => {
   financialConnectionsEventListener?.remove();
 
-  if (onEvent) {
+  if (params.onEvent) {
     financialConnectionsEventListener = eventEmitter.addListener(
       'onFinancialConnectionsEvent',
-      onEvent
+      params.onEvent
     );
   }
 

--- a/src/hooks/useFinancialConnectionsSheet.tsx
+++ b/src/hooks/useFinancialConnectionsSheet.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback } from 'react';
 import { useStripe } from './useStripe';
-import type { FinancialConnections } from 'src/types';
+import type { CollectFinancialConnectionsAccountsParams } from 'src/types/FinancialConnections';
+import type { CollectBankAccountTokenParams } from 'src/types/PaymentMethod';
 
 /**
  * React hook for accessing functions on the Financial Connections sheet.
@@ -14,12 +15,9 @@ export function useFinancialConnectionsSheet() {
     useStripe();
 
   const _collectBankAccountToken = useCallback(
-    async (
-      clientSecret: string,
-      onEvent?: (event: FinancialConnections.FinancialConnectionsEvent) => void
-    ) => {
+    async (clientSecret: string, params?: CollectBankAccountTokenParams) => {
       setLoading(true);
-      const result = await collectBankAccountToken(clientSecret, onEvent);
+      const result = await collectBankAccountToken(clientSecret, params);
       setLoading(false);
       return result;
     },
@@ -29,12 +27,12 @@ export function useFinancialConnectionsSheet() {
   const _collectFinancialConnectionsAccounts = useCallback(
     async (
       clientSecret: string,
-      onEvent?: (event: FinancialConnections.FinancialConnectionsEvent) => void
+      params?: CollectFinancialConnectionsAccountsParams
     ) => {
       setLoading(true);
       const result = await collectFinancialConnectionsAccounts(
         clientSecret,
-        onEvent
+        params
       );
       setLoading(false);
       return result;

--- a/src/hooks/useFinancialConnectionsSheet.tsx
+++ b/src/hooks/useFinancialConnectionsSheet.tsx
@@ -1,5 +1,6 @@
 import { useState, useCallback } from 'react';
 import { useStripe } from './useStripe';
+import type { FinancialConnections } from 'src/types';
 
 /**
  * React hook for accessing functions on the Financial Connections sheet.
@@ -13,9 +14,12 @@ export function useFinancialConnectionsSheet() {
     useStripe();
 
   const _collectBankAccountToken = useCallback(
-    async (clientSecret: string) => {
+    async (
+      clientSecret: string,
+      onEvent?: (event: FinancialConnections.FinancialConnectionsEvent) => void
+    ) => {
       setLoading(true);
-      const result = await collectBankAccountToken(clientSecret);
+      const result = await collectBankAccountToken(clientSecret, onEvent);
       setLoading(false);
       return result;
     },
@@ -23,9 +27,15 @@ export function useFinancialConnectionsSheet() {
   );
 
   const _collectFinancialConnectionsAccounts = useCallback(
-    async (clientSecret: string) => {
+    async (
+      clientSecret: string,
+      onEvent?: (event: FinancialConnections.FinancialConnectionsEvent) => void
+    ) => {
       setLoading(true);
-      const result = await collectFinancialConnectionsAccounts(clientSecret);
+      const result = await collectFinancialConnectionsAccounts(
+        clientSecret,
+        onEvent
+      );
       setLoading(false);
       return result;
     },

--- a/src/hooks/useStripe.tsx
+++ b/src/hooks/useStripe.tsx
@@ -225,17 +225,21 @@ export function useStripe() {
   );
 
   const _collectBankAccountToken = useCallback(
-    async (clientSecret: string): Promise<FinancialConnections.TokenResult> => {
-      return collectBankAccountToken(clientSecret);
+    async (
+      clientSecret: string,
+      onEvent?: (event: FinancialConnections.FinancialConnectionsEvent) => void
+    ): Promise<FinancialConnections.TokenResult> => {
+      return collectBankAccountToken(clientSecret, onEvent);
     },
     []
   );
 
   const _collectFinancialConnectionsAccounts = useCallback(
     async (
-      clientSecret: string
+      clientSecret: string,
+      onEvent?: (event: FinancialConnections.FinancialConnectionsEvent) => void
     ): Promise<FinancialConnections.SessionResult> => {
-      return collectFinancialConnectionsAccounts(clientSecret);
+      return collectFinancialConnectionsAccounts(clientSecret, onEvent);
     },
     []
   );

--- a/src/hooks/useStripe.tsx
+++ b/src/hooks/useStripe.tsx
@@ -60,6 +60,8 @@ import {
   updatePlatformPaySheet,
   openPlatformPaySetup,
 } from '../functions';
+import type { CollectBankAccountTokenParams } from 'src/types/PaymentMethod';
+import type { CollectFinancialConnectionsAccountsParams } from 'src/types/FinancialConnections';
 
 /**
  * useStripe hook
@@ -227,9 +229,9 @@ export function useStripe() {
   const _collectBankAccountToken = useCallback(
     async (
       clientSecret: string,
-      onEvent?: (event: FinancialConnections.FinancialConnectionsEvent) => void
+      params?: CollectBankAccountTokenParams
     ): Promise<FinancialConnections.TokenResult> => {
-      return collectBankAccountToken(clientSecret, onEvent);
+      return collectBankAccountToken(clientSecret, params);
     },
     []
   );
@@ -237,9 +239,9 @@ export function useStripe() {
   const _collectFinancialConnectionsAccounts = useCallback(
     async (
       clientSecret: string,
-      onEvent?: (event: FinancialConnections.FinancialConnectionsEvent) => void
+      params?: CollectFinancialConnectionsAccountsParams
     ): Promise<FinancialConnections.SessionResult> => {
-      return collectFinancialConnectionsAccounts(clientSecret, onEvent);
+      return collectFinancialConnectionsAccounts(clientSecret, params);
     },
     []
   );

--- a/src/types/FinancialConnections.ts
+++ b/src/types/FinancialConnections.ts
@@ -2,6 +2,7 @@ import type { BankAccount } from './Token';
 import type { StripeError } from './Errors';
 
 export type CollectFinancialConnectionsAccountsParams = {
+  /** An optional event listener to receive @type {FinancialConnectionEvent} for specific events during the process of a user connecting their financial accounts. */
   onEvent?: (event: FinancialConnectionsEvent) => void;
 };
 
@@ -130,7 +131,7 @@ export enum FinancialConnectionsSheetError {
 }
 
 export type FinancialConnectionsEvent = {
-  /** The event's name. Represents the type of event that has occurred during the financial connection process. */
+  /** The event's name. Represents the type of event that has occurred during the Financial Connections process. */
   name: FinancialConnectionsEventName;
   /** Event-associated metadata. Provides further detail related to the occurred event. */
   metadata: FinancialConnectionsEventMetadata;

--- a/src/types/FinancialConnections.ts
+++ b/src/types/FinancialConnections.ts
@@ -1,6 +1,10 @@
 import type { BankAccount } from './Token';
 import type { StripeError } from './Errors';
 
+export type CollectFinancialConnectionsAccountsParams = {
+  onEvent?: (event: FinancialConnectionsEvent) => void;
+};
+
 export type SessionResult =
   | {
       /** The updated Financial Connections Session object. */

--- a/src/types/FinancialConnections.ts
+++ b/src/types/FinancialConnections.ts
@@ -124,3 +124,67 @@ export enum FinancialConnectionsSheetError {
   Failed = 'Failed',
   Canceled = 'Canceled',
 }
+
+export type FinancialConnectionsEvent = {
+  /** The event's name. Represents the type of event that has occurred during the financial connection process. */
+  name: FinancialConnectionsEventName;
+  /** Event-associated metadata. Provides further detail related to the occurred event. */
+  metadata: FinancialConnectionsEventMetadata;
+};
+
+export enum FinancialConnectionsEventName {
+  /** Invoked when the sheet successfully opens. */
+  Open = 'open',
+  /** Invoked when the manual entry flow is initiated. */
+  ManualEntryInitiated = 'manual_entry_initiated',
+  /** Invoked when "Agree and continue" is selected on the consent pane. */
+  ConsentAcquired = 'consent_acquired',
+  /** Invoked when the search bar is selected, the user inputs search terms, and receives an API response. */
+  SearchInitiated = 'search_initiated',
+  /** Invoked when an institution is selected, either from featured institutions or search results. */
+  InstitutionSelected = 'institution_selected',
+  /** Invoked when the authorization is successfully completed. */
+  InstitutionAuthorized = 'institution_authorized',
+  /** Invoked when accounts are selected and "confirm" is selected. */
+  AccountsSelected = 'accounts_selected',
+  /** Invoked when the flow is completed and selected accounts are correctly connected to the payment instrument. */
+  Success = 'success',
+  /** Invoked when an error is encountered. Refer to error codes for more details. */
+  Error = 'error',
+  /** Invoked when the flow is cancelled, typically by the user pressing the "X" button. */
+  Cancel = 'cancel',
+  /** Invoked when the modal is launched in an external browser. After this event, no other events will be sent until the completion of the browser session. */
+  FlowLaunchedInBrowser = 'flow_launched_in_browser',
+}
+
+export type FinancialConnectionsEventMetadata = {
+  /** A Boolean value that indicates if the user completed the process through the manual entry flow. */
+  manualEntry?: boolean;
+  /** A String value containing the name of the institution that the user selected. */
+  institutionName?: string;
+  /** An ErrorCode value representing the type of error that occurred. */
+  errorCode?: FinancialConnectionsEventErrorCode;
+};
+
+export enum FinancialConnectionsEventErrorCode {
+  /** The system could not retrieve account numbers for selected accounts. */
+  AccountNumbersUnavailable = 'account_numbers_unavailable',
+  /** The system could not retrieve accounts for the selected institution. */
+  AccountsUnavailable = 'accounts_unavailable',
+  /** For payment flows, no debitable account was available at the selected institution. */
+  NoDebitableAccount = 'no_debitable_account',
+  /** Authorization with the selected institution has failed. */
+  AuthorizationFailed = 'authorization_failed',
+  /** The selected institution is down for expected maintenance. */
+  InstitutionUnavailablePlanned = 'institution_unavailable_planned',
+  /** The selected institution is unexpectedly down. */
+  InstitutionUnavailableUnplanned = 'institution_unavailable_unplanned',
+  /** A timeout occurred while communicating with our partner or downstream institutions. */
+  InstitutionTimeout = 'institution_timeout',
+  /** An unexpected error occurred, either in an API call or on the client-side. */
+  UnexpectedError = 'unexpected_error',
+  /** The client secret that powers the session has expired. */
+  SessionExpired = 'session_expired',
+  /** The hCaptcha challenge failed. */
+  FailedBotDetection = 'failed_bot_detection',
+}

--- a/src/types/PaymentMethod.ts
+++ b/src/types/PaymentMethod.ts
@@ -6,6 +6,7 @@ import type {
 } from './Token';
 import type { FutureUsage } from './PaymentIntent';
 import type { Address, BillingDetails } from './Common';
+import type { FinancialConnectionsEvent } from './FinancialConnections';
 
 export interface Result {
   id: string;
@@ -313,4 +314,5 @@ export type CollectBankAccountParams = {
       email?: string;
     };
   };
+  onEvent?: (event: FinancialConnectionsEvent) => void;
 };

--- a/src/types/PaymentMethod.ts
+++ b/src/types/PaymentMethod.ts
@@ -316,3 +316,7 @@ export type CollectBankAccountParams = {
   };
   onEvent?: (event: FinancialConnectionsEvent) => void;
 };
+
+export type CollectBankAccountTokenParams = {
+  onEvent?: (event: FinancialConnectionsEvent) => void;
+};

--- a/src/types/PaymentMethod.ts
+++ b/src/types/PaymentMethod.ts
@@ -314,9 +314,11 @@ export type CollectBankAccountParams = {
       email?: string;
     };
   };
+  /** An optional event listener to receive @type {FinancialConnectionEvent} for specific events during the process of a user connecting their financial accounts. */
   onEvent?: (event: FinancialConnectionsEvent) => void;
 };
 
 export type CollectBankAccountTokenParams = {
+  /** An optional event listener to receive @type {FinancialConnectionEvent} for specific events during the process of a user connecting their financial accounts. */
   onEvent?: (event: FinancialConnectionsEvent) => void;
 };


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

This pull request adds support for passing an `onEvent` handler to Financial Connections methods, similar to the native Android and iOS SDKs.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a link to the relevant issue, a code snippet, or an example project that demonstrates the bug. -->

[MOBILE_APIREVIEW-117](https://jira.corp.stripe.com/browse/MOBILE_APIREVIEW-117)

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
