### PR TITLE
Upgrade Stripe Android SDK to 21.6.0

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -3,4 +3,4 @@ StripeSdk_compileSdkVersion=30
 StripeSdk_targetSdkVersion=28
 StripeSdk_minSdkVersion=21
 # Keep StripeSdk_stripeVersion in sync with https://github.com/stripe/stripe-identity-react-native/blob/main/android/gradle.properties
-StripeSdk_stripeVersion=20.52.+
+StripeSdk_stripeVersion=21.6.+

--- a/android/src/main/java/com/reactnativestripesdk/PaymentSheetFragment.kt
+++ b/android/src/main/java/com/reactnativestripesdk/PaymentSheetFragment.kt
@@ -38,7 +38,6 @@ import com.stripe.android.ExperimentalAllowsRemovalOfLastSavedPaymentMethodApi
 import com.stripe.android.paymentsheet.CreateIntentCallback
 import com.stripe.android.paymentsheet.CreateIntentResult
 import com.stripe.android.paymentsheet.ExperimentalCustomerSessionApi
-import com.stripe.android.paymentsheet.ExperimentalPaymentMethodLayoutApi
 import com.stripe.android.paymentsheet.PaymentOptionCallback
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetResult
@@ -69,7 +68,6 @@ class PaymentSheetFragment(
     savedInstanceState: Bundle?,
   ): View = FrameLayout(requireActivity()).also { it.visibility = View.GONE }
 
-  @OptIn(ExperimentalPaymentMethodLayoutApi::class)
   override fun onViewCreated(
     view: View,
     savedInstanceState: Bundle?,

--- a/android/src/main/java/com/reactnativestripesdk/utils/Mappers.kt
+++ b/android/src/main/java/com/reactnativestripesdk/utils/Mappers.kt
@@ -427,7 +427,7 @@ internal fun mapFromPaymentMethod(paymentMethod: PaymentMethod): WritableMap {
       )
       it.putString("last4", paymentMethod.usBankAccount?.last4)
       it.putString("bankName", paymentMethod.usBankAccount?.bankName)
-      it.putString("linkedAccount", paymentMethod.usBankAccount?.linkedAccount)
+      it.putString("linkedAccount", paymentMethod.usBankAccount?.financialConnectionsAccount)
       it.putString("fingerprint", paymentMethod.usBankAccount?.fingerprint)
       it.putString("preferredNetworks", paymentMethod.usBankAccount?.networks?.preferred)
       it.putArray(


### PR DESCRIPTION
## Summary
Upgrade Stripe Android SDK to 21.6.0

## Motivation
Allows access to new Android APIs developed since `20.52.+`

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
