### PR TITLE
Add customer secrets to embedded API

### DIFF
--- a/src/types/EmbeddedPaymentElement.tsx
+++ b/src/types/EmbeddedPaymentElement.tsx
@@ -100,6 +100,12 @@ export interface EmbeddedPaymentElementConfiguration {
   merchantDisplayName: string;
   /** The identifier of the Stripe Customer object. See https://stripe.com/docs/api/customers/object#customer_object-id */
   customerId?: string;
+  /** A short-lived token that allows the SDK to access a Customer’s payment methods. */
+  customerEphemeralKeySecret?: string;
+  /** (Experimental) This parameter can be changed or removed at any time (use at your own risk).
+   *  The client secret of this Customer Session. Used on the client to set up secure access to the given customer.
+   */
+  customerSessionClientSecret?: string;
   /** iOS only. Enable Apple Pay in the Payment Sheet by passing an ApplePayParams object.  */
   applePay?: PaymentSheetTypes.ApplePayParams;
   /** Android only. Enable Google Pay in the Payment Sheet by passing a GooglePayParams object.  */


### PR DESCRIPTION
## Summary
- Adds customer secret keys to the embedded APIs
- These are already being parsed by native code, just an oversight initially

## Motivation
- Complete the API

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one: 
- [x] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
