### PR TITLE
Fix embedded presentation on iOS

### DIFF
--- a/example/src/screens/EmbeddedPaymentElementScreen.tsx
+++ b/example/src/screens/EmbeddedPaymentElementScreen.tsx
@@ -36,7 +36,12 @@ function PaymentElementView({ intentConfig, elementConfig }: any) {
   // Payment action
   const handlePay = React.useCallback(async () => {
     setLoading(true);
-    await confirm();
+    const result = await confirm();
+    if (result.status === 'completed')
+      Alert.alert('Success', 'Payment confirmed');
+    else if (result.status === 'failed')
+      Alert.alert('Error', `Failed: ${result.error.message}`);
+    else Alert.alert('Cancelled');
     setLoading(false);
   }, [confirm]);
 

--- a/ios/EmbeddedPaymentElementView.swift
+++ b/ios/EmbeddedPaymentElementView.swift
@@ -11,39 +11,78 @@ import UIKit
 
 @objc(EmbeddedPaymentElementView)
 class EmbeddedPaymentElementView: RCTViewManager {
-  
-  override static func requiresMainQueueSetup() -> Bool {
-    return true
-  }
-  
-  override func view() -> UIView! {
-    return EmbeddedPaymentElementContainerView(frame: .zero)
-  }
+    
+    override static func requiresMainQueueSetup() -> Bool {
+        return true
+    }
+
+    override func view() -> UIView! {
+        return EmbeddedPaymentElementContainerView(frame: .zero)
+    }
 }
 
 @objc(EmbeddedPaymentElementContainerView)
 public class EmbeddedPaymentElementContainerView: UIView, UIGestureRecognizerDelegate {
-  override init(frame: CGRect) {
-    super.init(frame: frame)
-    backgroundColor = .clear
-    attachPaymentElementIfAvailable()
-  }
+    private var embeddedPaymentElementView: UIView?
 
-  required init?(coder: NSCoder) {
-    fatalError()
-  }
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        backgroundColor = .clear
+    }
 
-  private func attachPaymentElementIfAvailable() {
-    guard let embeddedElement = StripeSdkImpl.shared.embeddedInstance else { return }
-    let paymentElementView = embeddedElement.view
-    addSubview(paymentElementView)
-    paymentElementView.translatesAutoresizingMaskIntoConstraints = false
+    required init?(coder: NSCoder) {
+        fatalError()
+    }
 
-    NSLayoutConstraint.activate([
-      paymentElementView.topAnchor.constraint(equalTo: topAnchor),
-      paymentElementView.leadingAnchor.constraint(equalTo: leadingAnchor),
-      paymentElementView.trailingAnchor.constraint(equalTo: trailingAnchor),
-      paymentElementView.bottomAnchor.constraint(equalTo: bottomAnchor),
-    ])
-  }
+    public override func didMoveToWindow() {
+        super.didMoveToWindow()
+        if window != nil {
+            // Only attach when we have a valid window
+            attachPaymentElementIfAvailable()
+        }
+    }
+
+    public override func willMove(toWindow newWindow: UIWindow?) {
+        super.willMove(toWindow: newWindow)
+        if newWindow == nil {
+            // Remove the embedded view when moving away from window
+            removePaymentElement()
+        }
+    }
+
+    private func attachPaymentElementIfAvailable() {
+        // Don't attach if already attached
+        guard embeddedPaymentElementView == nil,
+              let embeddedElement = StripeSdkImpl.shared.embeddedInstance else {
+            return
+        }
+
+        let paymentElementView = embeddedElement.view
+        addSubview(paymentElementView)
+        paymentElementView.translatesAutoresizingMaskIntoConstraints = false
+
+        NSLayoutConstraint.activate([
+            paymentElementView.topAnchor.constraint(equalTo: topAnchor),
+            paymentElementView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            paymentElementView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            paymentElementView.bottomAnchor.constraint(equalTo: bottomAnchor),
+        ])
+
+        self.embeddedPaymentElementView = paymentElementView
+
+        // Update the presenting view controller whenever we attach
+        updatePresentingViewController()
+    }
+
+    private func removePaymentElement() {
+        embeddedPaymentElementView?.removeFromSuperview()
+        embeddedPaymentElementView = nil
+    }
+
+    private func updatePresentingViewController() {
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+            StripeSdkImpl.shared.embeddedInstance?.presentingViewController = RCTPresentedViewController()
+        }
+    }
 }


### PR DESCRIPTION
## Summary
When navigating to a screen with an EmbeddedPaymentElement, then navigating back and returning, the embedded element could no longer present view controllers. The embedded element's presentingViewController property wasn't being updated when the React Native view hierarchy changed during navigation, causing it to reference stale view controllers.

## Motivation
- Embedded preview
