### PR TITLE
Parse string for updatePaymentMethod when using customerSessions on iOS

### DIFF
--- a/example/src/screens/PaymentsUICompleteScreen.tsx
+++ b/example/src/screens/PaymentsUICompleteScreen.tsx
@@ -141,6 +141,7 @@ export default function PaymentsUICompleteScreen() {
         paymentMethodLayout: PaymentMethodLayout.Automatic,
         removeSavedPaymentMethodMessage: 'remove this payment method?',
         preferredNetworks: [CardBrand.Amex, CardBrand.Visa],
+        updatePaymentMethodEnabled: true,
         ...clientSecretParams,
       });
       if (!error) {

--- a/ios/CustomerSheet/CustomerSheetUtils.swift
+++ b/ios/CustomerSheet/CustomerSheetUtils.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-@_spi(PrivateBetaCustomerSheet) @_spi(STP) import StripePaymentSheet
+@_spi(PrivateBetaCustomerSheet) @_spi(STP) @_spi(UpdatePaymentMethodBeta) import StripePaymentSheet
 
 class CustomerSheetUtils {
     internal class func buildCustomerSheetConfiguration(
@@ -21,6 +21,7 @@ class CustomerSheetUtils {
         defaultBillingDetails: NSDictionary?,
         preferredNetworks: Array<Int>?,
         allowsRemovalOfLastSavedPaymentMethod: Bool?,
+        updatePaymentMethodEnabled: Bool?,
         cardBrandAcceptance: PaymentSheet.CardBrandAcceptance
     ) -> CustomerSheet.Configuration {
         var config = CustomerSheet.Configuration()
@@ -59,10 +60,13 @@ class CustomerSheetUtils {
         if let allowsRemovalOfLastSavedPaymentMethod = allowsRemovalOfLastSavedPaymentMethod {
             config.allowsRemovalOfLastSavedPaymentMethod = allowsRemovalOfLastSavedPaymentMethod
         }
+        if let updatePaymentMethodEnabled = updatePaymentMethodEnabled {
+          config.updatePaymentMethodEnabled = updatePaymentMethodEnabled
+        }
         config.cardBrandAcceptance = cardBrandAcceptance
         return config
     }
-    
+
     internal class func buildStripeCustomerAdapter(
         customerId: String,
         ephemeralKeySecret: String,
@@ -79,7 +83,7 @@ class CustomerSheetUtils {
                 stripeSdk: stripeSdk
             )
         }
-        
+
         if let setupIntentClientSecret = setupIntentClientSecret {
             return StripeCustomerAdapter(
                 customerEphemeralKeyProvider: {
@@ -97,7 +101,7 @@ class CustomerSheetUtils {
             }
         )
     }
-    
+
     internal class func buildCustomerAdapterOverride(
         customerAdapter: NSDictionary,
         customerId: String,
@@ -153,7 +157,7 @@ class CustomerSheetUtils {
         }
     }
 
-    
+
     internal class func buildPaymentOptionResult(label: String, imageData: String?, paymentMethod: STPPaymentMethod?) -> NSMutableDictionary {
         let result: NSMutableDictionary = [:]
         let paymentOption: NSMutableDictionary = [:]
@@ -167,7 +171,7 @@ class CustomerSheetUtils {
         }
         return result
     }
-    
+
     internal class func interpretResult(result: CustomerSheet.CustomerSheetResult) -> NSDictionary {
         var payload: NSMutableDictionary = [:]
         switch result {

--- a/ios/StripeSdk+CustomerSheet.swift
+++ b/ios/StripeSdk+CustomerSheet.swift
@@ -25,6 +25,7 @@ extension StripeSdk {
                 defaultBillingDetails: params["defaultBillingDetails"] as? NSDictionary,
                 preferredNetworks: params["preferredNetworks"] as? Array<Int>,
                 allowsRemovalOfLastSavedPaymentMethod: params["allowsRemovalOfLastSavedPaymentMethod"] as? Bool,
+                updatePaymentMethodEnabled: params["updatePaymentMethodEnabled"] as? Bool,
                 cardBrandAcceptance: computeCardBrandAcceptance(params: params)
             )
         } catch {

--- a/ios/StripeSdk+PaymentSheet.swift
+++ b/ios/StripeSdk+PaymentSheet.swift
@@ -126,7 +126,7 @@ extension StripeSdk {
             configuration.paymentMethodOrder = paymentMethodOrder
         }
 
-      if let updatePaymentMethodEnabled = params["updatePaymentMethodEnabled"] as? Bool {
+        if let updatePaymentMethodEnabled = params["updatePaymentMethodEnabled"] as? Bool {
             configuration.updatePaymentMethodEnabled = updatePaymentMethodEnabled
         }
         switch params["paymentMethodLayout"] as? String? {

--- a/ios/StripeSdk+PaymentSheet.swift
+++ b/ios/StripeSdk+PaymentSheet.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-@_spi(ExperimentalAllowsRemovalOfLastSavedPaymentMethodAPI) @_spi(CustomerSessionBetaAccess) @_spi(STP) import StripePaymentSheet
+@_spi(ExperimentalAllowsRemovalOfLastSavedPaymentMethodAPI) @_spi(CustomerSessionBetaAccess) @_spi(UpdatePaymentMethodBeta) @_spi(STP) import StripePaymentSheet
 
 extension StripeSdk {
     internal func buildPaymentSheetConfiguration(
@@ -126,6 +126,9 @@ extension StripeSdk {
             configuration.paymentMethodOrder = paymentMethodOrder
         }
 
+      if let updatePaymentMethodEnabled = params["updatePaymentMethodEnabled"] as? Bool {
+            configuration.updatePaymentMethodEnabled = updatePaymentMethodEnabled
+        }
         switch params["paymentMethodLayout"] as? String? {
           case "Horizontal":
             configuration.paymentMethodLayout = .horizontal

--- a/src/types/CustomerSheet.ts
+++ b/src/types/CustomerSheet.ts
@@ -47,6 +47,10 @@ export type CustomerSheetInitParams = {
    *  If false, the customer can't delete if they only have one saved payment method remaining.
    */
   allowsRemovalOfLastSavedPaymentMethod?: boolean;
+  /** (Private Preview) This parameter is expected to be removed once we GA this feature
+   * When using customerSessions, allow users to update their saved cards
+   */
+  updatePaymentMethodEnabled?: boolean;
   /**
    * By default, CustomerSheet will accept all supported cards by Stripe.
    * You can specify card brands CustomerSheet should block or allow payment for by providing an array of those card brands.

--- a/src/types/PaymentSheet.ts
+++ b/src/types/PaymentSheet.ts
@@ -84,6 +84,10 @@ export type SetupParamsBase = IntentParams & {
    * Note: Card brand filtering is not currently supported in Link.
    */
   cardBrandAcceptance?: CardBrandAcceptance;
+  /** (Private Preview) This parameter is expected to be removed once we GA this feature
+   * When using customerSessions, allow users to update their saved cards
+   */
+  updatePaymentMethodEnabled?: boolean;
 };
 
 export type SetupParams =


### PR DESCRIPTION
## Summary
Users will use this flag to opt-into update payment method if they've integrated with customerSessions


## Motivation
UpdatePaymentSheet private beta

## Testing
- [x] I tested this manually for payment sheet, but didn't explicitly test for customer sheet -- currently the example app doesn't include customer sessions. Adding that in a follow up PR.
- [ ] I added automated tests

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes
- [x] Will communicate directly with private beta users on how to enable this