### PR TITLE
Update CHANGELOG.md with latest Expo and RN versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # CHANGELOG
-## 0.45.0 - 2025-04-29
+## 0.45.0 - 2025-04-29 (📌 Expo SDK 53)
 
 ** Features **
-- Support for the New Architecture in React Native v0.68 or later.
+- Support for the New Architecture in React Native v0.76 or later.
 - Ability to update saved cards when using CustomerSessions (private preview)
 
 **Fixes**


### PR DESCRIPTION
## Summary
Updating the CHANGELOG to add the latest Expo version that includes this SDK. Also updating the minimum RN version for the New Architecture, which was incorrect.