### PR TITLE
Nightly e2e tests

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -5,6 +5,9 @@ on:
     branches: [master]
   pull_request:
     branches: ['**']
+  schedule:
+    - cron: '0 7 * * *' # run at 7 AM UTC, 12 AM PST
+  workflow_dispatch: # manually trigger the e2e tests
 
 jobs:
   test-android:
@@ -174,3 +177,17 @@ jobs:
           name: maestro-artifacts-ios-${{ matrix.react_arch }}
           path: e2e-artifacts
           include-hidden-files: true
+
+  send-slack-email:
+    # needs: [test-android, test-ios]
+    # if: always()
+    # if: ${{ failure() && github.event_name == 'schedule'}}
+    name: e2e-test-fail-slack-email
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Send email Notification
+        uses: dawidd6/action-send-mail@v6
+        with:
+          to: "${{secrets.RUN_SLACK_EMAIL}}"
+          subject: 'Test React NativeE2E slack notification'
+          body: 'This is a test email'

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -180,7 +180,6 @@ jobs:
 
   send-slack-email:
     # needs: [test-android, test-ios]
-    # if: always()
     # if: ${{ failure() && github.event_name == 'schedule'}}
     name: e2e-test-fail-slack-email
     runs-on: ubuntu-24.04

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -113,12 +113,10 @@ jobs:
         # if: ${{ failure() && github.event_name == 'schedule'}}
         uses: slackapi/slack-github-action@v1.23.0
         with:
+          webhook: ${{ secrets.SLACK_RUN_CHANNEL_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
           payload: |
-            {
               "text": "testMessage REACT NATIVE Android E2E TESTS COMPLETED TEST"
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_RUN_CHANNEL_WEBHOOK_URL }}
 
   test-ios:
     name: e2e-ios-test
@@ -193,9 +191,7 @@ jobs:
         # if: ${{ failure() && github.event_name == 'schedule'}}
         uses: slackapi/slack-github-action@v1.23.0
         with:
+          webhook: ${{ secrets.SLACK_RUN_CHANNEL_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
           payload: |
-            {
               "text": "testMessage REACT NATIVE IOS E2E TESTS COMPLETED TEST"
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_RUN_CHANNEL_WEBHOOK_URL }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -111,7 +111,7 @@ jobs:
 
       - name: Send Slack notification
         # if: ${{ failure() && github.event_name == 'schedule'}}
-        uses: slackapi/slack-github-action@v1.23.0
+        uses: slackapi/slack-github-action@v2.1.1
         with:
           webhook: ${{ secrets.SLACK_RUN_CHANNEL_WEBHOOK_URL }}
           webhook-type: incoming-webhook
@@ -189,7 +189,7 @@ jobs:
 
       - name: Send Slack notification
         # if: ${{ failure() && github.event_name == 'schedule'}}
-        uses: slackapi/slack-github-action@v1.23.0
+        uses: slackapi/slack-github-action@v2.1.1
         with:
           webhook: ${{ secrets.SLACK_RUN_CHANNEL_WEBHOOK_URL }}
           webhook-type: incoming-webhook

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -110,13 +110,13 @@ jobs:
           include-hidden-files: true
 
       - name: Send Slack notification
-        # if: ${{ failure() && github.event_name == 'schedule'}}
+        if: ${{ failure() && github.event_name == 'schedule'}}
         uses: slackapi/slack-github-action@v2.1.1
         with:
           webhook: ${{ secrets.SLACK_RUN_CHANNEL_WEBHOOK_URL }}
           webhook-type: incoming-webhook
           payload: |
-              "text": " TEST MESSAGE *Nightly Build Failed* for ReactNative Android-${{ matrix.react_arch }}\nSee details: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+              "text": " *Nightly Build Failed* for e2e-android-test ( ${{ matrix.react_arch }} )\nSee details: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
   test-ios:
     name: e2e-ios-test
@@ -188,10 +188,10 @@ jobs:
           include-hidden-files: true
 
       - name: Send Slack notification
-        # if: ${{ failure() && github.event_name == 'schedule'}}
+        if: ${{ failure() && github.event_name == 'schedule'}}
         uses: slackapi/slack-github-action@v2.1.1
         with:
           webhook: ${{ secrets.SLACK_RUN_CHANNEL_WEBHOOK_URL }}
           webhook-type: incoming-webhook
           payload: |
-              "text": " TEST MESSAGE *Nightly Build Failed* for ReactNative iOS-${{ matrix.react_arch }}\nSee details: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+              "text": "*Nightly Build Failed* for e2e-ios-test ( ${{ matrix.react_arch }} )\nSee details: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -177,17 +177,3 @@ jobs:
           name: maestro-artifacts-ios-${{ matrix.react_arch }}
           path: e2e-artifacts
           include-hidden-files: true
-
-  send-slack-email:
-    # needs: [test-android, test-ios]
-    # if: ${{ failure() && github.event_name == 'schedule'}}
-    name: e2e-test-fail-slack-email
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Send email Notification
-        uses: dawidd6/action-send-mail@v6
-        with:
-          to: "${{secrets.RUN_SLACK_EMAIL}}"
-          from: 'React Native E2E Test Github Action'
-          subject: 'Test React NativeE2E slack notification'
-          body: 'This is a test email'

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -109,6 +109,17 @@ jobs:
           path: e2e-artifacts
           include-hidden-files: true
 
+      - name: Send Slack notification
+        # if: ${{ failure() && github.event_name == 'schedule'}}
+        uses: slackapi/slack-github-action@v1.23.0
+        with:
+          payload: |
+            {
+              "text": "testMessage REACT NATIVE Android E2E TESTS COMPLETED TEST"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_RUN_CHANNEL_WEBHOOK_URL }}
+
   test-ios:
     name: e2e-ios-test
     # Silicon chips run through the iOS tests much faster
@@ -177,3 +188,14 @@ jobs:
           name: maestro-artifacts-ios-${{ matrix.react_arch }}
           path: e2e-artifacts
           include-hidden-files: true
+
+      - name: Send Slack notification
+        # if: ${{ failure() && github.event_name == 'schedule'}}
+        uses: slackapi/slack-github-action@v1.23.0
+        with:
+          payload: |
+            {
+              "text": "testMessage REACT NATIVE IOS E2E TESTS COMPLETED TEST"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_RUN_CHANNEL_WEBHOOK_URL }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -6,8 +6,7 @@ on:
   pull_request:
     branches: ['**']
   schedule:
-    branches: [master]
-    cron: '0 7 * * *' # run at 7 AM UTC, 12 AM PST
+    - cron: '0 7 * * *' # run at 7 AM UTC, 12 AM PST
   workflow_dispatch: # manually trigger the e2e tests
 
 jobs:
@@ -117,7 +116,7 @@ jobs:
           webhook: ${{ secrets.SLACK_RUN_CHANNEL_WEBHOOK_URL }}
           webhook-type: incoming-webhook
           payload: |
-              "text": "testMessage REACT NATIVE Android E2E TESTS COMPLETED TEST"
+              "text": " TEST MESSAGE *Nightly Build Failed* for ReactNative Android-${{ matrix.react_arch }}\nSee details: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
   test-ios:
     name: e2e-ios-test
@@ -195,4 +194,4 @@ jobs:
           webhook: ${{ secrets.SLACK_RUN_CHANNEL_WEBHOOK_URL }}
           webhook-type: incoming-webhook
           payload: |
-              "text": "testMessage REACT NATIVE IOS E2E TESTS COMPLETED TEST"
+              "text": " TEST MESSAGE *Nightly Build Failed* for ReactNative iOS-${{ matrix.react_arch }}\nSee details: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -6,7 +6,8 @@ on:
   pull_request:
     branches: ['**']
   schedule:
-    - cron: '0 7 * * *' # run at 7 AM UTC, 12 AM PST
+    branches: [master]
+    cron: '0 7 * * *' # run at 7 AM UTC, 12 AM PST
   workflow_dispatch: # manually trigger the e2e tests
 
 jobs:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -188,5 +188,6 @@ jobs:
         uses: dawidd6/action-send-mail@v6
         with:
           to: "${{secrets.RUN_SLACK_EMAIL}}"
+          from: 'React Native E2E Test Github Action'
           subject: 'Test React NativeE2E slack notification'
           body: 'This is a test email'


### PR DESCRIPTION
## Summary
Added a scheduled midnight PT E2E test run.

Also added a job to the work flow that sends an email to the run slack channel. Currently testing that this sends an email to the slack channel as intended.

## Motivation
https://jira.corp.stripe.com/browse/RUN_MOBILESDK-4464
Incident remediation for violet lonely

## Testing
I need to test that this works on github
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [ ] I tested this manually
- [ ] I added automated tests
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [X] This PR does not result in any developer-facing changes.
