### PR TITLE
Propose 0.50.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## x.x.x - x.x.x
+## 0.51.0 - 2025-07-22
 
 **Fixes**
 - Fixed embedded payment element color support to accept both single color strings and light/dark color objects for `ThemedColor` properties (separatorColor, selectedColor, unselectedColor, checkmark color, chevron color).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## 0.51.0 - 2025-07-22
+## 0.50.1 - 2025-07-22
 
 **Fixes**
 - Fixed embedded payment element color support to accept both single color strings and light/dark color objects for `ThemedColor` properties (separatorColor, selectedColor, unselectedColor, checkmark color, chevron color).


### PR DESCRIPTION
- [x] Ensure the CHANGELOG is up to date with all relevant commits since the last release
- [x] Add the version number for this release & the date to the CHANGELOG, underneath "## Unreleased" 
  - e.g. "## 1.2.3 - 2022-02-14"
- [x] Update the README if necessary (this is only required when there are breaking changes in the release, such as dropping support for an iOS || Android version)