### PR TITLE
Deploy script fixes

### DIFF
--- a/scripts/publish
+++ b/scripts/publish
@@ -51,14 +51,14 @@ Please [see the changelog](https://github.com/stripe/stripe-react-native/blob/ma
 EOF
 )"
 
-  if which hub | grep -q "not found"; then
-    create_github_release_fallback "$release_notes"
-  else
+  if command -v hub >/dev/null 2>&1; then
     local current_version=${version_and_date% -*}
     echo "Creating GitHub release for tag: v$current_version"
     echo ""
     echo -n "    "
     hub release create -em "$release_notes" "v$current_version"
+  else
+    create_github_release_fallback "$release_notes"
   fi
 }
 
@@ -126,24 +126,25 @@ if ! grep -q 'working tree clean' <<< "$GIT_STATUS"; then
 fi
 
 echo "Installing dependencies according to lockfile"
-yarn -s install --frozen-lockfile
+yarn install --frozen-lockfile
 
 echo "Running tests"
-yarn -s run test
+yarn run test
 
 BRANCH_NAME=release-branch-$RANDOM
 git checkout -b "$BRANCH_NAME"
 
 echo "Bumping package.json $RELEASE_TYPE version and tagging commit"
-yarn -s version --"$RELEASE_TYPE"
+yarn version --"$RELEASE_TYPE"
 
 echo "Publishing release"
-yarn -s --ignore-scripts publish --non-interactive --access=public
+yarn --ignore-scripts publish --non-interactive --access=public
 echo "Published to npm!"
 
 echo "Pushing git commit and tag"
 git push -u origin "$BRANCH_NAME" --follow-tags
 
+echo ""
 echo "Tag pushed! Please open a PR for your version bump: https://github.com/stripe/stripe-react-native/pulls"
 echo ""
 


### PR DESCRIPTION
## Summary

We've had issues with the deploy script. The yarn commands pass the -s flag for silent, but this swallows all error output which makes debugging failures very hard. For example if a tag already exists the script would just exit before with no output. This also fixes the `hub` check, before it would exit the script since we're using these `set -euo pipefail` bash flags if hub is not installed.

## Motivation

Make deploy failures easier to debug.

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
