### PR TITLE
Fix inconsistent documentation comment to match code implementation

### DIFF
--- a/src/functions.ts
+++ b/src/functions.ts
@@ -711,7 +711,7 @@ export const isPlatformPaySupported = async (params?: {
  * Launches the relevant native wallet sheet (Apple Pay on iOS, Google Pay on Android) in order to confirm a Stripe [SetupIntent](https://stripe.com/docs/api/setup_intents).
  * @param clientSecret The client secret of the SetupIntent.
  * @param params an object describing the Apple Pay and Google Pay configurations.
- * @returns An object with an error field if something went wrong or the flow was cancelled, otherwise an object with both `setupIntent` and `paymentMethod` fields.
+ * @returns An object with an error field if something went wrong or the flow was cancelled, otherwise an object with a `setupIntent` field.
  */
 export const confirmPlatformPaySetupIntent = async (
   clientSecret: string,
@@ -742,7 +742,7 @@ export const confirmPlatformPaySetupIntent = async (
  * Launches the relevant native wallet sheet (Apple Pay on iOS, Google Pay on Android) in order to confirm a Stripe [PaymentIntent](https://stripe.com/docs/api/payment_intents).
  * @param clientSecret The client secret of the PaymentIntent.
  * @param params an object describing the Apple Pay and Google Pay configurations.
- * @returns An object with an error field if something went wrong or the flow was cancelled, otherwise an object with both `paymentIntent` and `paymentMethod` fields.
+ * @returns An object with an error field if something went wrong or the flow was cancelled, otherwise an object with a `paymentIntent` field.
  */
 export const confirmPlatformPayPayment = async (
   clientSecret: string,


### PR DESCRIPTION
## Summary
Fixed documentation comments

## Motivation
Comments were incorrectly stating that a function returns an object with two fields when it only has a single field (in two separate instances). These comments are used in generating the API reference docs, which can cause implementation errors for users.
https://stripe.dev/stripe-react-native/api-reference/functions/confirmPlatformPaySetupIntent.html
https://stripe.dev/stripe-react-native/api-reference/functions/confirmPlatformPayPayment.html 

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [ ] I tested this manually
- [ ] I added automated tests
- [x] N/A
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
- [x] This is a documentation change.
