### PR TITLE
[git] update secret for docs workflow

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.DOCS_GITHUB_SECRET }}
           publish_dir: ./docs
           commit_message: 'docs: update'
           force_orphan: true


### PR DESCRIPTION
## Summary
new secrets cannot start with `GITHUB_`
