### PR TITLE
Dark mode support in FC: Add style param to Bank Account Collector API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+**Features**
+
+- `StripeFinancialConnections` now supports dark mode on iOS, and will automatically adapt to the device's theme. [Learn more](https://docs.stripe.com/financial-connections/other-data-powered-products?platform=react-native#connections-customize-react-native) about configuring appearance settings.
+
 ## 0.42.0 - 2025-02-25
 
 **Features**

--- a/example/src/screens/ACHPaymentScreen.tsx
+++ b/example/src/screens/ACHPaymentScreen.tsx
@@ -156,7 +156,7 @@ export default function ACHPaymentScreen() {
             email,
           },
         },
-        style: FinancialConnections.FinancialConnectionsStyle.AlwaysLight,
+        style: 'alwaysLight',
         onEvent: onEvent,
       }
     );

--- a/example/src/screens/ACHPaymentScreen.tsx
+++ b/example/src/screens/ACHPaymentScreen.tsx
@@ -156,6 +156,7 @@ export default function ACHPaymentScreen() {
             email,
           },
         },
+        style: FinancialConnections.FinancialConnectionsStyle.AlwaysLight,
         onEvent: onEvent,
       }
     );

--- a/example/src/screens/ACHSetupScreen.tsx
+++ b/example/src/screens/ACHSetupScreen.tsx
@@ -1,4 +1,4 @@
-import { FinancialConnections, SetupIntent } from '@stripe/stripe-react-native';
+import { SetupIntent } from '@stripe/stripe-react-native';
 import React, { useState } from 'react';
 import { Alert, StyleSheet, TextInput, View } from 'react-native';
 import {
@@ -138,7 +138,7 @@ export default function ACHSetupScreen() {
             email,
           },
         },
-        style: FinancialConnections.FinancialConnectionsStyle.Automatic,
+        style: 'automatic',
       }
     );
 

--- a/example/src/screens/ACHSetupScreen.tsx
+++ b/example/src/screens/ACHSetupScreen.tsx
@@ -1,4 +1,4 @@
-import { SetupIntent } from '@stripe/stripe-react-native';
+import { FinancialConnections, SetupIntent } from '@stripe/stripe-react-native';
 import React, { useState } from 'react';
 import { Alert, StyleSheet, TextInput, View } from 'react-native';
 import {
@@ -138,6 +138,7 @@ export default function ACHSetupScreen() {
             email,
           },
         },
+        style: FinancialConnections.FinancialConnectionsStyle.Automatic,
       }
     );
 

--- a/ios/FinancialConnections.swift
+++ b/ios/FinancialConnections.swift
@@ -14,13 +14,15 @@ class FinancialConnections {
     internal static func present(
         withClientSecret: String,
         returnURL: String? = nil,
+        configuration: FinancialConnectionsSheet.Configuration? = nil,
         onEvent: ((FinancialConnectionsEvent) -> Void)? = nil,
         resolve: @escaping RCTPromiseResolveBlock
     ) -> Void {
         DispatchQueue.main.async {
             let financialConnectionsSheet = FinancialConnectionsSheet(
               financialConnectionsSessionClientSecret: withClientSecret,
-              returnURL: returnURL
+              returnURL: returnURL,
+              configuration: configuration ?? .init()
             )
             financialConnectionsSheet.onEvent = onEvent
             financialConnectionsSheet.present(
@@ -41,13 +43,15 @@ class FinancialConnections {
     internal static func presentForToken(
         withClientSecret: String,
         returnURL: String? = nil,
+        configuration: FinancialConnectionsSheet.Configuration? = nil,
         onEvent: ((FinancialConnectionsEvent) -> Void)? = nil,
         resolve: @escaping RCTPromiseResolveBlock
     ) -> Void {
         DispatchQueue.main.async {
             let financialConnectionsSheet = FinancialConnectionsSheet(
               financialConnectionsSessionClientSecret: withClientSecret,
-              returnURL: returnURL
+              returnURL: returnURL,
+              configuration: configuration ?? .init()
             )
             financialConnectionsSheet.onEvent = onEvent
             financialConnectionsSheet.presentForToken(

--- a/ios/StripeSdk.m
+++ b/ios/StripeSdk.m
@@ -170,11 +170,13 @@ RCT_EXTERN_METHOD(
                   )
 RCT_EXTERN_METHOD(
                   collectBankAccountToken:(NSString *)clientSecret
+                  params:(NSDictionary *)params
                   resolver: (RCTPromiseResolveBlock)resolve
                   rejecter: (RCTPromiseRejectBlock)reject
                   )
 RCT_EXTERN_METHOD(
                   collectFinancialConnectionsAccounts:(NSString *)clientSecret
+                  params:(NSDictionary *)params
                   resolver: (RCTPromiseResolveBlock)resolve
                   rejecter: (RCTPromiseRejectBlock)reject
                   )

--- a/ios/StripeSdk.swift
+++ b/ios/StripeSdk.swift
@@ -742,9 +742,26 @@ class StripeSdk: RCTEventEmitter, UIAdaptivePresentationControllerDelegate {
           }
         }
 
+        let style: STPBankAccountCollectorUserInterfaceStyle = {
+          if let styleString = params["style"] as? String {
+            switch styleString {
+            case "always_dark":
+              return .alwaysDark
+            case "always_light":
+              return .alwaysLight
+            default:
+              return .automatic
+            }
+          } else {
+            return .automatic
+          }
+        }()
+
+
         if (isPaymentIntent) {
             DispatchQueue.main.async {
-                STPBankAccountCollector().collectBankAccountForPayment(
+              STPBankAccountCollector(style: style)
+                .collectBankAccountForPayment(
                     clientSecret: clientSecret as String,
                     returnURL: connectionsReturnURL,
                     params: collectParams,
@@ -771,7 +788,8 @@ class StripeSdk: RCTEventEmitter, UIAdaptivePresentationControllerDelegate {
             }
         } else {
             DispatchQueue.main.async {
-                STPBankAccountCollector().collectBankAccountForSetup(
+              STPBankAccountCollector(style: style)
+                .collectBankAccountForSetup(
                     clientSecret: clientSecret as String,
                     returnURL: connectionsReturnURL,
                     params: collectParams,
@@ -1037,9 +1055,10 @@ class StripeSdk: RCTEventEmitter, UIAdaptivePresentationControllerDelegate {
         resolve(["isInWallet": PushProvisioningUtils.getPassLocation(last4: last4) != nil])
     }
 
-    @objc(collectBankAccountToken:resolver:rejecter:)
+  @objc(collectBankAccountToken:params:resolver:rejecter:)
     func collectBankAccountToken(
         clientSecret: String,
+        params: NSDictionary,
         resolver resolve: @escaping RCTPromiseResolveBlock,
         rejecter reject: @escaping RCTPromiseRejectBlock
     ) -> Void {
@@ -1054,7 +1073,26 @@ class StripeSdk: RCTEventEmitter, UIAdaptivePresentationControllerDelegate {
             returnURL = nil
         }
 
+        let configuration: FinancialConnectionsSheet.Configuration = {
+          let style: FinancialConnectionsSheet.Configuration.UserInterfaceStyle = {
+            if let styleString = params["style"] as? String {
+              switch styleString {
+              case "always_dark":
+                return .alwaysDark
+              case "always_light":
+                return .alwaysLight
+              default:
+                return .automatic
+              }
+            } else {
+              return .automatic
+            }
+          }()
+          return FinancialConnectionsSheet.Configuration(style: style)
+        }()
+
         var onEvent: ((FinancialConnectionsEvent) -> Void)? = nil
+
 
         if hasEventListeners {
           onEvent = { [weak self] event in
@@ -1063,12 +1101,19 @@ class StripeSdk: RCTEventEmitter, UIAdaptivePresentationControllerDelegate {
           }
         }
 
-        FinancialConnections.presentForToken(withClientSecret: clientSecret, returnURL: returnURL, onEvent: onEvent, resolve: resolve)
+        FinancialConnections.presentForToken(
+          withClientSecret: clientSecret,
+          returnURL: returnURL,
+          configuration: configuration,
+          onEvent: onEvent,
+          resolve: resolve
+        )
     }
 
-    @objc(collectFinancialConnectionsAccounts:resolver:rejecter:)
+    @objc(collectFinancialConnectionsAccounts:params:resolver:rejecter:)
     func collectFinancialConnectionsAccounts(
         clientSecret: String,
+        params: NSDictionary,
         resolver resolve: @escaping RCTPromiseResolveBlock,
         rejecter reject: @escaping RCTPromiseRejectBlock
     ) -> Void {
@@ -1083,6 +1128,24 @@ class StripeSdk: RCTEventEmitter, UIAdaptivePresentationControllerDelegate {
             returnURL = nil
         }
 
+        let configuration: FinancialConnectionsSheet.Configuration = {
+          let style: FinancialConnectionsSheet.Configuration.UserInterfaceStyle = {
+            if let styleString = params["style"] as? String {
+              switch styleString {
+              case "always_dark":
+                return .alwaysDark
+              case "always_light":
+                return .alwaysLight
+              default:
+                return .automatic
+              }
+            } else {
+              return .automatic
+            }
+          }()
+          return FinancialConnectionsSheet.Configuration(style: style)
+        }()
+
         var onEvent: ((FinancialConnectionsEvent) -> Void)? = nil
 
         if hasEventListeners {
@@ -1092,7 +1155,13 @@ class StripeSdk: RCTEventEmitter, UIAdaptivePresentationControllerDelegate {
           }
         }
 
-        FinancialConnections.present(withClientSecret: clientSecret, returnURL: returnURL, onEvent: onEvent, resolve: resolve)
+        FinancialConnections.present(
+          withClientSecret: clientSecret,
+          returnURL: returnURL,
+          configuration: configuration,
+          onEvent: onEvent,
+          resolve: resolve
+        )
     }
 
     @objc(configureOrderTracking:orderIdentifier:webServiceUrl:authenticationToken:resolver:rejecter:)

--- a/src/NativeStripeSdk.tsx
+++ b/src/NativeStripeSdk.tsx
@@ -33,7 +33,6 @@ import type {
   CustomerPaymentOption,
   CustomerAdapter,
 } from './types';
-import type { CollectBankAccountTokenParams } from 'src/types/PaymentMethod';
 
 type NativeStripeSdkType = {
   initialise(params: InitialiseParams): Promise<void>;
@@ -96,7 +95,7 @@ type NativeStripeSdkType = {
   }): Promise<IsCardInWalletResult>;
   collectBankAccountToken(
     clientSecret: string,
-    params: CollectBankAccountTokenParams
+    params: PaymentMethod.CollectBankAccountTokenParams
   ): Promise<FinancialConnections.TokenResult>;
   collectFinancialConnectionsAccounts(
     clientSecret: string,

--- a/src/NativeStripeSdk.tsx
+++ b/src/NativeStripeSdk.tsx
@@ -33,6 +33,7 @@ import type {
   CustomerPaymentOption,
   CustomerAdapter,
 } from './types';
+import type { CollectBankAccountTokenParams } from 'src/types/PaymentMethod';
 
 type NativeStripeSdkType = {
   initialise(params: InitialiseParams): Promise<void>;
@@ -94,10 +95,12 @@ type NativeStripeSdkType = {
     cardLastFour: string;
   }): Promise<IsCardInWalletResult>;
   collectBankAccountToken(
-    clientSecret: string
+    clientSecret: string,
+    params: CollectBankAccountTokenParams
   ): Promise<FinancialConnections.TokenResult>;
   collectFinancialConnectionsAccounts(
-    clientSecret: string
+    clientSecret: string,
+    params: FinancialConnections.CollectFinancialConnectionsAccountsParams
   ): Promise<FinancialConnections.SessionResult>;
   resetPaymentSheetCustomer(): Promise<null>;
   isPlatformPaySupported(params: {

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -565,7 +565,7 @@ export const collectBankAccountToken = async (
 
   try {
     const { session, token, error } =
-      await NativeStripeSdk.collectBankAccountToken(clientSecret);
+      await NativeStripeSdk.collectBankAccountToken(clientSecret, params);
 
     financialConnectionsEventListener?.remove();
 
@@ -608,7 +608,10 @@ export const collectFinancialConnectionsAccounts = async (
 
   try {
     const { session, error } =
-      await NativeStripeSdk.collectFinancialConnectionsAccounts(clientSecret);
+      await NativeStripeSdk.collectFinancialConnectionsAccounts(
+        clientSecret,
+        params
+      );
 
     financialConnectionsEventListener?.remove();
 

--- a/src/types/Common.ts
+++ b/src/types/Common.ts
@@ -38,3 +38,6 @@ export enum CardBrand {
   Visa = 7,
   Unknown = 8,
 }
+
+/** Theme options for colors used in our UI. */
+export type UserInterfaceStyle = 'alwaysLight' | 'alwaysDark' | 'automatic';

--- a/src/types/FinancialConnections.ts
+++ b/src/types/FinancialConnections.ts
@@ -1,9 +1,10 @@
+import type { UserInterfaceStyle } from './Common';
 import type { BankAccount } from './Token';
 import type { StripeError } from './Errors';
 
 export type CollectFinancialConnectionsAccountsParams = {
-  /** Style options for colors in Financial Connections. By default, the bank account collector will automatically switch between light and dark mode compatible colors based on device settings. */
-  style?: FinancialConnectionsStyle;
+  /** iOS Only. Style options for colors in Financial Connections. By default, the bank account collector will automatically switch between light and dark mode compatible colors based on device settings. */
+  style?: UserInterfaceStyle;
   /** An optional event listener to receive @type {FinancialConnectionEvent} for specific events during the process of a user connecting their financial accounts. */
   onEvent?: (event: FinancialConnectionsEvent) => void;
 };
@@ -194,13 +195,4 @@ export enum FinancialConnectionsEventErrorCode {
   SessionExpired = 'session_expired',
   /** The hCaptcha challenge failed. */
   FailedBotDetection = 'failed_bot_detection',
-}
-
-export enum FinancialConnectionsStyle {
-  /** (default) Financial Connections will automatically switch between light and dark mode compatible colors based on device settings. */
-  Automatic = 'automatic',
-  /** Financial Connections will always use colors appropriate for light mode UI. */
-  AlwaysLight = 'always_light',
-  /** Financial Connections will always use colors appropriate for dark mode UI. */
-  AlwaysDark = 'always_dark',
 }

--- a/src/types/FinancialConnections.ts
+++ b/src/types/FinancialConnections.ts
@@ -2,6 +2,8 @@ import type { BankAccount } from './Token';
 import type { StripeError } from './Errors';
 
 export type CollectFinancialConnectionsAccountsParams = {
+  /** Style options for colors in Financial Connections. By default, the bank account collector will automatically switch between light and dark mode compatible colors based on device settings. */
+  style?: FinancialConnectionsStyle;
   /** An optional event listener to receive @type {FinancialConnectionEvent} for specific events during the process of a user connecting their financial accounts. */
   onEvent?: (event: FinancialConnectionsEvent) => void;
 };
@@ -192,4 +194,13 @@ export enum FinancialConnectionsEventErrorCode {
   SessionExpired = 'session_expired',
   /** The hCaptcha challenge failed. */
   FailedBotDetection = 'failed_bot_detection',
+}
+
+export enum FinancialConnectionsStyle {
+  /** (default) Financial Connections will automatically switch between light and dark mode compatible colors based on device settings. */
+  Automatic = 'automatic',
+  /** Financial Connections will always use colors appropriate for light mode UI. */
+  AlwaysLight = 'always_light',
+  /** Financial Connections will always use colors appropriate for dark mode UI. */
+  AlwaysDark = 'always_dark',
 }

--- a/src/types/PaymentMethod.ts
+++ b/src/types/PaymentMethod.ts
@@ -6,7 +6,10 @@ import type {
 } from './Token';
 import type { FutureUsage } from './PaymentIntent';
 import type { Address, BillingDetails } from './Common';
-import type { FinancialConnectionsEvent } from './FinancialConnections';
+import type {
+  FinancialConnectionsStyle,
+  FinancialConnectionsEvent,
+} from './FinancialConnections';
 
 export interface Result {
   id: string;
@@ -314,11 +317,15 @@ export type CollectBankAccountParams = {
       email?: string;
     };
   };
+  /** Style options for colors in Financial Connections. By default, the bank account collector will automatically switch between light and dark mode compatible colors based on device settings. */
+  style?: FinancialConnectionsStyle;
   /** An optional event listener to receive @type {FinancialConnectionEvent} for specific events during the process of a user connecting their financial accounts. */
   onEvent?: (event: FinancialConnectionsEvent) => void;
 };
 
 export type CollectBankAccountTokenParams = {
+  /** Style options for colors in Financial Connections. By default, the bank account collector will automatically switch between light and dark mode compatible colors based on device settings. */
+  style?: FinancialConnectionsStyle;
   /** An optional event listener to receive @type {FinancialConnectionEvent} for specific events during the process of a user connecting their financial accounts. */
   onEvent?: (event: FinancialConnectionsEvent) => void;
 };

--- a/src/types/PaymentMethod.ts
+++ b/src/types/PaymentMethod.ts
@@ -5,11 +5,8 @@ import type {
   BankAcccountType,
 } from './Token';
 import type { FutureUsage } from './PaymentIntent';
-import type { Address, BillingDetails } from './Common';
-import type {
-  FinancialConnectionsStyle,
-  FinancialConnectionsEvent,
-} from './FinancialConnections';
+import type { Address, BillingDetails, UserInterfaceStyle } from './Common';
+import type { FinancialConnectionsEvent } from './FinancialConnections';
 
 export interface Result {
   id: string;
@@ -317,15 +314,15 @@ export type CollectBankAccountParams = {
       email?: string;
     };
   };
-  /** Style options for colors in Financial Connections. By default, the bank account collector will automatically switch between light and dark mode compatible colors based on device settings. */
-  style?: FinancialConnectionsStyle;
+  /** iOS only. Style options for colors in Financial Connections. By default, the bank account collector will automatically switch between light and dark mode compatible colors based on device settings. */
+  style?: UserInterfaceStyle;
   /** An optional event listener to receive @type {FinancialConnectionEvent} for specific events during the process of a user connecting their financial accounts. */
   onEvent?: (event: FinancialConnectionsEvent) => void;
 };
 
 export type CollectBankAccountTokenParams = {
-  /** Style options for colors in Financial Connections. By default, the bank account collector will automatically switch between light and dark mode compatible colors based on device settings. */
-  style?: FinancialConnectionsStyle;
+  /** iOS only. Style options for colors in Financial Connections. By default, the bank account collector will automatically switch between light and dark mode compatible colors based on device settings. */
+  style?: UserInterfaceStyle;
   /** An optional event listener to receive @type {FinancialConnectionEvent} for specific events during the process of a user connecting their financial accounts. */
   onEvent?: (event: FinancialConnectionsEvent) => void;
 };

--- a/src/types/PaymentSheet.ts
+++ b/src/types/PaymentSheet.ts
@@ -1,4 +1,9 @@
-import type { BillingDetails, AddressDetails, CardBrand } from './Common';
+import type {
+  BillingDetails,
+  AddressDetails,
+  CardBrand,
+  UserInterfaceStyle,
+} from './Common';
 import type { CartSummaryItem } from './ApplePay';
 import type {
   ButtonType,
@@ -23,7 +28,7 @@ export type SetupParamsBase = IntentParams & {
   /** Android only. Enable Google Pay in the Payment Sheet by passing a GooglePayParams object.  */
   googlePay?: GooglePayParams;
   /** The color styling to use for PaymentSheet UI. Defaults to 'automatic'. */
-  style?: 'alwaysLight' | 'alwaysDark' | 'automatic';
+  style?: UserInterfaceStyle;
   /** A URL that redirects back to your app that PaymentSheet can use to auto-dismiss web views used for additional authentication, e.g. 3DS2 */
   returnURL?: string;
   /** Configuration for how billing details are collected during checkout. */


### PR DESCRIPTION
**API Review:** [Dark Mode in FC for React Native](https://docs.google.com/document/d/18K0cu07lVchrDAPaPzEtaCHe2At4H_eXqd2-Op1a7a0/edit?usp=sharing)

## Summary

We recently [shipped](https://groups.google.com/a/stripe.com/d/msgid/connections-shipped/CAHNjHvyduE%3Dwv_UP52PmqV_jT%3DYJ7muT4S-jmXs0nc1EP7qGkQ%40mail.gmail.com) Dark Mode in the native mobile Financial Connections SDKs. This introduced a [new public API](https://docs.google.com/document/d/1pjaQA4LM3NVjC2PFr7_rgGleymHHbE_RTudNEgih5jw/edit?usp=sharing) for configuring the theme, such as specifying always light or always dark mode. We’d like to offer a similar API in our React Native SDK such that our React Native users can make use of this feature.

We’re adding an optional style property to the following models:
- `CollectBankAccountParams`
- `CollectBankAccountTokenParams`
- `CollectFinancialConnectionsAccountsParams`

On those models, the new `style` field is defined as:

```typescript
/** iOS only. Style options for colors in Financial Connections. By default, the bank account collector will automatically switch between light and dark mode compatible colors based on device settings. */
style?: UserInterfaceStyle;
```

And `UserInterfaceStyle` is defined as:

```typescript
/** Theme options for colors used in our UI. */
export type UserInterfaceStyle = 'alwaysLight' | 'alwaysDark' | 'automatic';
```

Subsequently, these params will be passed into the `NativeStripeSdk` equivalent methods, to then be passed into the native SDK.

**This API will only affect iOS.** Following Android platform conventions, if a merchant wants to solely use light or dark mode, we ask them to make use of Android’s `AppCompatDelegate`. Our UI will automatically respect this setting. We will be calling this out in our updated integration docs.

## Testing

Manual testing done. In this video, the first time I open the Financial Connections flow, I have the `style` set to `AlwaysLight` ([set here](https://github.com/stripe/stripe-react-native/pull/1842/files#diff-4795030283e0c6568c45bc964c5b31146f362ae9e8f70d49485f14a7939d6221R159)), and the flow does not switch theme when I switch device themes (using `CMD`+`SHIFT`+`A`). The second flow I open has the `style` set to `Automatic`, and dynamically switches themes as I switch the device theme:

https://github.com/user-attachments/assets/6d90bc61-c69f-4f03-b4e6-c17c45263c62

## Documentation

Our docs [Collect an account to build data-powered products](https://docs.stripe.com/financial-connections/other-data-powered-products?platform=react-native) and [Accept an ACH Direct Debit payment](https://docs.stripe.com/payments/ach-direct-debit/accept-a-payment?web-or-mobile=mobile&payments-ui-type=react-native) will be updated with a new section `Optional  Customize the bank account collector`
