### PR TITLE
Post FC test failures to Slack

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -83,6 +83,7 @@ jobs:
           echo "${HOME}/.maestro/bin" >> $GITHUB_PATH
 
       - name: Run Android Emulator and app
+        id: android_tests
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 33
@@ -108,6 +109,60 @@ jobs:
           name: maestro-artifacts-android-${{ matrix.react_arch }}
           path: e2e-artifacts
           include-hidden-files: true
+
+      - name: Send Financial Connections Slack notification
+        if: always() && steps.android_tests.outputs.FINANCIAL_CONNECTIONS_TESTS_FAILED == 'true'
+        uses: slackapi/slack-github-action@v2.1.1
+        with:
+          webhook: ${{ secrets.SLACK_LINK_MOBILE_ALERT_CHANNEL_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": "🚨 *Financial Connections Tests Failed* on Android (${{ matrix.react_arch }})",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "🚨 *Financial Connections Tests Failed* on Android (${{ matrix.react_arch }})"
+                  }
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Failed Tests:*\n${{ steps.android_tests.outputs.FAILED_FC_TESTS }}"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Branch:*\n${{ github.ref_name }}"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Commit:*\n${{ github.sha }}"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Triggered by:*\n${{ github.event_name }}"
+                    }
+                  ]
+                },
+                {
+                  "type": "actions",
+                  "elements": [
+                    {
+                      "type": "button",
+                      "text": {
+                        "type": "plain_text",
+                        "text": "View Build"
+                      },
+                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    }
+                  ]
+                }
+              ]
+            }
 
       - name: Send Slack notification
         if: ${{ failure() && github.event_name == 'schedule'}}
@@ -176,6 +231,7 @@ jobs:
           yarn run-example-ios:release
 
       - name: Run tests
+        id: ios_tests
         run: |
           yarn test:e2e:ios
 
@@ -186,6 +242,60 @@ jobs:
           name: maestro-artifacts-ios-${{ matrix.react_arch }}
           path: e2e-artifacts
           include-hidden-files: true
+
+      - name: Send Financial Connections Slack notification
+        if: always() && steps.ios_tests.outputs.FINANCIAL_CONNECTIONS_TESTS_FAILED == 'true'
+        uses: slackapi/slack-github-action@v2.1.1
+        with:
+          webhook: ${{ secrets.SLACK_LINK_MOBILE_ALERT_CHANNEL_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": "🚨 *Financial Connections Tests Failed* on iOS (${{ matrix.react_arch }})",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "🚨 *Financial Connections Tests Failed* on iOS (${{ matrix.react_arch }})"
+                  }
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Failed Tests:*\n${{ steps.ios_tests.outputs.FAILED_FC_TESTS }}"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Branch:*\n${{ github.ref_name }}"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Commit:*\n${{ github.sha }}"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Triggered by:*\n${{ github.event_name }}"
+                    }
+                  ]
+                },
+                {
+                  "type": "actions",
+                  "elements": [
+                    {
+                      "type": "button",
+                      "text": {
+                        "type": "plain_text",
+                        "text": "View Build"
+                      },
+                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    }
+                  ]
+                }
+              ]
+            }
 
       - name: Send Slack notification
         if: ${{ failure() && github.event_name == 'schedule'}}

--- a/scripts/run-maestro-tests
+++ b/scripts/run-maestro-tests
@@ -25,6 +25,8 @@ else
 fi
 
 failedTests=()
+failedFinancialConnectionsTests=()
+
 for file in $allTestFiles
 do
   testName=$(basename "${file%.*}")
@@ -40,10 +42,22 @@ do
       if ! eval "$testCmd --debug-output e2e-artifacts/$testName-retry-2";
       then
         failedTests+=("$file")
+        # Check if this is a Financial Connections test
+        if [[ "$testName" == *"financial-connections"* ]]; then
+          failedFinancialConnectionsTests+=("$file")
+        fi
       fi
     fi
   fi
 done
+
+# Output information for GitHub Actions
+if [ ${#failedFinancialConnectionsTests[@]} -gt 0 ]; then
+    echo "FINANCIAL_CONNECTIONS_TESTS_FAILED=true" >> $GITHUB_OUTPUT
+    echo "FAILED_FC_TESTS=${failedFinancialConnectionsTests[*]}" >> $GITHUB_OUTPUT
+else
+    echo "FINANCIAL_CONNECTIONS_TESTS_FAILED=false" >> $GITHUB_OUTPUT
+fi
 
 if [ ${#failedTests[@]} -eq 0 ]; then
     exit 0


### PR DESCRIPTION
## Summary

Posts a Slack message to #link-mobile-alerts whenever a Financial Connections test fails. Uses the `Link Mobile Alerts` Slack app / webhooks.

## Motivation

https://jira.corp.stripe.com/browse/RUN_LINK_MOBILE-16

## Testing

N/a

## Documentation

N/a