### PR TITLE
Remove ViewManagerWithGeneratedInterface from old arch interfaces

### DIFF
--- a/android/src/oldarch/java/com/facebook/react/viewmanagers/AddToWalletButtonManagerInterface.java
+++ b/android/src/oldarch/java/com/facebook/react/viewmanagers/AddToWalletButtonManagerInterface.java
@@ -13,9 +13,8 @@ import android.view.View;
 import androidx.annotation.Nullable;
 import com.facebook.react.bridge.Dynamic;
 import com.facebook.react.bridge.ReadableMap;
-import com.facebook.react.uimanager.ViewManagerWithGeneratedInterface;
 
-public interface AddToWalletButtonManagerInterface<T extends View> extends ViewManagerWithGeneratedInterface {
+public interface AddToWalletButtonManagerInterface<T extends View>  {
   void setIOSButtonStyle(T view, @Nullable String value);
   void setAndroidAssetSource(T view, @Nullable ReadableMap value);
   void setTestEnv(T view, boolean value);

--- a/android/src/oldarch/java/com/facebook/react/viewmanagers/AddressSheetViewManagerInterface.java
+++ b/android/src/oldarch/java/com/facebook/react/viewmanagers/AddressSheetViewManagerInterface.java
@@ -13,9 +13,8 @@ import android.view.View;
 import androidx.annotation.Nullable;
 import com.facebook.react.bridge.Dynamic;
 import com.facebook.react.bridge.ReadableArray;
-import com.facebook.react.uimanager.ViewManagerWithGeneratedInterface;
 
-public interface AddressSheetViewManagerInterface<T extends View> extends ViewManagerWithGeneratedInterface {
+public interface AddressSheetViewManagerInterface<T extends View>  {
   void setVisible(T view, boolean value);
   void setPresentationStyle(T view, @Nullable String value);
   void setAnimationStyle(T view, @Nullable String value);

--- a/android/src/oldarch/java/com/facebook/react/viewmanagers/ApplePayButtonManagerInterface.java
+++ b/android/src/oldarch/java/com/facebook/react/viewmanagers/ApplePayButtonManagerInterface.java
@@ -10,9 +10,8 @@
 package com.facebook.react.viewmanagers;
 
 import android.view.View;
-import com.facebook.react.uimanager.ViewManagerWithGeneratedInterface;
 
-public interface ApplePayButtonManagerInterface<T extends View> extends ViewManagerWithGeneratedInterface {
+public interface ApplePayButtonManagerInterface<T extends View>  {
   void setDisabled(T view, boolean value);
   void setType(T view, int value);
   void setButtonStyle(T view, int value);

--- a/android/src/oldarch/java/com/facebook/react/viewmanagers/AuBECSDebitFormManagerInterface.java
+++ b/android/src/oldarch/java/com/facebook/react/viewmanagers/AuBECSDebitFormManagerInterface.java
@@ -12,9 +12,8 @@ package com.facebook.react.viewmanagers;
 import android.view.View;
 import androidx.annotation.Nullable;
 import com.facebook.react.bridge.Dynamic;
-import com.facebook.react.uimanager.ViewManagerWithGeneratedInterface;
 
-public interface AuBECSDebitFormManagerInterface<T extends View> extends ViewManagerWithGeneratedInterface {
+public interface AuBECSDebitFormManagerInterface<T extends View>  {
   void setCompanyName(T view, @Nullable String value);
   void setFormStyle(T view, Dynamic value);
 }

--- a/android/src/oldarch/java/com/facebook/react/viewmanagers/CardFieldManagerInterface.java
+++ b/android/src/oldarch/java/com/facebook/react/viewmanagers/CardFieldManagerInterface.java
@@ -13,9 +13,8 @@ import android.view.View;
 import androidx.annotation.Nullable;
 import com.facebook.react.bridge.Dynamic;
 import com.facebook.react.bridge.ReadableArray;
-import com.facebook.react.uimanager.ViewManagerWithGeneratedInterface;
 
-public interface CardFieldManagerInterface<T extends View> extends ViewManagerWithGeneratedInterface {
+public interface CardFieldManagerInterface<T extends View>  {
   void setAutofocus(T view, boolean value);
   void setCardStyle(T view, Dynamic value);
   void setCountryCode(T view, @Nullable String value);

--- a/android/src/oldarch/java/com/facebook/react/viewmanagers/CardFormManagerInterface.java
+++ b/android/src/oldarch/java/com/facebook/react/viewmanagers/CardFormManagerInterface.java
@@ -13,9 +13,8 @@ import android.view.View;
 import androidx.annotation.Nullable;
 import com.facebook.react.bridge.Dynamic;
 import com.facebook.react.bridge.ReadableArray;
-import com.facebook.react.uimanager.ViewManagerWithGeneratedInterface;
 
-public interface CardFormManagerInterface<T extends View> extends ViewManagerWithGeneratedInterface {
+public interface CardFormManagerInterface<T extends View>  {
   void setAutofocus(T view, boolean value);
   void setCardStyle(T view, Dynamic value);
   void setDangerouslyGetFullCardDetails(T view, boolean value);

--- a/android/src/oldarch/java/com/facebook/react/viewmanagers/EmbeddedPaymentElementViewManagerInterface.java
+++ b/android/src/oldarch/java/com/facebook/react/viewmanagers/EmbeddedPaymentElementViewManagerInterface.java
@@ -11,9 +11,8 @@ package com.facebook.react.viewmanagers;
 
 import android.view.View;
 import com.facebook.react.bridge.Dynamic;
-import com.facebook.react.uimanager.ViewManagerWithGeneratedInterface;
 
-public interface EmbeddedPaymentElementViewManagerInterface<T extends View> extends ViewManagerWithGeneratedInterface {
+public interface EmbeddedPaymentElementViewManagerInterface<T extends View>  {
   void setConfiguration(T view, Dynamic value);
   void setIntentConfiguration(T view, Dynamic value);
   void confirm(T view);

--- a/android/src/oldarch/java/com/facebook/react/viewmanagers/GooglePayButtonManagerInterface.java
+++ b/android/src/oldarch/java/com/facebook/react/viewmanagers/GooglePayButtonManagerInterface.java
@@ -10,9 +10,8 @@
 package com.facebook.react.viewmanagers;
 
 import android.view.View;
-import com.facebook.react.uimanager.ViewManagerWithGeneratedInterface;
 
-public interface GooglePayButtonManagerInterface<T extends View> extends ViewManagerWithGeneratedInterface {
+public interface GooglePayButtonManagerInterface<T extends View>  {
   void setType(T view, int value);
   void setAppearance(T view, int value);
   void setBorderRadius(T view, int value);

--- a/android/src/oldarch/java/com/facebook/react/viewmanagers/StripeContainerManagerInterface.java
+++ b/android/src/oldarch/java/com/facebook/react/viewmanagers/StripeContainerManagerInterface.java
@@ -10,8 +10,7 @@
 package com.facebook.react.viewmanagers;
 
 import android.view.View;
-import com.facebook.react.uimanager.ViewManagerWithGeneratedInterface;
 
-public interface StripeContainerManagerInterface<T extends View> extends ViewManagerWithGeneratedInterface {
+public interface StripeContainerManagerInterface<T extends View>  {
   void setKeyboardShouldPersistTaps(T view, boolean value);
 }

--- a/scripts/old-arch-codegen-android
+++ b/scripts/old-arch-codegen-android
@@ -11,8 +11,16 @@ popd
 rm -rf android/src/oldarch/java
 cp -r android/build/generated/source/codegen/java android/src/oldarch/java
 
+find android/src/oldarch/java -type f -name '*Interface.java' | while IFS= read -r file; do
+  sed -i '' \
+    -e '/import com\.facebook\.react\.uimanager\.ViewManagerWithGeneratedInterface;/d' \
+    -e 's/extends ViewManagerWithGeneratedInterface//g' \
+    "$file"
+done
+
 # Apply a patch to modify the codegen code so it works with the old architecture.
-# If this patch needs to be updated, create android/src/oldarch/java/com/reactnativestripesdk/NativeStripeSdkModuleSpecNew.java
+# If this patch needs to be updated, temporarily remove the patch and sed lines and run this script.
+# Then create android/src/oldarch/java/com/reactnativestripesdk/NativeStripeSdkModuleSpecNew.java
 # and make the required changes then run the following command:
 # diff -u android/src/oldarch/java/com/reactnativestripesdk/NativeStripeSdkModuleSpec.java android/src/oldarch/java/com/reactnativestripesdk/NativeStripeSdkModuleSpecNew.java > scripts/NativeStripeSdkModuleSpec.patch
 patch android/src/oldarch/java/com/reactnativestripesdk/NativeStripeSdkModuleSpec.java < scripts/NativeStripeSdkModuleSpec.patch


### PR DESCRIPTION
## Summary

In older version of react native this `ViewManagerWithGeneratedInterface` interface does not exist. It is not needed for old arch so we should remove it.

## Motivation

Fix backwards compatibility with RN 0.77.

Fixes #1919

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
