### PR TITLE
Support dynamic height for Embedded on Android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -235,4 +235,5 @@ dependencies {
   androidTestImplementation "org.mockito:mockito-core:3.+"
 
   implementation "androidx.compose.ui:ui:1.7.8"
+  implementation "androidx.compose.foundation:foundation-layout:1.7.8"
 }

--- a/android/src/main/java/com/reactnativestripesdk/EmbeddedPaymentElementView.kt
+++ b/android/src/main/java/com/reactnativestripesdk/EmbeddedPaymentElementView.kt
@@ -12,7 +12,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.layout
 import androidx.compose.ui.layout.onPlaced
-import androidx.compose.ui.platform.AbstractComposeView
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
@@ -178,14 +177,13 @@ class EmbeddedPaymentElementView(
             layout(constraints.maxWidth, minIntrinsicHeight) {
               measurable.measure(constraints).placeRelative(IntOffset.Zero)
             }
-          }
-          .onPlaced {
+          }.onPlaced {
             reportHeightChange(
               with(density) {
                 height.toDp().value
-              }
+              },
             )
-          }
+          },
     ) {
       embedded.Content()
     }

--- a/android/src/main/java/com/reactnativestripesdk/EmbeddedPaymentElementView.kt
+++ b/android/src/main/java/com/reactnativestripesdk/EmbeddedPaymentElementView.kt
@@ -1,8 +1,21 @@
 package com.reactnativestripesdk
 
 import android.content.Context
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.requiredHeight
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.layout
+import androidx.compose.ui.layout.onPlaced
+import androidx.compose.ui.platform.AbstractComposeView
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.ReactContext
 import com.reactnativestripesdk.utils.mapFromPaymentMethod
@@ -98,6 +111,9 @@ class EmbeddedPaymentElementView(
   @Composable
   override fun Content() {
     val embedded = rememberEmbeddedPaymentElement(builder)
+    var height by remember {
+      mutableIntStateOf(0)
+    }
 
     // collect events: configure, confirm, clear
     LaunchedEffect(Unit) {
@@ -112,9 +128,7 @@ class EmbeddedPaymentElementView(
               )
 
             when (result) {
-              is EmbeddedPaymentElement.ConfigureResult.Succeeded -> {
-                reportHeightChange(450)
-              }
+              is EmbeddedPaymentElement.ConfigureResult.Succeeded -> reportHeightChange(1f)
               is EmbeddedPaymentElement.ConfigureResult.Failed -> {
                 // send the error back to JS
                 val err = result.error
@@ -150,13 +164,37 @@ class EmbeddedPaymentElementView(
       }
     }
 
-    embedded.Content()
+    val density = LocalDensity.current
+
+    Box(
+      modifier =
+        Modifier
+          .requiredHeight(height.dp)
+          .layout { measurable, constraints ->
+            val minIntrinsicHeight = measurable.minIntrinsicHeight(constraints.maxWidth)
+
+            height = minIntrinsicHeight
+
+            layout(constraints.maxWidth, minIntrinsicHeight) {
+              measurable.measure(constraints).placeRelative(IntOffset.Zero)
+            }
+          }
+          .onPlaced {
+            reportHeightChange(
+              with(density) {
+                height.toDp().value
+              }
+            )
+          }
+    ) {
+      embedded.Content()
+    }
   }
 
-  private fun reportHeightChange(height: Int) {
+  private fun reportHeightChange(height: Float) {
     val params =
       Arguments.createMap().apply {
-        putInt("height", height)
+        putDouble("height", height.toDouble())
       }
     requireStripeSdkModule().emitEmbeddedPaymentElementDidUpdateHeight(params)
   }

--- a/src/types/EmbeddedPaymentElement.tsx
+++ b/src/types/EmbeddedPaymentElement.tsx
@@ -365,14 +365,14 @@ export function useEmbeddedPaymentElement(
       'embeddedPaymentElementDidUpdateHeight',
       ({ height: h }) => {
         // ignore zero
-        if (h > 0) {
+        if (h > 0 || (isAndroid && h === 0)) {
           LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
           setHeight(h);
         }
       }
     );
     return () => sub.remove();
-  }, []);
+  }, [isAndroid]);
 
   // Listen for loading failures
   useEffect(() => {


### PR DESCRIPTION
## Summary
Support dynamic height for Embedded on Android.

## Motivation
Ensure `Embedded` reacts properly for height changes on Android for React Native.

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
