### PR TITLE
Auto select SPMs in embedded.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 **Fixes**
 - Fixed missing `onCustomPaymentMethodConfirmHandlerCallback` in old architecture codegen patch. This resolves pod install failures when using React Native 0.74+ with old architecture and custom payment methods.
+- Fixes an issue where saved payment methods weren't auto selected when using `EmbeddedPaymentElement` on Android.
 
 ## 0.50.1 - 2025-07-22
 

--- a/src/types/EmbeddedPaymentElement.tsx
+++ b/src/types/EmbeddedPaymentElement.tsx
@@ -415,19 +415,9 @@ export function useEmbeddedPaymentElement(
       elementRef.current = el;
       setElement(el);
     })();
-    const getCurrentRef = () => viewRef.current;
-
     return () => {
       active = false;
-      elementRef.current?.clearPaymentOption();
       elementRef.current = null;
-
-      const currentRef = getCurrentRef();
-
-      if (isAndroid && currentRef) {
-        Commands.clearPaymentOption(currentRef);
-      }
-
       setElement(null);
     };
   }, [intentConfig, configuration, viewRef, isAndroid]);


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
We don't need to clear the payment option as part of any lifecycle event. It should only happen as part of merchant integrations. The native embedded payment element will do the right thing if a selected payment option is no longer supported.
