### PR TITLE
Improve e2e tests artifacts

### DIFF
--- a/scripts/run-maestro-tests
+++ b/scripts/run-maestro-tests
@@ -27,16 +27,17 @@ fi
 failedTests=()
 for file in $allTestFiles
 do
-  testCmd="maestro test \"$file\" -e APP_ID=\"$APPID\" --debug-output e2e-artifacts"
-  if ! eval "$testCmd";
+  testName=$(basename "${file%.*}")
+  testCmd="maestro test \"$file\" -e APP_ID=\"$APPID\" --flatten-debug-output"
+  if ! eval "$testCmd --debug-output e2e-artifacts/$testName";
   then
     echo "Test ${file} failed. Retrying in 30 seconds..."
     sleep 30
-    if ! eval "$testCmd";
+    if ! eval "$testCmd --debug-output e2e-artifacts/$testName-retry-1";
     then
       echo "Test ${file} failed again. Retrying for the last time in 120 seconds..."
       sleep 120
-      if ! eval "$testCmd";
+      if ! eval "$testCmd --debug-output e2e-artifacts/$testName-retry-2";
       then
         failedTests+=("$file")
       fi


### PR DESCRIPTION
## Summary

Currently the artifacts generated by e2e tests are hard to analyze. Each test generate a folder with a data so to find the failing test you basically need to open every folder. This changes the structure so we create a folder with the name of the test, and optionally the retry.

Before:

<img width="324" alt="image" src="https://github.com/user-attachments/assets/32089164-32c4-4546-af86-1458f16feafb" />

After:

<img width="330" alt="image" src="https://github.com/user-attachments/assets/5c3fd47c-8d4b-42ea-9c37-bb207098364a" />

## Motivation

Make debugging e2e test failures easier.

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
