### PR TITLE
Fix Android `Embedded` calls to native functions

### DIFF
--- a/android/src/main/java/com/reactnativestripesdk/EmbeddedPaymentElementView.kt
+++ b/android/src/main/java/com/reactnativestripesdk/EmbeddedPaymentElementView.kt
@@ -4,8 +4,6 @@ import android.content.Context
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.platform.AbstractComposeView
-import androidx.lifecycle.findViewTreeLifecycleOwner
-import androidx.lifecycle.lifecycleScope
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.ReactContext
 import com.reactnativestripesdk.utils.mapFromPaymentMethod
@@ -17,7 +15,6 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.consumeAsFlow
-import kotlinx.coroutines.launch
 import toWritableMap
 
 @OptIn(ExperimentalEmbeddedPaymentElementApi::class)
@@ -170,22 +167,15 @@ class EmbeddedPaymentElementView(
     config: EmbeddedPaymentElement.Configuration,
     intentConfig: PaymentSheet.IntentConfiguration,
   ) {
-    findViewTreeLifecycleOwner()?.lifecycleScope?.launch {
-      events.send(Event.Configure(config, intentConfig))
-    }
     events.trySend(Event.Configure(config, intentConfig))
   }
 
   fun confirm() {
-    findViewTreeLifecycleOwner()?.lifecycleScope?.launch {
-      events.send(Event.Confirm)
-    }
+    events.trySend(Event.Confirm)
   }
 
   fun clearPaymentOption() {
-    findViewTreeLifecycleOwner()?.lifecycleScope?.launch {
-      events.send(Event.ClearPaymentOption)
-    }
+    events.trySend(Event.ClearPaymentOption)
   }
 
   private fun requireStripeSdkModule() = requireNotNull(reactContext.getNativeModule(StripeSdkModule::class.java))

--- a/android/src/main/java/com/reactnativestripesdk/EmbeddedPaymentElementViewManager.kt
+++ b/android/src/main/java/com/reactnativestripesdk/EmbeddedPaymentElementViewManager.kt
@@ -187,6 +187,14 @@ class EmbeddedPaymentElementViewManager :
     val intentConfig = PaymentSheetFragment.buildIntentConfiguration(toBundleObject(map))
     return intentConfig ?: throw IllegalArgumentException("IntentConfiguration is null")
   }
+
+  override fun confirm(view: EmbeddedPaymentElementView) {
+    view.confirm()
+  }
+
+  override fun clearPaymentOption(view: EmbeddedPaymentElementView) {
+    view.clearPaymentOption()
+  }
 }
 
 /**

--- a/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
+++ b/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
@@ -8,16 +8,12 @@ import androidx.fragment.app.FragmentActivity
 import com.facebook.react.bridge.BaseActivityEventListener
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
-import com.facebook.react.bridge.ReactContext
 import com.facebook.react.bridge.ReactMethod
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.WritableMap
 import com.facebook.react.bridge.WritableNativeMap
-import com.facebook.react.common.annotations.UnstableReactNativeAPI
-import com.facebook.react.fabric.FabricUIManager
 import com.facebook.react.module.annotations.ReactModule
-import com.facebook.react.uimanager.UIManagerHelper
 import com.reactnativestripesdk.addresssheet.AddressLauncherFragment
 import com.reactnativestripesdk.customersheet.CustomerSheetFragment
 import com.reactnativestripesdk.pushprovisioning.PushProvisioningProxy
@@ -1252,7 +1248,7 @@ class StripeSdkModule(
     viewTag: Double,
     promise: Promise,
   ) {
-    performOnEmbeddedView(viewTag.toInt(), promise) { confirm() }
+    // noop, iOS only
   }
 
   @ReactMethod
@@ -1268,7 +1264,7 @@ class StripeSdkModule(
     viewTag: Double,
     promise: Promise,
   ) {
-    performOnEmbeddedView(viewTag.toInt(), promise) { clearPaymentOption() }
+    // noop, iOS only
   }
 
   override fun handleURLCallback(
@@ -1303,36 +1299,6 @@ class StripeSdkModule(
     promise: Promise?,
   ) {
     // noop, iOS only.
-  }
-
-  @OptIn(UnstableReactNativeAPI::class)
-  private fun performOnEmbeddedView(
-    viewTag: Int,
-    promise: Promise,
-    action: EmbeddedPaymentElementView.() -> Unit,
-  ) {
-    val uiManager =
-      UIManagerHelper
-        .getUIManagerForReactTag(
-          reactApplicationContext as ReactContext,
-          viewTag,
-        ) as? FabricUIManager
-        ?: return promise.reject("E_UI_MANAGER", "UIManager not available")
-
-    val block =
-      com.facebook.react.fabric.interop.UIBlock { resolver ->
-        (resolver.resolveView(viewTag) as? EmbeddedPaymentElementView)
-          ?.apply {
-            action()
-            promise.resolve(null)
-          }
-          ?: promise.reject(
-            "E_INVALID_VIEW",
-            "Expected EmbeddedPaymentElementView, got ${resolver.resolveView(viewTag)?.javaClass?.simpleName}",
-          )
-      }
-
-    uiManager.addUIBlock(block)
   }
 
   /**

--- a/android/src/oldarch/java/com/facebook/react/viewmanagers/EmbeddedPaymentElementViewManagerDelegate.java
+++ b/android/src/oldarch/java/com/facebook/react/viewmanagers/EmbeddedPaymentElementViewManagerDelegate.java
@@ -12,6 +12,7 @@ package com.facebook.react.viewmanagers;
 import android.view.View;
 import androidx.annotation.Nullable;
 import com.facebook.react.bridge.DynamicFromObject;
+import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.uimanager.BaseViewManager;
 import com.facebook.react.uimanager.BaseViewManagerDelegate;
 import com.facebook.react.uimanager.LayoutShadowNode;
@@ -31,6 +32,18 @@ public class EmbeddedPaymentElementViewManagerDelegate<T extends View, U extends
         break;
       default:
         super.setProperty(view, propName, value);
+    }
+  }
+
+  @Override
+  public void receiveCommand(T view, String commandName, @Nullable ReadableArray args) {
+    switch (commandName) {
+      case "confirm":
+        mViewManager.confirm(view);
+        break;
+      case "clearPaymentOption":
+        mViewManager.clearPaymentOption(view);
+        break;
     }
   }
 }

--- a/android/src/oldarch/java/com/facebook/react/viewmanagers/EmbeddedPaymentElementViewManagerInterface.java
+++ b/android/src/oldarch/java/com/facebook/react/viewmanagers/EmbeddedPaymentElementViewManagerInterface.java
@@ -16,4 +16,6 @@ import com.facebook.react.uimanager.ViewManagerWithGeneratedInterface;
 public interface EmbeddedPaymentElementViewManagerInterface<T extends View> extends ViewManagerWithGeneratedInterface {
   void setConfiguration(T view, Dynamic value);
   void setIntentConfiguration(T view, Dynamic value);
+  void confirm(T view);
+  void clearPaymentOption(T view);
 }

--- a/src/specs/NativeEmbeddedPaymentElement.ts
+++ b/src/specs/NativeEmbeddedPaymentElement.ts
@@ -7,6 +7,7 @@ import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNati
 import { EmbeddedPaymentElementConfiguration } from '../types/EmbeddedPaymentElement';
 import { IntentConfiguration } from '../types/PaymentSheet';
 import type { UnsafeMixed } from './utils';
+import codegenNativeCommands from 'react-native/Libraries/Utilities/codegenNativeCommands';
 
 type OnEmbeddedPaymentElementDidUpdateHeightEvent = Readonly<{
   height: Double;
@@ -17,6 +18,17 @@ export interface NativeProps extends ViewProps {
   intentConfiguration: UnsafeMixed<IntentConfiguration>;
   onEmbeddedPaymentElementDidUpdateHeight?: DirectEventHandler<OnEmbeddedPaymentElementDidUpdateHeightEvent>;
 }
+
+export interface NativeCommands {
+  confirm: (viewRef: React.ElementRef<HostComponent<NativeProps>>) => void;
+  clearPaymentOption: (
+    viewRef: React.ElementRef<HostComponent<NativeProps>>
+  ) => void;
+}
+
+export const Commands: NativeCommands = codegenNativeCommands<NativeCommands>({
+  supportedCommands: ['confirm', 'clearPaymentOption'],
+});
 
 type ComponentType = HostComponent<NativeProps>;
 

--- a/src/types/EmbeddedPaymentElement.tsx
+++ b/src/types/EmbeddedPaymentElement.tsx
@@ -391,7 +391,7 @@ export function useEmbeddedPaymentElement(
       return (
         <NativeEmbeddedPaymentElement
           ref={viewRef}
-          style={[{ width: '100%', height: '100%' }]}
+          style={[{ width: '100%', height: height }]}
           configuration={configuration}
           intentConfiguration={intentConfig}
         />


### PR DESCRIPTION
## Summary
Fix Android `Embedded` calls to native functions

## Motivation
While working on the height solution for Embedded RN, I noticed that the calls to `confirm` and `clearPaymentOption` did not execute. This PR fixes that so the calls go through.

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
