### PR TITLE
Add functionality to set userKeyLiveMode value for user keys.

### DIFF
--- a/ios/StripeSdkImpl.swift
+++ b/ios/StripeSdkImpl.swift
@@ -1,5 +1,5 @@
 import PassKit
-import Stripe
+@_spi(DashboardOnly) @_spi(STP) import Stripe
 @_spi(EmbeddedPaymentElementPrivateBeta) import StripePaymentSheet
 import StripeFinancialConnections
 import Foundation
@@ -93,6 +93,10 @@ public class StripeSdkImpl: NSObject, UIAdaptivePresentationControllerDelegate {
         STPAPIClient.shared.publishableKey = publishableKey
         StripeAPI.defaultPublishableKey = publishableKey
         STPAPIClient.shared.stripeAccount = stripeAccountId
+
+        if STPAPIClient.shared.publishableKeyIsUserKey {
+            STPAPIClient.shared.userKeyLiveMode = UserDefaults.standard.object(forKey: "stripe_userKeyLiveMode") as? Bool ?? true
+        }
 
         let name = appInfo["name"] as? String ?? ""
         let partnerId = appInfo["partnerId"] as? String ?? ""


### PR DESCRIPTION
## Summary
Provides dashboard functionality for setting live/test mode.

## How to use
```
useEffect(() => {
    Settings.set({'stripe_userKeyLiveMode': liveMode})
    initStripe({
      publishableKey: apiKey 
      stripeAccountId: accountId,
      urlScheme: scheme,
    });
  }, [apiKey, liveMode, accountId, scheme]);
  ```