### PR TITLE
Fix JS running during presented UI on new arch Android

### DIFF
--- a/android/src/main/java/com/reactnativestripesdk/utils/KeepJsAwakeTask.kt
+++ b/android/src/main/java/com/reactnativestripesdk/utils/KeepJsAwakeTask.kt
@@ -1,0 +1,39 @@
+package com.reactnativestripesdk.utils
+
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.ReactContext
+import com.facebook.react.bridge.UiThreadUtil
+import com.facebook.react.jstasks.HeadlessJsTaskConfig
+import com.facebook.react.jstasks.HeadlessJsTaskContext
+
+/**
+ * When Stripe UI is presented, React Native pauses timers. This will cause issues if we need
+ * to run JS while UI is presented. This starts a HeadlessJsTask to prevent React Native from
+ * pausing timers.
+ */
+internal class KeepJsAwakeTask(
+  private val context: ReactContext,
+) {
+  private var taskId: Int? = null
+
+  fun start() {
+    val headlessJsTaskContext = HeadlessJsTaskContext.getInstance(context)
+    UiThreadUtil.runOnUiThread {
+      val taskConfig =
+        HeadlessJsTaskConfig(
+          "StripeKeepJsAwakeTask",
+          Arguments.createMap(),
+          0,
+          true,
+        )
+      taskId = headlessJsTaskContext.startTask(taskConfig)
+    }
+  }
+
+  fun stop() {
+    val taskId = taskId ?: return
+    val headlessJsTaskContext = HeadlessJsTaskContext.getInstance(context)
+    headlessJsTaskContext.finishTask(taskId)
+    this.taskId = null
+  }
+}

--- a/src/components/CustomerSheet.tsx
+++ b/src/components/CustomerSheet.tsx
@@ -3,8 +3,6 @@ import {
   NativeEventEmitter,
   NativeModules,
   EmitterSubscription,
-  AppRegistry,
-  Platform,
 } from 'react-native';
 import NativeStripeSdk from '../NativeStripeSdk';
 import type {
@@ -15,22 +13,6 @@ import type {
   StripeError,
   CustomerAdapter,
 } from '../types';
-
-// On Android when the activity is paused, JS timers are paused,
-// which causes network requests to hang indefinitely on new arch.
-// To work around this, we register a headless task that will keep
-// the JS runtime running while the customer sheet is open.
-// This task is started and stopped by the native module.
-if (Platform.OS === 'android') {
-  function stripeCustomerSheetHeadlessTask() {
-    return new Promise<void>(() => {});
-  }
-
-  AppRegistry.registerHeadlessTask(
-    'StripeCustomerSheetTask',
-    () => stripeCustomerSheetHeadlessTask
-  );
-}
 
 const eventEmitter = new NativeEventEmitter(NativeModules.StripeSdk);
 let fetchPaymentMethodsCallback: EmitterSubscription | null = null;

--- a/src/components/CustomerSheet.tsx
+++ b/src/components/CustomerSheet.tsx
@@ -3,6 +3,8 @@ import {
   NativeEventEmitter,
   NativeModules,
   EmitterSubscription,
+  AppRegistry,
+  Platform,
 } from 'react-native';
 import NativeStripeSdk from '../NativeStripeSdk';
 import type {
@@ -13,6 +15,22 @@ import type {
   StripeError,
   CustomerAdapter,
 } from '../types';
+
+// On Android when the activity is paused, JS timers are paused,
+// which causes network requests to hang indefinitely on new arch.
+// To work around this, we register a headless task that will keep
+// the JS runtime running while the customer sheet is open.
+// This task is started and stopped by the native module.
+if (Platform.OS === 'android') {
+  function stripeCustomerSheetHeadlessTask() {
+    return new Promise<void>(() => {});
+  }
+
+  AppRegistry.registerHeadlessTask(
+    'StripeCustomerSheetTask',
+    () => stripeCustomerSheetHeadlessTask
+  );
+}
 
 const eventEmitter = new NativeEventEmitter(NativeModules.StripeSdk);
 let fetchPaymentMethodsCallback: EmitterSubscription | null = null;

--- a/src/components/StripeProvider.tsx
+++ b/src/components/StripeProvider.tsx
@@ -4,6 +4,7 @@ import NativeStripeSdk from '../NativeStripeSdk';
 import { isAndroid, shouldAttributeExpo } from '../helpers';
 import type { AppInfo, InitStripeParams, InitialiseParams } from '../types';
 import pjson from '../../package.json';
+import { AppRegistry, Platform } from 'react-native';
 
 const EXPO_PARTNER_ID = 'pp_partner_JBN7LkABco2yUu';
 
@@ -27,6 +28,22 @@ const appInfo: AppInfo = {
 };
 
 export const initStripe = async (params: InitStripeParams): Promise<void> => {
+  // On Android when the activity is paused, JS timers are paused,
+  // which causes network requests to hang indefinitely on new arch.
+  // To work around this, we register a headless task that will keep
+  // the JS runtime running while the Stripe UI is opened.
+  // This task is started and stopped by the native module.
+  if (Platform.OS === 'android') {
+    function stripeHeadlessTask() {
+      return new Promise<void>(() => {});
+    }
+
+    AppRegistry.registerHeadlessTask(
+      'StripeKeepJsAwakeTask',
+      () => stripeHeadlessTask
+    );
+  }
+
   const extendedParams: InitialiseParams = { ...params, appInfo };
   NativeStripeSdk.initialise(extendedParams);
 };


### PR DESCRIPTION
## Summary

I noticed that the customer sheet loads indefinitely when using a `customerAdapter` when the new arch is enabled.

To reproduce in the example app:

Set `newArchEnabled=true` and `bridgelessEnabled=true` in gradle.properties.

Then go to:

Accept a Payment -> Customer Sheet -> Select Use Component -> Edit Payment Methods

This happens because on the new arch with bridgeless enabled, a web like event loop is implemented and used in the fetch implementation. This event loop requires timers to be running to work, but when an activity is paused react native pauses timers. This causes fetch to hang until the customer sheet is closed, so the sheet never loads when using a custom customer adapter.

The best way I found to fix this is to trick react native into not pausing timers by creating a headless js task. This is normally used to execute JS code in the background, but we can use it here to start a task that does nothing to prevent timers from stopping while the customer sheet is visible.

I was considering doing this only on new arch, but it could also help on old arch for example if someone uses setTimeout in the adapter it would also trigger this issue.

Edit: This also happens for deferred intents so I updated this to also fix it.

## Motivation

Fix customer sheet with custom customer adapter on new arch

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
