### PR TITLE
Fix iOS build on react-native 0.76 new arch

### DIFF
--- a/ios/NewArch/GooglePayButtonComponentView.mm
+++ b/ios/NewArch/GooglePayButtonComponentView.mm
@@ -1,0 +1,9 @@
+#import <React/RCTFabricComponentsPlugins.h>
+#import <React/RCTViewComponentView.h>
+
+// On older versions of react-native every single spec is linked so we need
+// to include a dummy implementation to avoid linker errors.
+Class<RCTComponentViewProtocol> GooglePayButtonCls(void)
+{
+  return RCTViewComponentView.class;
+}


### PR DESCRIPTION
## Summary

On older version of react-native every single spec is linked so we need to add this dummy implementation for GooglePayButton. On more recent versions this was not a problem since we provide an explicit list of views to link.

## Motivation

Fixes compatibility with 0.76 new arch.

Fixes #1923

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
