### PR TITLE
Handle safe area in embedded app and fix crash

### DIFF
--- a/example/src/screens/EmbeddedPaymentElementScreen.tsx
+++ b/example/src/screens/EmbeddedPaymentElementScreen.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Alert, View, Text, Modal } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import Button from '../components/Button';
 import PaymentScreen from '../components/PaymentScreen';
 import CustomerSessionSwitch from '../components/CustomerSessionSwitch';
@@ -363,7 +364,7 @@ export default function EmbeddedPaymentElementScreen() {
           setModalVisible(false);
         }}
       >
-        <View style={{ padding: 20 }}>
+        <SafeAreaView style={{ padding: 20 }}>
           <PaymentElementView
             elementConfig={elementConfig}
             intentConfig={intentConfig}
@@ -375,7 +376,7 @@ export default function EmbeddedPaymentElementScreen() {
               setModalVisible(false);
             }}
           />
-        </View>
+        </SafeAreaView>
       </Modal>
     </PaymentScreen>
   );

--- a/example/src/screens/EmbeddedPaymentElementScreen.tsx
+++ b/example/src/screens/EmbeddedPaymentElementScreen.tsx
@@ -353,10 +353,12 @@ export default function EmbeddedPaymentElementScreen() {
           }}
         />
       </View>
-      <PaymentElementView
-        elementConfig={elementConfig}
-        intentConfig={intentConfig}
-      />
+      {!modalVisible && (
+        <PaymentElementView
+          elementConfig={elementConfig}
+          intentConfig={intentConfig}
+        />
+      )}
       <Modal
         visible={modalVisible}
         animationType="slide"


### PR DESCRIPTION
## Summary
- Lay the embedded view out in the safe area to prevent it from being smushed.
- Fix modal crash on second open. The root cause of the issue was multiple concurrent EmbeddedPaymentElement instances causing conflicts in the native layer, which was resolved by implementing conditional rendering to ensure only one PaymentElementView exists at a time.