### PR TITLE
CI: Tweak iOS version to align with runner image

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "bootstrap-no-pods": "yarn example && yarn",
     "docs": "yarn typedoc ./src/index.tsx --out ./docs/api-reference --tsconfig ./tsconfig.json --readme none --sort source-order",
     "run-example-ios": "cd example && yarn ios --simulator \"iPhone 16\"",
-    "run-example-ios:release": "cd example && yarn build:ios && yarn ios --mode Release --simulator \"iPhone 16 (18.2)\" --no-packager",
+    "run-example-ios:release": "cd example && yarn build:ios && yarn ios --mode Release --simulator \"iPhone 16 (18.6)\" --no-packager",
     "run-example-android": "cd example && yarn android",
     "run-example-android:release": "cd example && yarn build:android && yarn android --mode=release --no-packager",
     "test:e2e:ios": "bash ./scripts/run-maestro-tests ios",


### PR DESCRIPTION
## Summary
Changing which iOS version to use for the simulator when running E2E tests

## Motivation
GitHub has updated base image which makes current CI fail

Here is the changes by GitHub:
https://github.com/actions/runner-images/pull/12734

## Testing
Will test by running the tests in this PR

## Documentation
- [x] This PR does not result in any developer-facing changes.

-----

ping @mats-stripe, I think that this should fix the CI problems 🚀 