### PR TITLE
Fix CI e2e test artifacts upload

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -103,7 +103,8 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: maestro-artifacts-android
-          path: /Users/runner/.maestro/tests/**
+          path: e2e-artifacts
+          include-hidden-files: true
 
   test-ios:
     name: e2e-ios-test
@@ -174,4 +175,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: maestro-artifacts-ios
-          path: /Users/runner/.maestro/tests/**
+          path: e2e-artifacts
+          include-hidden-files: true

--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,6 @@ docs/api-reference/
 
 # Local stripe-android dependency
 example/android/stripe-android
+
+# e2e tests
+e2e-artifacts/

--- a/scripts/run-maestro-tests
+++ b/scripts/run-maestro-tests
@@ -27,15 +27,16 @@ fi
 failedTests=()
 for file in $allTestFiles
 do
-  if ! maestro test "$file" -e APP_ID="$APPID";
+  testCmd="maestro test \"$file\" -e APP_ID=\"$APPID\" --debug-output e2e-artifacts"
+  if ! eval "$testCmd";
   then
     echo "Test ${file} failed. Retrying in 30 seconds..."
     sleep 30
-    if ! maestro test "$file" -e APP_ID="$APPID";
+    if ! eval "$testCmd";
     then
       echo "Test ${file} failed again. Retrying for the last time in 120 seconds..."
       sleep 120
-      if ! maestro test "$file" -e APP_ID="$APPID";
+      if ! eval "$testCmd";
       then
         failedTests+=("$file")
       fi


### PR DESCRIPTION
## Summary

I had some issues debugging e2e ci since artifacts were not available for some reason, this config fixes it.

## Motivation

Make e2e test failures easier to debug.

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
