### PR TITLE
Fix compose views inside react-native Modal

### DIFF
--- a/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
+++ b/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
@@ -6,6 +6,7 @@ import android.app.Application
 import android.content.Intent
 import android.os.Bundle
 import android.util.Log
+import android.view.ViewGroup
 import androidx.fragment.app.FragmentActivity
 import com.facebook.react.bridge.BaseActivityEventListener
 import com.facebook.react.bridge.Promise
@@ -13,6 +14,7 @@ import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactMethod
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.bridge.UiThreadUtil
 import com.facebook.react.bridge.WritableMap
 import com.facebook.react.bridge.WritableNativeMap
 import com.facebook.react.module.annotations.ReactModule
@@ -90,6 +92,8 @@ class StripeSdkModule(
   private var customerSheetFragment: CustomerSheetFragment? = null
 
   internal var embeddedIntentCreationCallback = CompletableDeferred<ReadableMap>()
+
+  internal var composeCompatView: StripeAbstractComposeView.CompatView? = null
 
   // If you create a new Fragment, you must put the tag here, otherwise result callbacks for that
   // Fragment will not work on RN < 0.65
@@ -216,6 +220,7 @@ class StripeSdkModule(
     PaymentConfiguration.init(reactApplicationContext, publishableKey, stripeAccountId)
 
     preventActivityRecreation()
+    setupComposeCompatView()
 
     promise.resolve(null)
   }
@@ -1364,6 +1369,16 @@ class StripeSdkModule(
    */
   private fun preventActivityRecreation() {
     currentActivity?.application?.registerActivityLifecycleCallbacks(activityLifecycleCallbacks)
+  }
+
+  private fun setupComposeCompatView() {
+    UiThreadUtil.runOnUiThread {
+      composeCompatView = composeCompatView ?: StripeAbstractComposeView.CompatView(context = reactApplicationContext).also {
+        currentActivity?.findViewById<ViewGroup>(android.R.id.content)?.addView(
+          it,
+        )
+      }
+    }
   }
 
   companion object {

--- a/e2e-tests/android-only/embedded-rn-compose.yml
+++ b/e2e-tests/android-only/embedded-rn-compose.yml
@@ -12,5 +12,5 @@ appId: ${APP_ID}
 - assertVisible: 'Card'
 - tapOn: 'Open modal'
 - assertVisible: 'Card'
-- tapOn: 'Close modal'
+- back
 - assertVisible: 'Card'

--- a/e2e-tests/android-only/embedded-rn-compose.yml
+++ b/e2e-tests/android-only/embedded-rn-compose.yml
@@ -1,5 +1,4 @@
-# Test that embedded view works when using react-native-screens. This tests pushing a
-# screen on top of the embedded view and making sure it stays visible.
+# Test that interactions between Compose and React Native work as expected.
 appId: ${APP_ID}
 ---
 - launchApp
@@ -10,4 +9,8 @@ appId: ${APP_ID}
     timeout: 150000
 - tapOn: 'Open screen'
 - back
+- assertVisible: 'Card'
+- tapOn: 'Open modal'
+- assertVisible: 'Card'
+- tapOn: 'Close modal'
 - assertVisible: 'Card'


### PR DESCRIPTION
## Summary

Android Dialog class, which react-native modal uses doesn't propagate the context that compose needs to work. Usually the context would be created, but because react-native tries to measure the compose view before it is attached to the window it crashes.

To avoid this we can create the context compose needs (by creating a dummy compose view) when initializing the stripe sdk and attaching the context from that view on our compose views.

## Motivation

Allow using compose views inside of modals.

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [x] I added automated tests

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
