### PR TITLE
fix: Make currencyCode optional for setup mode on Android to match iOS behavior

### DIFF
--- a/android/src/main/java/com/reactnativestripesdk/PaymentSheetFragment.kt
+++ b/android/src/main/java/com/reactnativestripesdk/PaymentSheetFragment.kt
@@ -617,14 +617,13 @@ class PaymentSheetFragment :
     }
 
     @OptIn(PaymentMethodOptionsSetupFutureUsagePreview::class)
-    private fun buildIntentConfigurationMode(modeParams: Bundle): PaymentSheet.IntentConfiguration.Mode {
-      val currencyCode =
-        modeParams.getString("currencyCode")
-          ?: throw PaymentSheetException(
-            "You must provide a value to intentConfiguration.mode.currencyCode",
-          )
-
-      return if (modeParams.containsKey("amount")) {
+    private fun buildIntentConfigurationMode(modeParams: Bundle): PaymentSheet.IntentConfiguration.Mode =
+      if (modeParams.containsKey("amount")) {
+        val currencyCode =
+          modeParams.getString("currencyCode")
+            ?: throw PaymentSheetException(
+              "You must provide a value to intentConfiguration.mode.currencyCode",
+            )
         PaymentSheet.IntentConfiguration.Mode.Payment(
           amount = modeParams.getInt("amount").toLong(),
           currency = currencyCode,
@@ -639,11 +638,10 @@ class PaymentSheetFragment :
               "You must provide a value to intentConfiguration.mode.setupFutureUsage",
             )
         PaymentSheet.IntentConfiguration.Mode.Setup(
-          currency = currencyCode,
+          currency = modeParams.getString("currencyCode"),
           setupFutureUse = setupFutureUsage,
         )
       }
-    }
 
     @OptIn(ExperimentalCustomerSessionApi::class)
     @Throws(PaymentSheetException::class)


### PR DESCRIPTION
## Summary
- Fixes platform inconsistency where Android required `currencyCode` in setup mode but iOS didn't
- Enables deferred payment flows on Android by making `currencyCode` optional in setup mode
- Maintains backward compatibility for payment mode

## Problem
Users reported crashes when trying to add payment methods without creating a Payment Intent first on Android, while the same code worked fine on iOS. The issue was in `buildIntentConfigurationMode()` which required `currencyCode` regardless of payment vs setup mode.

## Solution
- **Payment mode**: Still requires `currencyCode` (unchanged behavior)
- **Setup mode**: `currencyCode` is now optional (matches iOS behavior)
- Moved currency validation inside mode-specific branches

## Test plan
- [x] Build passes (`./gradlew build`)
- [x] Code formatting applied (`./gradlew spotlessApply`)
- [x] Setup mode works without `currencyCode`
- [x] Payment mode still requires `currencyCode`
- [x] No regressions in existing functionality

## References
- Fixes RUN_MOBILESDK-4409
- File: `src/main/java/com/reactnativestripesdk/PaymentSheetFragment.kt`
- iOS reference: `ios/StripeSdkImpl+PaymentSheet.swift:308`

🤖 Generated with [Claude Code](https://claude.ai/code)