### PR TITLE
Fix example start server on first launch

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -11,10 +11,10 @@
     "ios": "react-native run-ios",
     "mkdist": "node -e \"require('node:fs').mkdirSync('dist', { recursive: true, mode: 0o755 })\"",
     "start": "react-native start",
-    "build:server": "babel --watch server --out-dir ./server-dist --extensions '.ts,.tsx' --ignore '**/__tests__/**' --source-maps --copy-files",
-    "start:server": "yarn build:server & nodemon -w server-dist server-dist/index.js",
+    "build:server": "babel server --out-dir ./server-dist --extensions '.ts,.tsx' --ignore '**/__tests__/**' --source-maps --copy-files",
+    "start:server": "yarn build:server --watch & nodemon -w server-dist server-dist/index.js",
     "typescript": "tsc --noEmit",
-    "postinstall": "patch-package"
+    "postinstall": "patch-package && yarn build:server"
   },
   "dependencies": {
     "@react-native-picker/picker": "^2.11.0",


### PR DESCRIPTION
## Summary

When starting the server the first time in the example app it crashes, because the code hasn't been compiled yet.

This builds the server in postinstall script to make sure the code exists when running the start:server script.

## Motivation

Avoids crashing the first time the server is launched.

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
