### PR TITLE
Bump native libs, rename FlatWithChevron

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## x.x.x - x-x-x
 
+**Changes**
+- Renamed `RowStyle.FlatWithChevron` to `RowStyle.FlatWithDisclosure` and updated related interfaces (`ChevronConfig` → `DisclosureConfig`).
+- Updated `stripe-ios` to 24.19.0
+- Updated `stripe-android` to 21.22.+
+
 **Fixes**
 - Fixed missing `onCustomPaymentMethodConfirmHandlerCallback` in old architecture codegen patch. This resolves pod install failures when using React Native 0.74+ with old architecture and custom payment methods.
 

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -3,4 +3,4 @@ StripeSdk_compileSdkVersion=30
 StripeSdk_targetSdkVersion=28
 StripeSdk_minSdkVersion=21
 # Keep StripeSdk_stripeVersion in sync with https://github.com/stripe/stripe-identity-react-native/blob/main/android/gradle.properties
-StripeSdk_stripeVersion=21.19.+
+StripeSdk_stripeVersion=21.22.+

--- a/android/src/main/java/com/reactnativestripesdk/PaymentSheetAppearance.kt
+++ b/android/src/main/java/com/reactnativestripesdk/PaymentSheetAppearance.kt
@@ -341,7 +341,7 @@ private fun buildEmbeddedAppearance(
         val checkmarkParams = getBundleOrNull(flatParams, PaymentSheetAppearanceKeys.CHECKMARK)
         val separatorInsetsParams = getBundleOrNull(flatParams, PaymentSheetAppearanceKeys.SEPARATOR_INSETS)
 
-        // Default separator insets specific to FlatWithCheckmark and FlatWithChevron
+        // Default separator insets specific to FlatWithCheckmark and FlatWithDisclosure
         val defaultSeparatorStartInsetDp = 0.0f
         val defaultSeparatorEndInsetDp = 0.0f
 
@@ -392,12 +392,12 @@ private fun buildEmbeddedAppearance(
           colorsDark = flatCheckmarkColors,
         )
       }
-      "flatWithChevron" -> {
+      "flatWithDisclosure" -> {
         val flatParams = getBundleOrNull(rowParams, PaymentSheetAppearanceKeys.FLAT)
-        val chevronParams = getBundleOrNull(flatParams, PaymentSheetAppearanceKeys.CHEVRON)
+        val disclosureParams = getBundleOrNull(flatParams, PaymentSheetAppearanceKeys.DISCLOSURE)
         val separatorInsetsParams = getBundleOrNull(flatParams, PaymentSheetAppearanceKeys.SEPARATOR_INSETS)
 
-        // Default separator insets specific to FlatWithCheckmark and FlatWithChevron
+        // Default separator insets specific to FlatWithCheckmark and FlatWithDisclosure
         val defaultSeparatorStartInsetDp = 0.0f
         val defaultSeparatorEndInsetDp = 0.0f
 
@@ -418,32 +418,33 @@ private fun buildEmbeddedAppearance(
             Color.GRAY,
           )
 
-        val parsedChevronColor =
+        val parsedDisclosureColor =
           dynamicColorFromParams(
             context,
-            chevronParams,
+            disclosureParams,
             PaymentSheetAppearanceKeys.COLOR,
             defaultColors.componentBorder, // Default to component border color like other elements
           )
 
         // Create the required Colors object
-        val flatChevronColors =
-          PaymentSheet.Appearance.Embedded.RowStyle.FlatWithChevron.Colors(
+        val flatDisclosureColors =
+          PaymentSheet.Appearance.Embedded.RowStyle.FlatWithDisclosure.Colors(
             separatorColor = parsedSeparatorColor,
-            chevronColor = parsedChevronColor,
+            disclosureColor = parsedDisclosureColor,
           )
 
-        PaymentSheet.Appearance.Embedded.RowStyle.FlatWithChevron(
-          separatorThicknessDp = separatorThickness,
-          startSeparatorInsetDp = startSeparatorInset,
-          endSeparatorInsetDp = endSeparatorInset,
-          topSeparatorEnabled = topEnabled,
-          bottomSeparatorEnabled = bottomEnabled,
-          additionalVerticalInsetsDp = additionalInsets,
-          horizontalInsetsDp = 0.0F, // We do not have an iOS equal for this API so it's not configurable in React Native
-          colorsLight = flatChevronColors,
-          colorsDark = flatChevronColors,
-        )
+        PaymentSheet.Appearance.Embedded.RowStyle.FlatWithDisclosure
+          .Builder()
+          .separatorThicknessDp(separatorThickness)
+          .startSeparatorInsetDp(startSeparatorInset)
+          .endSeparatorInsetDp(endSeparatorInset)
+          .topSeparatorEnabled(topEnabled)
+          .bottomSeparatorEnabled(bottomEnabled)
+          .additionalVerticalInsetsDp(additionalInsets)
+          .horizontalInsetsDp(0.0F) // We do not have an iOS equal for this API so it's not configurable in React Native
+          .colorsLight(flatDisclosureColors)
+          .colorsDark(flatDisclosureColors)
+          .build()
       }
       "floatingButton" -> {
         val floatingParams = getBundleOrNull(rowParams, PaymentSheetAppearanceKeys.FLOATING)
@@ -670,7 +671,7 @@ private class PaymentSheetAppearanceKeys {
     const val SELECTED_COLOR = "selectedColor"
     const val UNSELECTED_COLOR = "unselectedColor"
     const val CHECKMARK = "checkmark"
-    const val CHEVRON = "chevron"
+    const val DISCLOSURE = "disclosure"
     const val COLOR = "color"
     const val CHECKMARK_INSET = "inset"
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1685,13 +1685,13 @@ PODS:
     - ReactCommon/turbomodule/core
     - Yoga
   - SocketRocket (0.7.1)
-  - Stripe (24.16.1):
-    - StripeApplePay (= 24.16.1)
-    - StripeCore (= 24.16.1)
-    - StripePayments (= 24.16.1)
-    - StripePaymentsUI (= 24.16.1)
-    - StripeUICore (= 24.16.1)
-  - stripe-react-native (0.49.0):
+  - Stripe (24.19.0):
+    - StripeApplePay (= 24.19.0)
+    - StripeCore (= 24.19.0)
+    - StripePayments (= 24.19.0)
+    - StripePaymentsUI (= 24.19.0)
+    - StripeUICore (= 24.19.0)
+  - stripe-react-native (0.50.1):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1711,15 +1711,15 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - Stripe (~> 24.16.1)
-    - stripe-react-native/NewArch (= 0.49.0)
-    - StripeApplePay (~> 24.16.1)
-    - StripeFinancialConnections (~> 24.16.1)
-    - StripePayments (~> 24.16.1)
-    - StripePaymentSheet (~> 24.16.1)
-    - StripePaymentsUI (~> 24.16.1)
+    - Stripe (~> 24.19.0)
+    - stripe-react-native/NewArch (= 0.50.1)
+    - StripeApplePay (~> 24.19.0)
+    - StripeFinancialConnections (~> 24.19.0)
+    - StripePayments (~> 24.19.0)
+    - StripePaymentSheet (~> 24.19.0)
+    - StripePaymentsUI (~> 24.19.0)
     - Yoga
-  - stripe-react-native/NewArch (0.49.0):
+  - stripe-react-native/NewArch (0.50.1):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1739,62 +1739,35 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - Stripe (~> 24.16.1)
-    - StripeApplePay (~> 24.16.1)
-    - StripeFinancialConnections (~> 24.16.1)
-    - StripePayments (~> 24.16.1)
-    - StripePaymentSheet (~> 24.16.1)
-    - StripePaymentsUI (~> 24.16.1)
+    - Stripe (~> 24.19.0)
+    - StripeApplePay (~> 24.19.0)
+    - StripeFinancialConnections (~> 24.19.0)
+    - StripePayments (~> 24.19.0)
+    - StripePaymentSheet (~> 24.19.0)
+    - StripePaymentsUI (~> 24.19.0)
     - Yoga
-  - stripe-react-native/Tests (0.49.0):
-    - DoubleConversion
-    - glog
-    - hermes-engine
-    - RCT-Folly (= 2024.11.18.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-ImageManager
-    - React-NativeModulesApple
-    - React-RCTFabric
-    - React-rendererdebug
-    - React-utils
-    - ReactCodegen
-    - ReactCommon/turbomodule/bridging
-    - ReactCommon/turbomodule/core
-    - Stripe (~> 24.16.1)
-    - StripeApplePay (~> 24.16.1)
-    - StripeFinancialConnections (~> 24.16.1)
-    - StripePayments (~> 24.16.1)
-    - StripePaymentSheet (~> 24.16.1)
-    - StripePaymentsUI (~> 24.16.1)
-    - Yoga
-  - StripeApplePay (24.16.1):
-    - StripeCore (= 24.16.1)
-  - StripeCore (24.16.1)
-  - StripeFinancialConnections (24.16.1):
-    - StripeCore (= 24.16.1)
-    - StripeUICore (= 24.16.1)
-  - StripePayments (24.16.1):
-    - StripeCore (= 24.16.1)
-    - StripePayments/Stripe3DS2 (= 24.16.1)
-  - StripePayments/Stripe3DS2 (24.16.1):
-    - StripeCore (= 24.16.1)
-  - StripePaymentSheet (24.16.1):
-    - StripeApplePay (= 24.16.1)
-    - StripeCore (= 24.16.1)
-    - StripePayments (= 24.16.1)
-    - StripePaymentsUI (= 24.16.1)
-  - StripePaymentsUI (24.16.1):
-    - StripeCore (= 24.16.1)
-    - StripePayments (= 24.16.1)
-    - StripeUICore (= 24.16.1)
-  - StripeUICore (24.16.1):
-    - StripeCore (= 24.16.1)
+  - StripeApplePay (24.19.0):
+    - StripeCore (= 24.19.0)
+  - StripeCore (24.19.0)
+  - StripeFinancialConnections (24.19.0):
+    - StripeCore (= 24.19.0)
+    - StripeUICore (= 24.19.0)
+  - StripePayments (24.19.0):
+    - StripeCore (= 24.19.0)
+    - StripePayments/Stripe3DS2 (= 24.19.0)
+  - StripePayments/Stripe3DS2 (24.19.0):
+    - StripeCore (= 24.19.0)
+  - StripePaymentSheet (24.19.0):
+    - StripeApplePay (= 24.19.0)
+    - StripeCore (= 24.19.0)
+    - StripePayments (= 24.19.0)
+    - StripePaymentsUI (= 24.19.0)
+  - StripePaymentsUI (24.19.0):
+    - StripeCore (= 24.19.0)
+    - StripePayments (= 24.19.0)
+    - StripeUICore (= 24.19.0)
+  - StripeUICore (24.19.0):
+    - StripeCore (= 24.19.0)
   - Yoga (0.0.0)
 
 DEPENDENCIES:
@@ -1872,7 +1845,6 @@ DEPENDENCIES:
   - "RNCPicker (from `../node_modules/@react-native-picker/picker`)"
   - RNScreens (from `../node_modules/react-native-screens`)
   - "stripe-react-native (from `../node_modules/@stripe/stripe-react-native`)"
-  - "stripe-react-native/Tests (from `../node_modules/@stripe/stripe-react-native`)"
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
 
 SPEC REPOS:
@@ -2109,17 +2081,17 @@ SPEC CHECKSUMS:
   RNCPicker: ffbd7b9fc7c1341929e61dbef6219f7860f57418
   RNScreens: 991214b4e69016c1ae32830d9cea31c9c9422367
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
-  Stripe: 4a3519963904b46b2a5a051022f4e67d2831aff6
-  stripe-react-native: d1a3ffe2f89dcbe2ab68d8e0fd19f7af7d5863b4
-  StripeApplePay: 4303d484ec3b43d96b73a3127470674f8484a27d
-  StripeCore: 45ccc543ea1d54f00f03dd4813b4ab1071ae5d34
-  StripeFinancialConnections: 983bd6b15f8a1e7be40943bc5a87b41aa2acb3f7
-  StripePayments: 3f3cd1970de45f1d26d263bb5a6be5cfd9df93eb
-  StripePaymentSheet: edfe0ecd4d1d25ac3a3bda7c53e80e7c2df7a1e0
-  StripePaymentsUI: f3e663c841a0c9303e315f61db145f96667db9c0
-  StripeUICore: 1ddbdd49d9fde119d9e64c17e7e79d49c29ccb98
+  Stripe: d1824162e4bcb6ead10401a0dc8e8a3d5ffee41f
+  stripe-react-native: 3b98d0ee40e0d7c623101e14c0d9197d196e8e6f
+  StripeApplePay: eb64705d3c919492b1b28876652fd0aca2db38cc
+  StripeCore: b5bee05167f0c8ccce936244a031a9972fdeade8
+  StripeFinancialConnections: fd6c661f86f47b1d26a32f588b3a0b09826aba84
+  StripePayments: cf00b3c85cd7b57e40f622493f81bdf361cb3982
+  StripePaymentSheet: b126816213ae4f56ff4525ad25f94bb985a43e27
+  StripePaymentsUI: 05d4be35b34f821d5ddc8617dee04219f3646253
+  StripeUICore: d07bd63a4b53dee8cab4d6f81ce5a7ab3e28511e
   Yoga: 9b7fb56e7b08cde60e2153344fa6afbd88e5d99f
 
-PODFILE CHECKSUM: a2ed964678852d4cc306ff4add3e4fa90be77ea6
+PODFILE CHECKSUM: 7c3fc4b13a8a44eacacfd730f90b1c4f872efeb8
 
 COCOAPODS: 1.15.2

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1746,6 +1746,33 @@ PODS:
     - StripePaymentSheet (~> 24.19.0)
     - StripePaymentsUI (~> 24.19.0)
     - Yoga
+  - stripe-react-native/Tests (0.50.1):
+    - DoubleConversion
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.11.18.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - Stripe (~> 24.19.0)
+    - StripeApplePay (~> 24.19.0)
+    - StripeFinancialConnections (~> 24.19.0)
+    - StripePayments (~> 24.19.0)
+    - StripePaymentSheet (~> 24.19.0)
+    - StripePaymentsUI (~> 24.19.0)
+    - Yoga
   - StripeApplePay (24.19.0):
     - StripeCore (= 24.19.0)
   - StripeCore (24.19.0)
@@ -1845,6 +1872,7 @@ DEPENDENCIES:
   - "RNCPicker (from `../node_modules/@react-native-picker/picker`)"
   - RNScreens (from `../node_modules/react-native-screens`)
   - "stripe-react-native (from `../node_modules/@stripe/stripe-react-native`)"
+  - "stripe-react-native/Tests (from `../node_modules/@stripe/stripe-react-native`)"
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
 
 SPEC REPOS:
@@ -2082,7 +2110,7 @@ SPEC CHECKSUMS:
   RNScreens: 991214b4e69016c1ae32830d9cea31c9c9422367
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Stripe: d1824162e4bcb6ead10401a0dc8e8a3d5ffee41f
-  stripe-react-native: 3b98d0ee40e0d7c623101e14c0d9197d196e8e6f
+  stripe-react-native: 0a175dece5787169285638bb62d071d72f75ec0b
   StripeApplePay: eb64705d3c919492b1b28876652fd0aca2db38cc
   StripeCore: b5bee05167f0c8ccce936244a031a9972fdeade8
   StripeFinancialConnections: fd6c661f86f47b1d26a32f588b3a0b09826aba84
@@ -2092,6 +2120,6 @@ SPEC CHECKSUMS:
   StripeUICore: d07bd63a4b53dee8cab4d6f81ce5a7ab3e28511e
   Yoga: 9b7fb56e7b08cde60e2153344fa6afbd88e5d99f
 
-PODFILE CHECKSUM: 7c3fc4b13a8a44eacacfd730f90b1c4f872efeb8
+PODFILE CHECKSUM: a2ed964678852d4cc306ff4add3e4fa90be77ea6
 
 COCOAPODS: 1.15.2

--- a/example/src/screens/EmbeddedPaymentElementImmediateActionScreen.tsx
+++ b/example/src/screens/EmbeddedPaymentElementImmediateActionScreen.tsx
@@ -141,9 +141,9 @@ export default function EmbeddedPaymentElementImmediateActionScreen() {
         },
         embeddedPaymentElement: {
           row: {
-            style: RowStyle.FlatWithChevron,
+            style: RowStyle.FlatWithDisclosure,
             flat: {
-              chevron: { color: '#90EE90' }, // Light green color
+              disclosure: { color: '#90EE90' }, // Light green color
             },
           },
         },

--- a/ios/PaymentSheetAppearance.swift
+++ b/ios/PaymentSheetAppearance.swift
@@ -185,8 +185,8 @@ internal class PaymentSheetAppearance {
                   row.style = .floatingButton
               case PaymentSheetAppearanceKeys.ROW_STYLE_FLAT_WITH_CHECKMARK:
                   row.style = .flatWithCheckmark
-              case PaymentSheetAppearanceKeys.ROW_STYLE_FLAT_WITH_CHEVRON:
-                  row.style = .flatWithChevron
+              case PaymentSheetAppearanceKeys.ROW_STYLE_FLAT_WITH_DISCLOSURE:
+                  row.style = .flatWithDisclosure
               default:
                   throw PaymentSheetAppearanceError.invalidRowStyle(styleString)
               }
@@ -240,8 +240,8 @@ internal class PaymentSheetAppearance {
               flat.checkmark = try buildEmbeddedCheckmark(params: checkmarkParams)
           }
 
-          if let chevronParams = params[PaymentSheetAppearanceKeys.CHEVRON] as? NSDictionary {
-              flat.chevron = try buildEmbeddedChevron(params: chevronParams)
+          if let disclosureParams = params[PaymentSheetAppearanceKeys.DISCLOSURE] as? NSDictionary {
+              flat.disclosure = try buildEmbeddedDisclosure(params: disclosureParams)
           }
 
           return flat
@@ -279,16 +279,16 @@ internal class PaymentSheetAppearance {
           return checkmark
       }
 
-      private class func buildEmbeddedChevron(params: NSDictionary) throws -> PaymentSheet.Appearance.EmbeddedPaymentElement.Row.Flat.Chevron {
-        var chevron = PaymentSheet.Appearance.default.embeddedPaymentElement.row.flat.chevron
+    private class func buildEmbeddedDisclosure(params: NSDictionary) throws -> PaymentSheet.Appearance.EmbeddedPaymentElement.Row.Flat.Disclosure {
+        var disclosure = PaymentSheet.Appearance.default.embeddedPaymentElement.row.flat.disclosure
 
-        chevron.color = parseThemedColor(
+        disclosure.color = parseThemedColor(
           params: params,
           key: PaymentSheetAppearanceKeys.COLOR,
           default: UIColor.systemGray // Default iOS system gray color
         )
 
-          return chevron
+        return disclosure
       }
 
       private class func buildEmbeddedFloating(params: NSDictionary) throws -> PaymentSheet.Appearance.EmbeddedPaymentElement.Row.Floating {
@@ -387,7 +387,7 @@ extension PaymentSheetAppearanceError: LocalizedError {
         case .unexpectedHexStringLength(let hexString):
             return NSLocalizedString("Failed to set Payment Sheet appearance. Expected hex string of length 6 or 8, but received: \(hexString)", comment: "Failed to set color")
         case .invalidRowStyle(let styleString):
-            return NSLocalizedString("Failed to set Embedded Payment Element appearance. Invalid row style '\(styleString)'. Expected one of: 'flatWithRadio', 'floatingButton', 'flatWithCheckmark', 'flatWithChevron'.", comment: "Invalid row style string")
+            return NSLocalizedString("Failed to set Embedded Payment Element appearance. Invalid row style '\(styleString)'. Expected one of: 'flatWithRadio', 'floatingButton', 'flatWithCheckmark', 'flatWithDisclosure'.", comment: "Invalid row style string")
         }
     }
 }
@@ -444,7 +444,7 @@ private struct PaymentSheetAppearanceKeys {
     static let SELECTED_COLOR = "selectedColor"
     static let UNSELECTED_COLOR = "unselectedColor"
     static let CHECKMARK = "checkmark"
-    static let CHEVRON = "chevron"
+    static let DISCLOSURE = "disclosure"
     static let SPACING = "spacing"
     static let TOP = "top"
     static let LEFT = "left"
@@ -456,7 +456,7 @@ private struct PaymentSheetAppearanceKeys {
     static let ROW_STYLE_FLAT_WITH_RADIO = "flatWithRadio"
     static let ROW_STYLE_FLOATING_BUTTON = "floatingButton"
     static let ROW_STYLE_FLAT_WITH_CHECKMARK = "flatWithCheckmark"
-    static let ROW_STYLE_FLAT_WITH_CHEVRON = "flatWithChevron"
+    static let ROW_STYLE_FLAT_WITH_DISCLOSURE = "flatWithDisclosure"
 
     static let FORM_INSETS = "formInsetValues"
 }

--- a/src/types/PaymentSheet.ts
+++ b/src/types/PaymentSheet.ts
@@ -360,10 +360,10 @@ export enum RowStyle {
   FloatingButton = 'floatingButton',
   /** A flat style with a checkmark */
   FlatWithCheckmark = 'flatWithCheckmark',
-  /** A flat style with a chevron
+  /** A flat style with a disclosure
    * Note that the EmbeddedPaymentElementConfiguration.rowSelectionBehavior must be set to `immediateAction` to use this style.
    */
-  FlatWithChevron = 'flatWithChevron',
+  FlatWithDisclosure = 'flatWithDisclosure',
 }
 
 /** Describes the appearance of the radio button */
@@ -379,7 +379,7 @@ export interface RadioConfig {
   unselectedColor?: ThemedColor;
 }
 
-/** Describes the appearance of the checkmark */
+/** Describes the appearance of the disclosure indicator */
 export interface CheckmarkConfig {
   /** The color of the checkmark when selected, represented as a hex string #AARRGGBB or #RRGGBB.
    * @default The root appearance.colors.primary
@@ -387,9 +387,9 @@ export interface CheckmarkConfig {
   color?: ThemedColor;
 }
 
-/** Describes the appearance of the chevron */
-export interface ChevronConfig {
-  /** The color of the chevron, represented as a hex string #AARRGGBB or #RRGGBB.
+/** Describes the appearance of the disclosure indicator */
+export interface DisclosureConfig {
+  /** The color of the disclosure indicator, represented as a hex string #AARRGGBB or #RRGGBB.
    * @default The iOS or Android system gray color
    */
   color?: ThemedColor;
@@ -409,7 +409,7 @@ export interface FlatConfig {
 
   /** The insets of the separator line between rows.
    * @default { top: 0, left: 30, bottom: 0, right: 0 } for RowStyle.FlatWithRadio
-   * @default { top: 0, left: 0, bottom: 0, right: 0 } for RowStyle.FlatWithCheckmark, RowStyle.FlatWithChevron, and RowStyle.FloatingButton
+   * @default { top: 0, left: 0, bottom: 0, right: 0 } for RowStyle.FlatWithCheckmark, RowStyle.FlatWithDisclosure, and RowStyle.FloatingButton
    */
   separatorInsets?: EdgeInsetsConfig;
 
@@ -429,8 +429,8 @@ export interface FlatConfig {
   /** Appearance settings for the checkmark (used when RowStyle is FlatWithCheckmark) */
   checkmark?: CheckmarkConfig;
 
-  /** Appearance settings for the chevron (used when RowStyle is FlatWithChevron) */
-  chevron?: ChevronConfig;
+  /** Appearance settings for the disclosure indicator (used when RowStyle is FlatWithDisclosure) */
+  disclosure?: DisclosureConfig;
 }
 
 /** Describes the appearance of the floating button style payment method row */

--- a/stripe-react-native.podspec
+++ b/stripe-react-native.podspec
@@ -2,7 +2,7 @@ require 'json'
 
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 # Keep stripe_version in sync with https://github.com/stripe/stripe-identity-react-native/blob/main/stripe-identity-react-native.podspec
-stripe_version = '~> 24.16.1'
+stripe_version = '~> 24.19.0'
 
 fabric_enabled = ENV['RCT_NEW_ARCH_ENABLED'] == '1'
 


### PR DESCRIPTION
## Summary
- Renamed `RowStyle.FlatWithChevron` to `RowStyle.FlatWithDisclosure` and updated related interfaces (`ChevronConfig` → `DisclosureConfig`).
- Updated `stripe-ios` to 24.19.0
- Updated `stripe-android` to 21.22.+


## Motivation
- Bug fixes

## Testing
- Manual
- CI

