### PR TITLE
Fix compose views inside react-native-screens fragments

### DIFF
--- a/android/src/main/java/com/reactnativestripesdk/EmbeddedPaymentElementView.kt
+++ b/android/src/main/java/com/reactnativestripesdk/EmbeddedPaymentElementView.kt
@@ -3,7 +3,6 @@ package com.reactnativestripesdk
 import android.content.Context
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.ui.platform.AbstractComposeView
 import androidx.lifecycle.findViewTreeLifecycleOwner
 import androidx.lifecycle.lifecycleScope
 import com.facebook.react.bridge.Arguments
@@ -23,7 +22,7 @@ import toWritableMap
 @OptIn(ExperimentalEmbeddedPaymentElementApi::class)
 class EmbeddedPaymentElementView(
   context: Context,
-) : AbstractComposeView(context) {
+) : StripeAbstractComposeView(context) {
   private sealed interface Event {
     data class Configure(
       val configuration: EmbeddedPaymentElement.Configuration,

--- a/android/src/main/java/com/reactnativestripesdk/EmbeddedPaymentElementViewManager.kt
+++ b/android/src/main/java/com/reactnativestripesdk/EmbeddedPaymentElementViewManager.kt
@@ -2,7 +2,6 @@ package com.reactnativestripesdk
 
 import android.annotation.SuppressLint
 import android.content.Context
-import androidx.compose.ui.platform.ViewCompositionStrategy
 import com.facebook.react.bridge.Dynamic
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
@@ -40,12 +39,13 @@ class EmbeddedPaymentElementViewManager :
 
   override fun getDelegate() = delegate
 
-  override fun createViewInstance(ctx: ThemedReactContext): EmbeddedPaymentElementView =
-    EmbeddedPaymentElementView(ctx).apply {
-      setViewCompositionStrategy(
-        ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed,
-      )
-    }
+  override fun createViewInstance(ctx: ThemedReactContext): EmbeddedPaymentElementView = EmbeddedPaymentElementView(ctx)
+
+  override fun onDropViewInstance(view: EmbeddedPaymentElementView) {
+    super.onDropViewInstance(view)
+
+    view.handleOnDropViewInstance()
+  }
 
   override fun needsCustomLayoutForChildren(): Boolean = true
 

--- a/android/src/main/java/com/reactnativestripesdk/StripeAbstractComposeView.kt
+++ b/android/src/main/java/com/reactnativestripesdk/StripeAbstractComposeView.kt
@@ -1,0 +1,80 @@
+package com.reactnativestripesdk
+
+import android.content.Context
+import androidx.compose.ui.platform.AbstractComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LifecycleRegistry
+import androidx.lifecycle.setViewTreeLifecycleOwner
+import com.facebook.react.bridge.ReactContext
+
+/**
+ * Compose disposes views by default when using Fragments, which is not compatible with how
+ * react-native-screens work. To avoid this we change the composition strategy to use the
+ * activity lifecycle instead of the fragment. Note that `setViewTreeLifecycleOwner` also
+ * needs to be set otherwise a different code path will dispose of the view.
+ *
+ * **IMPORTANT** Views using this will need to call `handleOnDropViewInstance` manually to avoid leaking.
+ * This can be done using the using the following code in the view manager:
+ *
+ * ```
+ * override fun onDropViewInstance(view: SomeStripeAbstractComposeView) {
+ *   super.onDropViewInstance(view)
+ *
+ *   view.handleOnDropViewInstance()
+ * }
+ * ```
+ */
+abstract class StripeAbstractComposeView(
+  context: Context,
+) : AbstractComposeView(context) {
+  private var isLifecycleSetup = false
+
+  // Create a lifecycle this is tied to the activity, but that we can manually
+  // update to DESTROYED state when the view is dropped.
+  private val lifecycleOwner: LifecycleOwner =
+    object : LifecycleOwner {
+      override val lifecycle: Lifecycle get() {
+        return lifecycleRegistry
+      }
+    }
+  private var lifecycleRegistry = LifecycleRegistry(lifecycleOwner)
+
+  init {
+    setViewCompositionStrategy(
+      ViewCompositionStrategy.DisposeOnLifecycleDestroyed(lifecycleOwner = lifecycleOwner),
+    )
+    setViewTreeLifecycleOwner(lifecycleOwner = lifecycleOwner)
+  }
+
+  override fun onAttachedToWindow() {
+    super.onAttachedToWindow()
+
+    if (isLifecycleSetup) {
+      return
+    }
+
+    ((context as? ReactContext)?.currentActivity as? LifecycleOwner?)?.let {
+      isLifecycleSetup = true
+
+      // Setup our lifecycle to match the activity.
+      it.lifecycle.addObserver(
+        object : LifecycleEventObserver {
+          override fun onStateChanged(
+            source: LifecycleOwner,
+            event: Lifecycle.Event,
+          ) {
+            lifecycleRegistry.handleLifecycleEvent(event)
+          }
+        },
+      )
+    }
+  }
+
+  fun handleOnDropViewInstance() {
+    // Update the lifecycle state to DESTROYED to cause the composition to be destroyed.
+    lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY)
+  }
+}

--- a/e2e-tests/android-only/embedded-rnscreens.yml
+++ b/e2e-tests/android-only/embedded-rnscreens.yml
@@ -1,0 +1,13 @@
+# Test that embedded view works when using react-native-screens. This tests pushing a
+# screen on top of the embedded view and making sure it stays visible.
+appId: ${APP_ID}
+---
+- launchApp
+- tapOn: 'Accept a payment'
+- tapOn: 'Prebuilt UI (EmbeddedPaymentElement)'
+- extendedWaitUntil:
+    visible: 'Card'
+    timeout: 150000
+- tapOn: 'Open screen'
+- back
+- assertVisible: 'Card'

--- a/example/src/screens/EmbeddedPaymentElementScreen.tsx
+++ b/example/src/screens/EmbeddedPaymentElementScreen.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react-native/no-inline-styles */
 import React from 'react';
 import { Alert, View, Text } from 'react-native';
 import Button from '../components/Button';
@@ -20,8 +19,11 @@ import {
   AppearanceParams,
   RowStyle,
 } from '@stripe/stripe-react-native';
+import { useNavigation } from '@react-navigation/native';
 
 export default function EmbeddedPaymentElementScreen() {
+  const navigation = useNavigation();
+
   // Local UI state
   const [loading, setLoading] = React.useState(false);
   const [customerKeyType, setCustomerKeyType] = React.useState<
@@ -241,7 +243,21 @@ export default function EmbeddedPaymentElementScreen() {
           setCustomerKeyType(val ? 'customer_session' : 'legacy_ephemeral_key')
         }
       />
-
+      <View style={{ flexDirection: 'row', gap: 20, marginBottom: 10 }}>
+        <Button
+          variant="default"
+          title="Clear"
+          onPress={clearPaymentOption}
+          disabled={!paymentOption}
+        />
+        <Button
+          variant="default"
+          title="Open screen"
+          onPress={() => {
+            navigation.navigate('HomeScreen');
+          }}
+        />
+      </View>
       {loadingError && (
         <View style={{ padding: 12, backgroundColor: '#fee', margin: 8 }}>
           <Text style={{ color: '#900', fontWeight: '600' }}>
@@ -264,12 +280,6 @@ export default function EmbeddedPaymentElementScreen() {
         title="Pay"
         onPress={handlePay}
         loading={loading}
-        disabled={!paymentOption}
-      />
-      <Button
-        variant="default"
-        title="Clear"
-        onPress={clearPaymentOption}
         disabled={!paymentOption}
       />
     </PaymentScreen>


### PR DESCRIPTION
## Summary

This fixes an issue with screens and compose. The issue is described here https://github.com/software-mansion/react-native-screens/issues/2098. Basically if a screen is pushed on top of a view using compose when the screen is dismissed the compose view will disappear.

We can reproduce this issue with our Embedded component in the example app with the "Push screen" button added in this PR. Tap on the button then go back and the Embedded view is no longer visible.

What happens is that react native screens reuses views when a fragment is destroyed, which composes doesn't support by default. So when pushing a new screen the previous screen fragment is destroyed causes the compose view to be disposed. When the fragment is re-created when going back, the disposed compose view is re-used which is not supported.

To fix this we need to avoid dispatching the fragment DESTROY event so the compose view is not disposed. To do this we can create a custom lifecycle that will follow the activity's lifecycle events instead of the fragment's. When the view is actually destroyed by react we can dispatch the DESTROY event manually.

## Motivation

Make embedded view work properly when using react native screens.

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [x] I added automated tests

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
