### PR TITLE
Update tests to reflect new web page button text

### DIFF
--- a/e2e-tests/android-only/financial-connections-session.yml
+++ b/e2e-tests/android-only/financial-connections-session.yml
@@ -27,8 +27,8 @@ appId: ${APP_ID}
     text: "Manually verify instead"
 - tapOn: "Manually verify instead"
 - assertVisible:
-    text: "Use test account"
-- tapOn: "Use test account"
+    text: "Autofill"
+- tapOn: "Autofill"
 - assertVisible:
     text: "Not now"
 - tapOn: "Not now"

--- a/e2e-tests/android-only/financial-connections-token.yml
+++ b/e2e-tests/android-only/financial-connections-token.yml
@@ -27,8 +27,8 @@ appId: ${APP_ID}
     text: "Manually verify instead"
 - tapOn: "Manually verify instead"
 - assertVisible:
-    text: "Use test account"
-- tapOn: "Use test account"
+    text: "Autofill"
+- tapOn: "Autofill"
 - assertVisible:
     text: "Not now"
 - tapOn: "Not now"


### PR DESCRIPTION
## Summary
Tests were failing because the financial connections manual bank account info entry page has new button text for filling in test account details.

## Motivation
CI is better when it's not broken.

## Testing
- [x] I tested this manually
- [x] I added automated tests

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
