### PR TITLE
Run e2e CI on both new and old arch

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -10,8 +10,12 @@ jobs:
   test-android:
     name: e2e-android-test
     runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        react_arch: [old_arch, new_arch]
     env:
       MAESTRO_CLI_ANALYSIS_NOTIFICATION_DISABLED: true
+      NEW_ARCH_ENABLED: ${{ matrix.react_arch == 'new_arch' }}
     steps:
       - name: Delete unnecessary tools 🔧
         uses: jlumbroso/free-disk-space@v1.3.1
@@ -53,9 +57,6 @@ jobs:
         with:
           node-version: 20
 
-      - name: Install React Native CLI
-        run: npm install react-native-cli
-
       - name: Install Dependencies
         run: yarn bootstrap-no-pods
 
@@ -74,10 +75,9 @@ jobs:
           key: gradle-${{ runner.os }}-${{ hashFiles('**/*.gradle*') }}-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}-${{ hashFiles('**/buildSrc/**/*.kt') }}
 
       - name: Install Maestro CLI
-        run: curl -Ls "https://get.maestro.mobile.dev" | bash
-
-      - name: Add Maestro to path
-        run: echo "${HOME}/.maestro/bin" >> $GITHUB_PATH
+        run: |
+          curl -Ls "https://get.maestro.mobile.dev" | bash
+          echo "${HOME}/.maestro/bin" >> $GITHUB_PATH
 
       - name: Run Android Emulator and app
         uses: reactivecircus/android-emulator-runner@v2
@@ -95,14 +95,14 @@ jobs:
             # Wait for system to settle
             adb wait-for-device shell 'while [[ -z $(getprop sys.boot_completed) ]]; do sleep 1; done'
             # Retry once if necessary
-            yarn run-example-android:release || (sleep 60 && yarn run-example-android:release)
+            yarn run-example-android:release --extra-params="-PnewArchEnabled=$NEW_ARCH_ENABLED" || (sleep 60 && yarn run-example-android:release --extra-params="-PnewArchEnabled=$NEW_ARCH_ENABLED")
             yarn test:e2e:android
 
       - name: Upload test artifacts
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: maestro-artifacts-android
+          name: maestro-artifacts-android-${{ matrix.react_arch }}
           path: e2e-artifacts
           include-hidden-files: true
 
@@ -110,9 +110,13 @@ jobs:
     name: e2e-ios-test
     # Silicon chips run through the iOS tests much faster
     runs-on: macos-15-xlarge
+    strategy:
+      matrix:
+        react_arch: [old_arch, new_arch]
     env:
       MAESTRO_DRIVER_STARTUP_TIMEOUT: 300_000 # 5 minutes
       MAESTRO_CLI_ANALYSIS_NOTIFICATION_DISABLED: true
+      NEW_ARCH_ENABLED: ${{ matrix.react_arch == 'new_arch' }}
     steps:
       - name: checkout
         uses: actions/checkout@v4
@@ -141,9 +145,6 @@ jobs:
         with:
           node-version: 20
 
-      - name: Install React Native CLI
-        run: npm install react-native-cli
-
       - name: Install Dependencies
         run: yarn bootstrap-no-pods
 
@@ -156,11 +157,7 @@ jobs:
       - name: Install Maestro CLI
         run: |
           curl -Ls "https://get.maestro.mobile.dev" | bash
-          brew tap facebook/fb
-          brew install facebook/fb/idb-companion
-
-      - name: Add Maestro to path
-        run: echo "${HOME}/.maestro/bin" >> $GITHUB_PATH
+          echo "${HOME}/.maestro/bin" >> $GITHUB_PATH
 
       - name: Build iOS App
         run: |
@@ -174,6 +171,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: maestro-artifacts-ios
+          name: maestro-artifacts-ios-${{ matrix.react_arch }}
           path: e2e-artifacts
           include-hidden-files: true

--- a/e2e-tests/rn-arch.yml
+++ b/e2e-tests/rn-arch.yml
@@ -1,0 +1,16 @@
+# Validates that we are testing the correct react architecture.
+appId: ${APP_ID}
+---
+- launchApp
+- runFlow:
+    when:
+      true: ${NEW_ARCH == 'true'}
+    commands:
+      - assertVisible: 'New arch enabled: true'
+      - assertVisible: 'Bridgeless enabled: true'
+- runFlow:
+    when:
+      true: ${NEW_ARCH == 'false'}
+    commands:
+      - assertVisible: 'New arch enabled: false'
+      - assertVisible: 'Bridgeless enabled: false'

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -40,8 +40,8 @@ reactNativeArchitectures=armeabi-v7a,arm64-v8a,x86,x86_64
 # to write custom TurboModules/Fabric components OR use libraries that
 # are providing them.
 # Note that this is incompatible with web debugging.
-newArchEnabled=false
-bridgelessEnabled=false
+newArchEnabled=true
+bridgelessEnabled=true
 
 # Uncomment the line below to build React Native from source.
 #react.buildFromSource=true

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -6,9 +6,11 @@ require "#{ws_dir}/node_modules/react-native-test-app/test_app.rb"
 
 workspace 'example.xcworkspace'
 
+new_arch_enabled = ENV['NEW_ARCH_ENABLED'].nil? ? true : ENV['NEW_ARCH_ENABLED'] == 'true'
+
 options = {
-  :bridgeless_enabled => false,
-  :fabric_enabled => false,
+  :bridgeless_enabled => new_arch_enabled,
+  :fabric_enabled =>  new_arch_enabled,
   :hermes_enabled => true,
 }
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1239,7 +1239,71 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
   - react-native-safe-area-context (5.2.0):
+    - DoubleConversion
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.11.18.00)
+    - RCTRequired
+    - RCTTypeSafety
     - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - react-native-safe-area-context/common (= 5.2.0)
+    - react-native-safe-area-context/fabric (= 5.2.0)
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - Yoga
+  - react-native-safe-area-context/common (5.2.0):
+    - DoubleConversion
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.11.18.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - Yoga
+  - react-native-safe-area-context/fabric (5.2.0):
+    - DoubleConversion
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.11.18.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - react-native-safe-area-context/common
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - Yoga
   - React-NativeModulesApple (0.78.0):
     - glog
     - hermes-engine
@@ -1542,6 +1606,7 @@ PODS:
     - React-graphics
     - React-ImageManager
     - React-NativeModulesApple
+    - React-RCTAppDelegate
     - React-RCTFabric
     - React-rendererdebug
     - React-utils
@@ -1554,8 +1619,50 @@ PODS:
     - React-jsi
   - ReactTestApp-Resources (1.0.0-dev)
   - RNCPicker (2.11.0):
+    - DoubleConversion
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.11.18.00)
+    - RCTRequired
+    - RCTTypeSafety
     - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - Yoga
   - RNScreens (4.9.1):
+    - DoubleConversion
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.11.18.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-RCTImage
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - RNScreens/common (= 4.9.1)
+    - Yoga
+  - RNScreens/common (4.9.1):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1585,21 +1692,87 @@ PODS:
     - StripePaymentsUI (= 24.12.0)
     - StripeUICore (= 24.12.0)
   - stripe-react-native (0.44.0):
+    - DoubleConversion
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.11.18.00)
+    - RCTRequired
+    - RCTTypeSafety
     - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - Stripe (~> 24.12.0)
+    - stripe-react-native/NewArch (= 0.44.0)
+    - StripeApplePay (~> 24.12.0)
+    - StripeFinancialConnections (~> 24.12.0)
+    - StripePayments (~> 24.12.0)
+    - StripePaymentSheet (~> 24.12.0)
+    - StripePaymentsUI (~> 24.12.0)
+    - Yoga
+  - stripe-react-native/NewArch (0.44.0):
+    - DoubleConversion
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.11.18.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
     - Stripe (~> 24.12.0)
     - StripeApplePay (~> 24.12.0)
     - StripeFinancialConnections (~> 24.12.0)
     - StripePayments (~> 24.12.0)
     - StripePaymentSheet (~> 24.12.0)
     - StripePaymentsUI (~> 24.12.0)
+    - Yoga
   - stripe-react-native/Tests (0.44.0):
+    - DoubleConversion
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.11.18.00)
+    - RCTRequired
+    - RCTTypeSafety
     - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
     - Stripe (~> 24.12.0)
     - StripeApplePay (~> 24.12.0)
     - StripeFinancialConnections (~> 24.12.0)
     - StripePayments (~> 24.12.0)
     - StripePaymentSheet (~> 24.12.0)
     - StripePaymentsUI (~> 24.12.0)
+    - Yoga
   - StripeApplePay (24.12.0):
     - StripeCore (= 24.12.0)
   - StripeCore (24.12.0)
@@ -1901,16 +2074,16 @@ SPEC CHECKSUMS:
   React-logger: 018826bfd51b9f18e87f67db1590bc510ad20664
   React-Mapbuffer: 3c11cee7737609275c7b66bd0b1de475f094cedf
   React-microtasksnativemodule: 843f352b32aacbe13a9c750190d34df44c3e6c2c
-  react-native-safe-area-context: 3e33e7c43c8b74dba436a5a32651cb8d7064c740
+  react-native-safe-area-context: 7e513d737b0b5c1d10bbe0e5fcc9f925a7be144c
   React-NativeModulesApple: 88433b6946778bea9c153e27b671de15411bf225
   React-perflogger: 9e8d3c0dc0194eb932162812a168aa5dc662f418
   React-performancetimeline: 5a2d6efef52bdcefac079c7baa30934978acd023
   React-RCTActionSheet: 592674cf61142497e0e820688f5a696e41bf16dd
   React-RCTAnimation: e6d669872f9b3b4ab9527aab283b7c49283236b7
-  React-RCTAppDelegate: 1768f69e774410cbd0716465db9494acc823a63a
+  React-RCTAppDelegate: de2343fe08be4c945d57e0ecce44afcc7dd8fc03
   React-RCTBlob: 3e2dce94c56218becc4b32b627fc2293149f798d
-  React-RCTFabric: 4dd8a0d13c5e15acc48fac2996a7ef76fc7c5e6a
-  React-RCTFBReactNativeSpec: b2aeef7ea8755ddfdf0c6ca1363ff6766a91080f
+  React-RCTFabric: cac2c033381d79a5956e08550b0220cb2d78ea93
+  React-RCTFBReactNativeSpec: d10ca5e0ccbfeac8c047361fedf8e4ac653887b6
   React-RCTImage: dc04b176c022d12a8f55ae7a7279b1e091066ae0
   React-RCTLinking: 88f5e37fe4f26fbc80791aa2a5f01baf9b9a3fd5
   React-RCTNetwork: f213693565efbd698b8e9c18d700a514b49c0c8e
@@ -1930,14 +2103,14 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: a1fb08dfdc7ebc387b2e54cfc9decd283ed821d8
   ReactCodegen: 008c319179d681a6a00966edfc67fda68f9fbb2e
   ReactCommon: 0c097b53f03d6bf166edbcd0915da32f3015dd90
-  ReactNativeHost: e147df87506869f1e9d877f133fdb4c67e742eb7
+  ReactNativeHost: 2503667b2e20fff53f55c4f85d9c7e66e0f3d702
   ReactTestApp-DevSupport: 881bdd4c9f703cf611e46715b8a5f27b2ff15e5d
   ReactTestApp-Resources: 49fb7249af8203b9c74fd85de8c6f5bbb77a41df
-  RNCPicker: 124b4fb5859ba1a3fd53a91e16d1e7a0fc016e59
-  RNScreens: c11a9eb1e6df43890cd572ba68805b123defe8d1
+  RNCPicker: cfb51a08c6e10357d9a65832e791825b0747b483
+  RNScreens: 0d4cb9afe052607ad0aa71f645a88bb7c7f2e64c
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Stripe: ddb4645ea7f46475ce790b4a6c6475ec3e45bfd4
-  stripe-react-native: 2f2d1997a1724ea0c89cb69b5e01c0a5ee03e7ca
+  stripe-react-native: 340a5df47d71f472b25045aacef68fa4f0b69378
   StripeApplePay: ab8fc9905220fe4d5a46fd8b790065982bbfbad8
   StripeCore: 1c40a6b42a385bf96d051a6184dd3969b9ab3174
   StripeFinancialConnections: 4c5c2136191e0a385332eb59566f9b966d40a660
@@ -1947,6 +2120,6 @@ SPEC CHECKSUMS:
   StripeUICore: 0e0f3005fd3027dad3d3d77927f371d5fe4eb9ac
   Yoga: 9b7fb56e7b08cde60e2153344fa6afbd88e5d99f
 
-PODFILE CHECKSUM: 07143717076b55d29f3c245358c0026c3df220ef
+PODFILE CHECKSUM: a2ed964678852d4cc306ff4add3e4fa90be77ea6
 
 COCOAPODS: 1.16.2

--- a/example/src/screens/HomeScreen.tsx
+++ b/example/src/screens/HomeScreen.tsx
@@ -8,6 +8,7 @@ import {
   ScrollView,
   Platform,
   Alert,
+  Text,
 } from 'react-native';
 import { colors } from '../colors';
 import Button from '../components/Button';
@@ -432,6 +433,15 @@ export default function HomeScreen() {
           </View>
         </>
       </Collapse>
+      <View style={styles.infoContainer}>
+        <Text style={styles.infoText}>
+          New arch enabled:{' '}
+          {(global as any).nativeFabricUIManager ? 'true' : 'false'}
+        </Text>
+        <Text style={styles.infoText}>
+          Bridgeless enabled: {(global as any).RN$Bridgeless ? 'true' : 'false'}
+        </Text>
+      </View>
     </ScrollView>
   );
 }
@@ -445,5 +455,12 @@ const styles = StyleSheet.create({
     paddingVertical: 8,
     borderBottomColor: colors.light_gray,
     borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  infoContainer: {
+    padding: 16,
+    gap: 4,
+  },
+  infoText: {
+    fontSize: 12,
   },
 });

--- a/scripts/run-maestro-tests
+++ b/scripts/run-maestro-tests
@@ -28,7 +28,7 @@ failedTests=()
 for file in $allTestFiles
 do
   testName=$(basename "${file%.*}")
-  testCmd="maestro test \"$file\" -e APP_ID=\"$APPID\" --flatten-debug-output"
+  testCmd="maestro test \"$file\" -e APP_ID=\"$APPID\" -e NEW_ARCH=\"$RCT_NEW_ARCH_ENABLED\" --flatten-debug-output"
   if ! eval "$testCmd --debug-output e2e-artifacts/$testName";
   then
     echo "Test ${file} failed. Retrying in 30 seconds..."


### PR DESCRIPTION
## Summary

Run e2e test on both old arch and new arch.

This also switches the example app to new arch by default.

## Motivation

Improve test coverage of new arch.

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [ ] I tested this manually
- [x] I added automated tests

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
