### PR TITLE
Fix embedded on Android new arch

### DIFF
--- a/android/src/main/java/com/reactnativestripesdk/utils/KeepJsAwakeTask.kt
+++ b/android/src/main/java/com/reactnativestripesdk/utils/KeepJsAwakeTask.kt
@@ -1,7 +1,7 @@
 package com.reactnativestripesdk.utils
 
 import com.facebook.react.bridge.Arguments
-import com.facebook.react.bridge.ReactContext
+import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.UiThreadUtil
 import com.facebook.react.jstasks.HeadlessJsTaskConfig
 import com.facebook.react.jstasks.HeadlessJsTaskContext
@@ -12,7 +12,7 @@ import com.facebook.react.jstasks.HeadlessJsTaskContext
  * pausing timers.
  */
 internal class KeepJsAwakeTask(
-  private val context: ReactContext,
+  private val context: ReactApplicationContext,
 ) {
   private var taskId: Int? = null
 


### PR DESCRIPTION
## Summary

This adds a KeepJsAwakeTask call to make sure JS can execute while Embedded Card sheet is presented. This is needed on new arch.

## Motivation

Fix Embedded on Android with new arch.

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
