### PR TITLE
Fix Android Build Error: Kotlin Argument Type Mismatch (ReadableMap? vs ReadableMap) (#1971)

### DIFF
--- a/android/src/main/java/com/reactnativestripesdk/EmbeddedPaymentElementViewManager.kt
+++ b/android/src/main/java/com/reactnativestripesdk/EmbeddedPaymentElementViewManager.kt
@@ -54,7 +54,9 @@ class EmbeddedPaymentElementViewManager :
     view: EmbeddedPaymentElementView,
     cfg: Dynamic,
   ) {
-    val elementConfig = parseElementConfiguration(cfg.asMap(), view.context)
+    val readableMap = cfg.asMap()
+    if (readableMap == null) return
+    val elementConfig = parseElementConfiguration(readableMap, view.context)
     view.latestElementConfig = elementConfig
     // if intentConfig is already set, configure immediately:
     view.latestIntentConfig?.let { intentCfg ->
@@ -71,7 +73,9 @@ class EmbeddedPaymentElementViewManager :
     view: EmbeddedPaymentElementView,
     cfg: Dynamic,
   ) {
-    val intentConfig = parseIntentConfiguration(cfg.asMap())
+    val readableMap = cfg.asMap()
+    if (readableMap == null) return
+    val intentConfig = parseIntentConfiguration(readableMap)
     view.latestIntentConfig = intentConfig
     view.latestElementConfig?.let { elemCfg ->
       view.configure(elemCfg, intentConfig)

--- a/android/src/main/java/com/reactnativestripesdk/pushprovisioning/AddToWalletButtonManager.kt
+++ b/android/src/main/java/com/reactnativestripesdk/pushprovisioning/AddToWalletButtonManager.kt
@@ -64,7 +64,9 @@ class AddToWalletButtonManager(
     view: AddToWalletButtonView,
     ephemeralKey: Dynamic,
   ) {
-    view.setEphemeralKey(ephemeralKey.asMap())
+    val map = ephemeralKey.asMap()
+    if (map == null) return
+    view.setEphemeralKey(map)
   }
 
   @ReactProp(name = "token")


### PR DESCRIPTION
## Summary

This PR fixes a build error on Android related to Kotlin argument type mismatch in the Stripe React Native SDK.  
The root issue was that `Dynamic.asMap()` can return `null` (i.e., type `ReadableMap?`), while the functions were expecting a non-nullable `ReadableMap`.  
This led to compilation failures when building on Android with React Native 0.70+.

The PR updates method signatures and usages in both `EmbeddedPaymentElementViewManager` and `AddToWalletButtonManager` to safely handle nullable `ReadableMap` types, preventing argument type mismatch and build errors.

## Motivation

The motivation is to resolve [issue #1971](https://github.com/stripe/stripe-react-native/issues/1971), which is a **blocking Android build error** for anyone using the Stripe React Native SDK with newer versions of React Native (0.70 and above).

The error message is similar to:
Argument type mismatch: actual type is ‘ReadableMap?’, but ‘ReadableMap’ was expected.

See also:  
- [#1971](https://github.com/stripe/stripe-react-native/issues/1971)
- [Relevant lines in EmbeddedPaymentElementViewManager.kt and AddToWalletButtonManager.kt]

## Testing

- [x] I tested this manually: Android build now succeeds, and EmbeddedPaymentElement/AddToWalletButton behave as expected in our production app.

## Documentation

- [x] This PR does not result in any developer-facing changes.

## Additional context

- See the [original issue #1971](https://github.com/stripe/stripe-react-native/issues/1971) for reproduction steps and error details.
- This PR only modifies type handling and null-safety for Kotlin interop, no changes to JS API or business logic.