### PR TITLE
Add success colors to primary button config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Renamed `RowStyle.FlatWithChevron` to `RowStyle.FlatWithDisclosure` and updated related interfaces (`ChevronConfig` → `DisclosureConfig`).
 - Updated `stripe-ios` to 24.19.0
 - Updated `stripe-android` to 21.22.+
+- Added `successBackgroundColor` and `successTextColor` properties to `PrimaryButtonColorConfig` for customizing the primary button appearance in success states.
 
 **Fixes**
 - Fixed missing `onCustomPaymentMethodConfirmHandlerCallback` in old architecture codegen patch. This resolves pod install failures when using React Native 0.74+ with old architecture and custom payment methods.

--- a/android/src/main/java/com/reactnativestripesdk/PaymentSheetAppearance.kt
+++ b/android/src/main/java/com/reactnativestripesdk/PaymentSheetAppearance.kt
@@ -194,9 +194,9 @@ private fun buildPrimaryButton(
 
   return PaymentSheet.PrimaryButton(
     colorsLight =
-      buildPrimaryButtonColors(lightColorParams, PaymentSheet.PrimaryButtonColors.defaultLight),
+      buildPrimaryButtonColors(lightColorParams, PaymentSheet.PrimaryButtonColors.defaultLight, context),
     colorsDark =
-      buildPrimaryButtonColors(darkColorParams, PaymentSheet.PrimaryButtonColors.defaultDark),
+      buildPrimaryButtonColors(darkColorParams, PaymentSheet.PrimaryButtonColors.defaultDark, context),
     shape =
       PaymentSheet.PrimaryButtonShape(
         cornerRadiusDp =
@@ -217,6 +217,7 @@ private fun buildPrimaryButton(
 private fun buildPrimaryButtonColors(
   colorParams: Bundle,
   default: PaymentSheet.PrimaryButtonColors,
+  context: Context,
 ): PaymentSheet.PrimaryButtonColors =
   PaymentSheet.PrimaryButtonColors(
     background =
@@ -242,6 +243,20 @@ private fun buildPrimaryButtonColors(
       colorFromHexOrDefault(
         colorParams.getString(PaymentSheetAppearanceKeys.BORDER),
         default.border,
+      ),
+    successBackgroundColor =
+      dynamicColorFromParams(
+        context,
+        colorParams,
+        PaymentSheetAppearanceKeys.SUCCESS_BACKGROUND,
+        default.successBackgroundColor,
+      ),
+    onSuccessBackgroundColor =
+      dynamicColorFromParams(
+        context,
+        colorParams,
+        PaymentSheetAppearanceKeys.SUCCESS_TEXT,
+        default.onSuccessBackgroundColor,
       ),
   )
 
@@ -654,6 +669,8 @@ private class PaymentSheetAppearanceKeys {
     const val PRIMARY_BUTTON = "primaryButton"
     const val TEXT = "text"
     const val BORDER = "border"
+    const val SUCCESS_BACKGROUND = "successBackgroundColor"
+    const val SUCCESS_TEXT = "successTextColor"
 
     const val EMBEDDED_PAYMENT_ELEMENT = "embeddedPaymentElement"
     const val ROW = "row"

--- a/example/src/screens/EmbeddedPaymentElementScreen.tsx
+++ b/example/src/screens/EmbeddedPaymentElementScreen.tsx
@@ -149,6 +149,10 @@ export default function EmbeddedPaymentElementScreen() {
       const darkBorderColor = '#48484A'; // Dark mode border
       const darkSecondaryText = '#8E8E93'; // Dark mode secondary text
 
+      // Blurple colors for success states
+      const blurple = '#635BFF'; // Stripe's signature blurple color
+      const blurpleText = '#FFFFFF'; // White text on blurple
+
       const appearance: AppearanceParams = {
         colors: {
           light: {
@@ -199,12 +203,16 @@ export default function EmbeddedPaymentElementScreen() {
               background: actionPink,
               text: brandWhite, // White text on pink
               border: '00000000', // No border color needed
-            },
+              successBackgroundColor: blurple, // Blurple success background
+              successTextColor: blurpleText, // White text on blurple
+            } as any,
             dark: {
               background: actionPink,
               text: brandWhite, // White text on pink
               border: '#00000000', // No border color needed
-            },
+              successBackgroundColor: blurple, // Blurple success background
+              successTextColor: blurpleText, // White text on blurple
+            } as any,
           },
         },
         embeddedPaymentElement: {

--- a/ios/PaymentSheetAppearance.swift
+++ b/ios/PaymentSheetAppearance.swift
@@ -134,6 +134,8 @@ internal class PaymentSheetAppearance {
             primaryButton.backgroundColor = try buildUserInterfaceStyleAwareColor(key: PaymentSheetAppearanceKeys.BACKGROUND, lightParams: lightModeParams, darkParams: darkModeParams)
             primaryButton.textColor = try buildUserInterfaceStyleAwareColor(key: PaymentSheetAppearanceKeys.TEXT, lightParams: lightModeParams, darkParams: darkModeParams)
             primaryButton.borderColor = try buildUserInterfaceStyleAwareColor(key: PaymentSheetAppearanceKeys.BORDER, lightParams: lightModeParams, darkParams: darkModeParams) ?? PaymentSheet.Appearance.default.primaryButton.borderColor
+            primaryButton.successBackgroundColor = try buildUserInterfaceStyleAwareColor(key: PaymentSheetAppearanceKeys.SUCCESS_BACKGROUND, lightParams: lightModeParams, darkParams: darkModeParams) ?? PaymentSheet.Appearance.default.primaryButton.successBackgroundColor
+            primaryButton.successTextColor = try buildUserInterfaceStyleAwareColor(key: PaymentSheetAppearanceKeys.SUCCESS_TEXT, lightParams: lightModeParams, darkParams: darkModeParams)
         }
 
         return primaryButton
@@ -428,6 +430,8 @@ private struct PaymentSheetAppearanceKeys {
     static let PRIMARY_BUTTON = "primaryButton"
     static let TEXT = "text"
     static let BORDER = "border"
+    static let SUCCESS_BACKGROUND = "successBackgroundColor"
+    static let SUCCESS_TEXT = "successTextColor"
 
     static let EMBEDDED_PAYMENT_ELEMENT = "embeddedPaymentElement"
     static let ROW = "row"

--- a/src/types/PaymentSheet.ts
+++ b/src/types/PaymentSheet.ts
@@ -339,6 +339,14 @@ export type PrimaryButtonColorConfig = {
    * @default The System quaternary label on iOS, transparent on Android.
    */
   border: string;
+  /** The background color of the primary button when in a success state. Supports both single color strings and light/dark color objects.
+   * @default Green (#34C759 on iOS, system green on Android)
+   */
+  successBackgroundColor?: ThemedColor;
+  /** The text color of the primary button when in a success state. Supports both single color strings and light/dark color objects.
+   * @default White
+   */
+  successTextColor?: ThemedColor;
 };
 
 /** A color that’s either a single hex or a light/dark pair */


### PR DESCRIPTION
## Summary
- Added `successBackgroundColor` and `successTextColor` properties to `PrimaryButtonColorConfig` for customizing the primary button appearance in success states.

## Motivation
- Parity with native

## Testing
Manual
