### PR TITLE
Add note about kotlin 2 requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ to your `app.json` file, where `merchantIdentifier` is the Apple merchant ID obt
 - Android 5.0 (API level 21) and above
   - Your `compileSdkVersion` must be `34`. See [this issue](https://github.com/stripe/stripe-react-native/issues/812) for potential workarounds.
 - Android gradle plugin 4.x and above
+- Kotlin 2.x and above. See [this issue](https://github.com/stripe/stripe-react-native/issues/1924#issuecomment-2867227374) for how to update the Kotlin version when using react-native 0.77 and below or Expo SDK 52.
 
 _Components_
 


### PR DESCRIPTION
## Summary

Since version 0.45 we require kotlin 2.x because of the android sdk.

## Motivation

Clarify android requirements.

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [ ] I tested this manually
- [ ] I added automated tests

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
