### PR TITLE
Add Form Insets and Primary Button height API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # CHANGELOG
+
+**Feature**
+- Added `height` to `PrimaryButtonConfig.shapes`.
+- Added `formInsetValues` to `AppearanceParams`.
+
 ## 0.47.1 - 2025-05-29
 
 **Fixes**

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -3,4 +3,4 @@ StripeSdk_compileSdkVersion=30
 StripeSdk_targetSdkVersion=28
 StripeSdk_minSdkVersion=21
 # Keep StripeSdk_stripeVersion in sync with https://github.com/stripe/stripe-identity-react-native/blob/main/android/gradle.properties
-StripeSdk_stripeVersion=21.15.+
+StripeSdk_stripeVersion=21.17.+

--- a/android/src/main/java/com/reactnativestripesdk/PaymentSheetAppearance.kt
+++ b/android/src/main/java/com/reactnativestripesdk/PaymentSheetAppearance.kt
@@ -8,6 +8,7 @@ import android.os.Bundle
 import com.reactnativestripesdk.utils.PaymentSheetAppearanceException
 import com.stripe.android.paymentelement.ExperimentalEmbeddedPaymentElementApi
 import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.uicore.StripeThemeDefaults
 
 @SuppressLint("RestrictedApi")
 fun buildPaymentSheetAppearance(
@@ -407,15 +408,13 @@ private fun buildEmbeddedAppearance(
   return PaymentSheet.Appearance.Embedded(style = rowStyle)
 }
 
+@SuppressLint("RestrictedApi")
 private fun buildFormInsets(insetParams: Bundle?): PaymentSheet.Insets {
-  val defaultLeft = 20f
-  val defaultTop = 0f
-  val defaultRight = 20f
-  val defaultBottom = 40f
-  val left = getFloatOr(insetParams, PaymentSheetAppearanceKeys.LEFT, defaultLeft)
-  val top = getFloatOr(insetParams, PaymentSheetAppearanceKeys.TOP, defaultTop)
-  val right = getFloatOr(insetParams, PaymentSheetAppearanceKeys.RIGHT, defaultRight)
-  val bottom = getFloatOr(insetParams, PaymentSheetAppearanceKeys.BOTTOM, defaultBottom)
+  val defaults = StripeThemeDefaults.formInsets
+  val left = getFloatOr(insetParams, PaymentSheetAppearanceKeys.LEFT, defaults.start)
+  val top = getFloatOr(insetParams, PaymentSheetAppearanceKeys.TOP, defaults.top)
+  val right = getFloatOr(insetParams, PaymentSheetAppearanceKeys.RIGHT, defaults.end)
+  val bottom = getFloatOr(insetParams, PaymentSheetAppearanceKeys.BOTTOM, defaults.bottom)
 
   return PaymentSheet.Insets(
     startDp = left,

--- a/android/src/main/java/com/reactnativestripesdk/PaymentSheetAppearance.kt
+++ b/android/src/main/java/com/reactnativestripesdk/PaymentSheetAppearance.kt
@@ -38,7 +38,7 @@ fun buildPaymentSheetAppearance(
           context,
         ),
       embeddedAppearance = embeddedAppearance,
-      formInsetValues = buildFormInsets(insetParams)
+      formInsetValues = buildFormInsets(insetParams),
     )
   }
 
@@ -52,7 +52,7 @@ fun buildPaymentSheetAppearance(
         userParams?.getBundle(PaymentSheetAppearanceKeys.PRIMARY_BUTTON),
         context,
       ),
-    formInsetValues = buildFormInsets(insetParams)
+    formInsetValues = buildFormInsets(insetParams),
   )
 }
 
@@ -201,7 +201,7 @@ private fun buildPrimaryButton(
           getFloatOrNull(shapeParams, PaymentSheetAppearanceKeys.BORDER_RADIUS),
         borderStrokeWidthDp =
           getFloatOrNull(shapeParams, PaymentSheetAppearanceKeys.BORDER_WIDTH),
-        heightDp = getFloatOrNull(shapeParams, PaymentSheetAppearanceKeys.HEIGHT)
+        heightDp = getFloatOrNull(shapeParams, PaymentSheetAppearanceKeys.HEIGHT),
       ),
     typography =
       PaymentSheet.PrimaryButtonTypography(
@@ -407,9 +407,7 @@ private fun buildEmbeddedAppearance(
   return PaymentSheet.Appearance.Embedded(style = rowStyle)
 }
 
-private fun buildFormInsets(
-  insetParams: Bundle?,
-): PaymentSheet.Insets {
+private fun buildFormInsets(insetParams: Bundle?): PaymentSheet.Insets {
   val defaultLeft = 20f
   val defaultTop = 0f
   val defaultRight = 20f
@@ -423,7 +421,7 @@ private fun buildFormInsets(
     startDp = left,
     topDp = top,
     endDp = right,
-    bottomDp = bottom
+    bottomDp = bottom,
   )
 }
 

--- a/android/src/main/java/com/reactnativestripesdk/PaymentSheetAppearance.kt
+++ b/android/src/main/java/com/reactnativestripesdk/PaymentSheetAppearance.kt
@@ -17,6 +17,7 @@ fun buildPaymentSheetAppearance(
   val colorParams = userParams?.getBundle(PaymentSheetAppearanceKeys.COLORS)
   val lightColorParams = colorParams?.getBundle(PaymentSheetAppearanceKeys.LIGHT) ?: colorParams
   val darkColorParams = colorParams?.getBundle(PaymentSheetAppearanceKeys.DARK) ?: colorParams
+  val insetParams = userParams?.getBundle(PaymentSheetAppearanceKeys.FORM_INSETS)
 
   val embeddedAppearance =
     buildEmbeddedAppearance(
@@ -37,6 +38,7 @@ fun buildPaymentSheetAppearance(
           context,
         ),
       embeddedAppearance = embeddedAppearance,
+      formInsetValues = buildFormInsets(insetParams)
     )
   }
 
@@ -50,6 +52,7 @@ fun buildPaymentSheetAppearance(
         userParams?.getBundle(PaymentSheetAppearanceKeys.PRIMARY_BUTTON),
         context,
       ),
+    formInsetValues = buildFormInsets(insetParams)
   )
 }
 
@@ -198,6 +201,7 @@ private fun buildPrimaryButton(
           getFloatOrNull(shapeParams, PaymentSheetAppearanceKeys.BORDER_RADIUS),
         borderStrokeWidthDp =
           getFloatOrNull(shapeParams, PaymentSheetAppearanceKeys.BORDER_WIDTH),
+        heightDp = getFloatOrNull(shapeParams, PaymentSheetAppearanceKeys.HEIGHT)
       ),
     typography =
       PaymentSheet.PrimaryButtonTypography(
@@ -403,6 +407,26 @@ private fun buildEmbeddedAppearance(
   return PaymentSheet.Appearance.Embedded(style = rowStyle)
 }
 
+private fun buildFormInsets(
+  insetParams: Bundle?,
+): PaymentSheet.Insets {
+  val defaultLeft = 20f
+  val defaultTop = 0f
+  val defaultRight = 20f
+  val defaultBottom = 40f
+  val left = getFloatOr(insetParams, PaymentSheetAppearanceKeys.LEFT, defaultLeft)
+  val top = getFloatOr(insetParams, PaymentSheetAppearanceKeys.TOP, defaultTop)
+  val right = getFloatOr(insetParams, PaymentSheetAppearanceKeys.RIGHT, defaultRight)
+  val bottom = getFloatOr(insetParams, PaymentSheetAppearanceKeys.BOTTOM, defaultBottom)
+
+  return PaymentSheet.Insets(
+    startDp = left,
+    topDp = top,
+    endDp = right,
+    bottomDp = bottom
+  )
+}
+
 /**
  * Pulls a light/dark hex‑string map out of [params],
  * chooses the right one based on the current UI mode,
@@ -564,6 +588,7 @@ private class PaymentSheetAppearanceKeys {
     const val SHAPES = "shapes"
     const val BORDER_RADIUS = "borderRadius"
     const val BORDER_WIDTH = "borderWidth"
+    const val HEIGHT = "height"
 
     const val PRIMARY_BUTTON = "primaryButton"
     const val TEXT = "text"
@@ -593,5 +618,9 @@ private class PaymentSheetAppearanceKeys {
     // Keys for EdgeInsetsConfig
     const val LEFT = "left"
     const val RIGHT = "right"
+    const val TOP = "top"
+    const val BOTTOM = "bottom"
+
+    const val FORM_INSETS = "formInsetValues"
   }
 }

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1685,13 +1685,13 @@ PODS:
     - ReactCommon/turbomodule/core
     - Yoga
   - SocketRocket (0.7.1)
-  - Stripe (24.14.0):
-    - StripeApplePay (= 24.14.0)
-    - StripeCore (= 24.14.0)
-    - StripePayments (= 24.14.0)
-    - StripePaymentsUI (= 24.14.0)
-    - StripeUICore (= 24.14.0)
-  - stripe-react-native (0.46.0):
+  - Stripe (24.15.0):
+    - StripeApplePay (= 24.15.0)
+    - StripeCore (= 24.15.0)
+    - StripePayments (= 24.15.0)
+    - StripePaymentsUI (= 24.15.0)
+    - StripeUICore (= 24.15.0)
+  - stripe-react-native (0.47.1):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1711,15 +1711,15 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - Stripe (~> 24.14.0)
-    - stripe-react-native/NewArch (= 0.46.0)
-    - StripeApplePay (~> 24.14.0)
-    - StripeFinancialConnections (~> 24.14.0)
-    - StripePayments (~> 24.14.0)
-    - StripePaymentSheet (~> 24.14.0)
-    - StripePaymentsUI (~> 24.14.0)
+    - Stripe (~> 24.15.0)
+    - stripe-react-native/NewArch (= 0.47.1)
+    - StripeApplePay (~> 24.15.0)
+    - StripeFinancialConnections (~> 24.15.0)
+    - StripePayments (~> 24.15.0)
+    - StripePaymentSheet (~> 24.15.0)
+    - StripePaymentsUI (~> 24.15.0)
     - Yoga
-  - stripe-react-native/NewArch (0.46.0):
+  - stripe-react-native/NewArch (0.47.1):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1739,14 +1739,14 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - Stripe (~> 24.14.0)
-    - StripeApplePay (~> 24.14.0)
-    - StripeFinancialConnections (~> 24.14.0)
-    - StripePayments (~> 24.14.0)
-    - StripePaymentSheet (~> 24.14.0)
-    - StripePaymentsUI (~> 24.14.0)
+    - Stripe (~> 24.15.0)
+    - StripeApplePay (~> 24.15.0)
+    - StripeFinancialConnections (~> 24.15.0)
+    - StripePayments (~> 24.15.0)
+    - StripePaymentSheet (~> 24.15.0)
+    - StripePaymentsUI (~> 24.15.0)
     - Yoga
-  - stripe-react-native/Tests (0.46.0):
+  - stripe-react-native/Tests (0.47.1):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1766,35 +1766,35 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - Stripe (~> 24.14.0)
-    - StripeApplePay (~> 24.14.0)
-    - StripeFinancialConnections (~> 24.14.0)
-    - StripePayments (~> 24.14.0)
-    - StripePaymentSheet (~> 24.14.0)
-    - StripePaymentsUI (~> 24.14.0)
+    - Stripe (~> 24.15.0)
+    - StripeApplePay (~> 24.15.0)
+    - StripeFinancialConnections (~> 24.15.0)
+    - StripePayments (~> 24.15.0)
+    - StripePaymentSheet (~> 24.15.0)
+    - StripePaymentsUI (~> 24.15.0)
     - Yoga
-  - StripeApplePay (24.14.0):
-    - StripeCore (= 24.14.0)
-  - StripeCore (24.14.0)
-  - StripeFinancialConnections (24.14.0):
-    - StripeCore (= 24.14.0)
-    - StripeUICore (= 24.14.0)
-  - StripePayments (24.14.0):
-    - StripeCore (= 24.14.0)
-    - StripePayments/Stripe3DS2 (= 24.14.0)
-  - StripePayments/Stripe3DS2 (24.14.0):
-    - StripeCore (= 24.14.0)
-  - StripePaymentSheet (24.14.0):
-    - StripeApplePay (= 24.14.0)
-    - StripeCore (= 24.14.0)
-    - StripePayments (= 24.14.0)
-    - StripePaymentsUI (= 24.14.0)
-  - StripePaymentsUI (24.14.0):
-    - StripeCore (= 24.14.0)
-    - StripePayments (= 24.14.0)
-    - StripeUICore (= 24.14.0)
-  - StripeUICore (24.14.0):
-    - StripeCore (= 24.14.0)
+  - StripeApplePay (24.15.0):
+    - StripeCore (= 24.15.0)
+  - StripeCore (24.15.0)
+  - StripeFinancialConnections (24.15.0):
+    - StripeCore (= 24.15.0)
+    - StripeUICore (= 24.15.0)
+  - StripePayments (24.15.0):
+    - StripeCore (= 24.15.0)
+    - StripePayments/Stripe3DS2 (= 24.15.0)
+  - StripePayments/Stripe3DS2 (24.15.0):
+    - StripeCore (= 24.15.0)
+  - StripePaymentSheet (24.15.0):
+    - StripeApplePay (= 24.15.0)
+    - StripeCore (= 24.15.0)
+    - StripePayments (= 24.15.0)
+    - StripePaymentsUI (= 24.15.0)
+  - StripePaymentsUI (24.15.0):
+    - StripeCore (= 24.15.0)
+    - StripePayments (= 24.15.0)
+    - StripeUICore (= 24.15.0)
+  - StripeUICore (24.15.0):
+    - StripeCore (= 24.15.0)
   - Yoga (0.0.0)
 
 DEPENDENCIES:
@@ -2044,80 +2044,80 @@ SPEC CHECKSUMS:
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: eb93e2f488219332457c3c4eafd2738ddc7e80b8
   hermes-engine: b417d2b2aee3b89b58e63e23a51e02be91dc876d
-  RCT-Folly: 36fe2295e44b10d831836cc0d1daec5f8abcf809
+  RCT-Folly: e78785aa9ba2ed998ea4151e314036f6c49e6d82
   RCTDeprecation: b2eecf2d60216df56bc5e6be5f063826d3c1ee35
   RCTRequired: 78522de7dc73b81f3ed7890d145fa341f5bb32ea
   RCTTypeSafety: c135dd2bf50402d87fd12884cbad5d5e64850edd
   React: b229c49ed5898dab46d60f61ed5a0bfa2ee2fadb
   React-callinvoker: 2ac508e92c8bd9cf834cc7d7787d94352e4af58f
-  React-Core: 13cdd1558d0b3f6d9d5a22e14d89150280e79f02
-  React-CoreModules: b07a6744f48305405e67c845ebf481b6551b712a
-  React-cxxreact: 1055a86c66ac35b4e80bd5fb766aed5f494dfff4
+  React-Core: 325b4f6d9162ae8b9a6ff42fe78e260eb124180d
+  React-CoreModules: 558041e5258f70cd1092f82778d07b8b2ff01897
+  React-cxxreact: 8fff17cbe76e6a8f9991b59552e1235429f9c74b
   React-debug: 0a5fcdbacc6becba0521e910c1bcfdb20f32a3f6
-  React-defaultsnativemodule: 4bb28fc97fee5be63a9ebf8f7a435cfe8ba69459
-  React-domnativemodule: b36a11c2597243d7563985028c51ece988d8ae33
-  React-Fabric: afc561718f25b2cd800b709d934101afe376a12c
-  React-FabricComponents: f4e0a4e18a27bf6d39cbf2a0b42f37a92fa4e37f
-  React-FabricImage: 37d8e8b672eda68a19d71143eb65148084efb325
+  React-defaultsnativemodule: 618dc50a0fad41b489997c3eb7aba3a74479fd14
+  React-domnativemodule: 7ba599afb6c2a7ec3eb6450153e2efe0b8747e9a
+  React-Fabric: 252112089d2c63308f4cbfade4010b6606db67d1
+  React-FabricComponents: 3c0f75321680d14d124438ab279c64ec2a3d13c4
+  React-FabricImage: 728b8061cdec2857ca885fd605ee03ad43ffca98
   React-featureflags: 19682e02ef5861d96b992af16a19109c3dfc1200
-  React-featureflagsnativemodule: d7cddf6d907b4e5ab84f9e744b7e88461656e48c
-  React-graphics: b0f78580cdaf5800d25437e3d41cc6c3d83b7aea
-  React-hermes: 71186f872c932e4574d5feb3ed754dda63a0b3bd
-  React-idlecallbacksnativemodule: dd2af19cdd3bc55149d17a2409ed72b694dfbe9c
-  React-ImageManager: a77dde8d5aa6a2b6962c702bf3a47695ef0aa32b
-  React-jserrorhandler: 9c14e89f12d5904257a79aaf84a70cd2e5ac07ba
-  React-jsi: 0775a66820496769ad83e629f0f5cce621a57fc7
-  React-jsiexecutor: 2cf5ba481386803f3c88b85c63fa102cba5d769e
-  React-jsinspector: 8052d532bb7a98b6e021755674659802fb140cc5
-  React-jsinspectortracing: bdd8fd0adcb4813663562e7874c5842449df6d8a
-  React-jsitracing: 2bab3bf55de3d04baf205def375fa6643c47c794
-  React-logger: 795cd5055782db394f187f9db0477d4b25b44291
-  React-Mapbuffer: 0502faf46cab8fb89cfc7bf3e6c6109b6ef9b5de
-  React-microtasksnativemodule: 663bc64e3a96c5fc91081923ae7481adc1359a78
-  react-native-safe-area-context: 9c33120e9eac7741a5364cc2d9f74665049b76b3
-  React-NativeModulesApple: 16fbd5b040ff6c492dacc361d49e63cba7a6a7a1
-  React-perflogger: ab51b7592532a0ea45bf6eed7e6cae14a368b678
-  React-performancetimeline: bc2e48198ec814d578ac8401f65d78a574358203
+  React-featureflagsnativemodule: 23528c7e7d50782b7ef0804168ba40bbaf1e86ab
+  React-graphics: fefe48f71bfe6f48fd037f59e8277b12e91b6be1
+  React-hermes: a9a0c8377627b5506ef9a7b6f60a805c306e3f51
+  React-idlecallbacksnativemodule: 7e2b6a3b70e042f89cd91dbd73c479bb39a72a7e
+  React-ImageManager: e3300996ac2e2914bf821f71e2f2c92ae6e62ae2
+  React-jserrorhandler: fa75876c662e5d7e79d6efc763fc9f4c88e26986
+  React-jsi: f3f51595cc4c089037b536368f016d4742bf9cf7
+  React-jsiexecutor: cca6c232db461e2fd213a11e9364cfa6fdaa20eb
+  React-jsinspector: 2bd4c9fddf189d6ec2abf4948461060502582bef
+  React-jsinspectortracing: a417d8a0ad481edaa415734b4dac81e3e5ee7dc6
+  React-jsitracing: 1ff7172c5b0522cbf6c98d82bdbb160e49b5804e
+  React-logger: 018826bfd51b9f18e87f67db1590bc510ad20664
+  React-Mapbuffer: 3c11cee7737609275c7b66bd0b1de475f094cedf
+  React-microtasksnativemodule: 843f352b32aacbe13a9c750190d34df44c3e6c2c
+  react-native-safe-area-context: 7e513d737b0b5c1d10bbe0e5fcc9f925a7be144c
+  React-NativeModulesApple: 88433b6946778bea9c153e27b671de15411bf225
+  React-perflogger: 9e8d3c0dc0194eb932162812a168aa5dc662f418
+  React-performancetimeline: 5a2d6efef52bdcefac079c7baa30934978acd023
   React-RCTActionSheet: 592674cf61142497e0e820688f5a696e41bf16dd
-  React-RCTAnimation: 8fbb8dba757b49c78f4db403133ab6399a4ce952
-  React-RCTAppDelegate: 7f88baa8cb4e5d6c38bb4d84339925c70c9ac864
-  React-RCTBlob: f89b162d0fe6b570a18e755eb16cbe356d3c6d17
-  React-RCTFabric: 8ad6d875abe6e87312cef90e4b15ef7f6bed72e6
-  React-RCTFBReactNativeSpec: 8c29630c2f379c729300e4c1e540f3d1b78d1936
-  React-RCTImage: ccac9969940f170503857733f9a5f63578e106e1
-  React-RCTLinking: d82427bbf18415a3732105383dff119131cadd90
-  React-RCTNetwork: 12ad4d0fbde939e00251ca5ca890da2e6825cc3c
-  React-RCTSettings: e7865bf9f455abf427da349c855f8644b5c39afa
-  React-RCTText: 2cdfd88745059ec3202a0842ea75a956c7d6f27d
-  React-RCTVibration: a3a1458e6230dfd64b3768ebc0a4aac430d9d508
+  React-RCTAnimation: e6d669872f9b3b4ab9527aab283b7c49283236b7
+  React-RCTAppDelegate: de2343fe08be4c945d57e0ecce44afcc7dd8fc03
+  React-RCTBlob: 3e2dce94c56218becc4b32b627fc2293149f798d
+  React-RCTFabric: cac2c033381d79a5956e08550b0220cb2d78ea93
+  React-RCTFBReactNativeSpec: d10ca5e0ccbfeac8c047361fedf8e4ac653887b6
+  React-RCTImage: dc04b176c022d12a8f55ae7a7279b1e091066ae0
+  React-RCTLinking: 88f5e37fe4f26fbc80791aa2a5f01baf9b9a3fd5
+  React-RCTNetwork: f213693565efbd698b8e9c18d700a514b49c0c8e
+  React-RCTSettings: a2d32a90c45a3575568cad850abc45924999b8a5
+  React-RCTText: 54cdcd1cbf6f6a91dc6317f5d2c2b7fc3f6bf7a0
+  React-RCTVibration: 11dae0e7f577b5807bb7d31e2e881eb46f854fd4
   React-rendererconsistency: 64e897e00d2568fd8dfe31e2496f80e85c0aaad1
-  React-rendererdebug: a3f6d3ae7d2fa0035885026756281c07ee32479e
+  React-rendererdebug: 41ce452460c44bba715d9e41d5493a96de277764
   React-rncore: 58748c2aa445f56b99e5118dad0aedb51c40ce9f
-  React-RuntimeApple: f0fda7bacabd32daa099cfda8f07466c30acd149
-  React-RuntimeCore: 683ee0b6a76d4b4bf6fbf83a541895b4887cc636
+  React-RuntimeApple: 7785ed0d8ae54da65a88736bb63ca97608a6d933
+  React-RuntimeCore: 6029ea70bc77f98cfd43ebe69217f14e93ba1f12
   React-runtimeexecutor: a188df372373baf5066e6e229177836488799f80
-  React-RuntimeHermes: 907c8e9bec13ea6466b94828c088c24590d4d0b6
-  React-runtimescheduler: a2e2a39125dd6426b5d8b773f689d660cd7c5f60
+  React-RuntimeHermes: a264609c28b796edfffc8ae4cb8fad1773ab948b
+  React-runtimescheduler: 23ec3a1e0fb1ec752d1a9c1fb15258c30bfc7222
   React-timing: bb220a53a795ed57976a4855c521f3de2f298fe5
-  React-utils: 300d8bbb6555dcffaca71e7a0663201b5c7edbbc
-  ReactAppDependencyProvider: f2e81d80afd71a8058589e19d8a134243fa53f17
-  ReactCodegen: a63a0ab6ae824aef2e8c744981edd718b16eb9f2
-  ReactCommon: 3d39389f8e2a2157d5c999f8fba57bd1c8f226f0
-  ReactNativeHost: 472eee4aad1fa9b3a265d2f5eb76eaa52ef75c1e
-  ReactTestApp-DevSupport: 0580b002f78d63804f1609dce622c4f54820f3c6
+  React-utils: 3b054aaebe658fc710a8d239d0e4b9fd3e0b78f9
+  ReactAppDependencyProvider: a1fb08dfdc7ebc387b2e54cfc9decd283ed821d8
+  ReactCodegen: 008c319179d681a6a00966edfc67fda68f9fbb2e
+  ReactCommon: 0c097b53f03d6bf166edbcd0915da32f3015dd90
+  ReactNativeHost: 2503667b2e20fff53f55c4f85d9c7e66e0f3d702
+  ReactTestApp-DevSupport: 881bdd4c9f703cf611e46715b8a5f27b2ff15e5d
   ReactTestApp-Resources: 49fb7249af8203b9c74fd85de8c6f5bbb77a41df
-  RNCPicker: ffbd7b9fc7c1341929e61dbef6219f7860f57418
-  RNScreens: 991214b4e69016c1ae32830d9cea31c9c9422367
+  RNCPicker: cfb51a08c6e10357d9a65832e791825b0747b483
+  RNScreens: 0d4cb9afe052607ad0aa71f645a88bb7c7f2e64c
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
-  Stripe: 6d254bcbf0706a656fb5d9d84cd77365c8b3c9f6
-  stripe-react-native: c6c5a0d0cfa2c3909583b76e2c023aa1ed913df2
-  StripeApplePay: 4b1ef56530fb97ed699ec1d9120cdcbf3013748f
-  StripeCore: 16957868cac857937324a7cf4c9380ca1eda7e38
-  StripeFinancialConnections: ccaa2b1a77f8f617d16e51f7410a0d59d7a87346
-  StripePayments: 861a570434090ec08f8ba62e211fd03813b2a2f4
-  StripePaymentSheet: e4ae294f0e09b296a7dfc2c702e26ee30fe088a5
-  StripePaymentsUI: a8480e78da13266ce2d94e4ed0990258583a9cab
-  StripeUICore: 86c852985d9aece3658420f28ff73b27310e4249
+  Stripe: 6f0047bdd52bbeecc3c87a9c0d429bf5bb2b1b86
+  stripe-react-native: d97ef667fb463e69b430f77395f145e20f629b88
+  StripeApplePay: e7a2f5fa07cbdba9c56cb7586cbfd4e7e32ed895
+  StripeCore: 224f995bb108e3be3bdf6cfab918657edf325559
+  StripeFinancialConnections: 71c55281ef86f7c47c545fe51657574fac1f842c
+  StripePayments: 07ad9e3c5f22e0b068874c47c2ec37663f1b7aa5
+  StripePaymentSheet: f576ebb935f7bf3ef956d302ade75b9148906a65
+  StripePaymentsUI: d0549558424d3884b3fb7b8f3905ea685e750600
+  StripeUICore: dbd893086aa4fe697517624af2f1f0cea3218ac8
   Yoga: 9b7fb56e7b08cde60e2153344fa6afbd88e5d99f
 
 PODFILE CHECKSUM: a2ed964678852d4cc306ff4add3e4fa90be77ea6

--- a/ios/PaymentSheetAppearance.swift
+++ b/ios/PaymentSheetAppearance.swift
@@ -33,6 +33,10 @@ internal class PaymentSheetAppearance {
           appearance.embeddedPaymentElement = try buildEmbeddedPaymentElementAppearance(params: embeddedPaymentElementParams)
         }
         
+        if let formInsetParams = userParams[PaymentSheetAppearanceKeys.FORM_INSETS] as? NSDictionary {
+            appearance.formInsets = try buildFormInsets(params: formInsetParams)
+        }
+        
         return appearance
     }
     
@@ -113,6 +117,9 @@ internal class PaymentSheetAppearance {
             }
             if let shadowParams = shapeParams[PaymentSheetAppearanceKeys.SHADOW] as? NSDictionary {
                 primaryButton.shadow = try buildShadow(params: shadowParams)
+            }
+            if let height = shapeParams[PaymentSheetAppearanceKeys.HEIGHT] as? CGFloat {
+                primaryButton.height = height
             }
         }
         if let colorParams = params[PaymentSheetAppearanceKeys.COLORS] as? NSDictionary {
@@ -314,6 +321,20 @@ internal class PaymentSheetAppearance {
             return defaultColor
           })
       }
+    
+    private class func buildFormInsets(params: NSDictionary) throws -> NSDirectionalEdgeInsets {
+        let top = params[PaymentSheetAppearanceKeys.TOP] as? CGFloat ?? PaymentSheet.Appearance.default.formInsets.top
+        let leading = params[PaymentSheetAppearanceKeys.LEFT] as? CGFloat ?? PaymentSheet.Appearance.default.formInsets.leading
+        let bottom = params[PaymentSheetAppearanceKeys.BOTTOM] as? CGFloat ?? PaymentSheet.Appearance.default.formInsets.bottom
+        let trailing = params[PaymentSheetAppearanceKeys.RIGHT] as? CGFloat ?? PaymentSheet.Appearance.default.formInsets.trailing
+        
+        return NSDirectionalEdgeInsets(
+          top: top,
+          leading: leading,
+          bottom: bottom,
+          trailing: trailing
+        )
+    }
 }
 
 enum PaymentSheetAppearanceError : Error {
@@ -361,6 +382,7 @@ private struct PaymentSheetAppearanceKeys {
     static let SHAPES = "shapes"
     static let BORDER_RADIUS = "borderRadius"
     static let BORDER_WIDTH = "borderWidth"
+    static let HEIGHT = "height"
 
     static let SHADOW = "shadow"
     static let SHADOW_COLOR = "color"
@@ -400,4 +422,6 @@ private struct PaymentSheetAppearanceKeys {
     static let ROW_STYLE_FLAT_WITH_RADIO = "flatWithRadio"
     static let ROW_STYLE_FLOATING_BUTTON = "floatingButton"
     static let ROW_STYLE_FLAT_WITH_CHECKMARK = "flatWithCheckmark"
+    
+    static let FORM_INSETS = "formInsetValues"
 }

--- a/src/types/PaymentSheet.ts
+++ b/src/types/PaymentSheet.ts
@@ -206,6 +206,9 @@ export type AppearanceParams = RecursivePartial<{
 
   /** Describes the appearance of the Embedded Mobile Payment Element */
   embeddedPaymentElement: EmbeddedPaymentElementAppearance;
+
+  /** Describes the inset values applied to Mobile Payment Element forms */
+  formInsetValues: EdgeInsetsConfig;
 }>;
 
 export type FontConfig = {
@@ -313,6 +316,11 @@ export type PrimaryButtonConfig = {
      * @default The root `appearance.shapes.shadow`
      */
     shadow: ShadowConfig;
+    /**
+     * The height of the primary button
+     * @default 48
+     */
+    height: number;
   };
 };
 

--- a/stripe-react-native.podspec
+++ b/stripe-react-native.podspec
@@ -2,7 +2,7 @@ require 'json'
 
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 # Keep stripe_version in sync with https://github.com/stripe/stripe-identity-react-native/blob/main/stripe-identity-react-native.podspec
-stripe_version = '~> 24.14.0'
+stripe_version = '~> 24.15.0'
 
 fabric_enabled = ENV['RCT_NEW_ARCH_ENABLED'] == '1'
 


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
Add `formInsetValues` and `PrimaryButtonConfig.shapes.height` to `AppearanceParams`
Update `stripe-ios` to version `24.15.0`
Update `stripe-android` to version `21.17.+`

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a link to the relevant issue, a code snippet, or an example project that demonstrates the bug. -->
https://jira.corp.stripe.com/browse/MOBILESDK-3610

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [X] I tested this manually
- [ ] I added automated tests

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
