### PR TITLE
Remove cancel stuff from CI workflows

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,9 +1,5 @@
 name: RN Stripe
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 on:
   push:
     branches: [master]

--- a/.github/workflows/js-tests.yml
+++ b/.github/workflows/js-tests.yml
@@ -9,10 +9,6 @@ on:
       - '**/*.md'
       - '**/*.MD'
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   js-tests:
     name: js-tests

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -9,10 +9,6 @@ on:
       - '**/*.md'
       - '**/*.MD'
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   test-ios:
     name: unit-test-ios


### PR DESCRIPTION
## Summary
- This step was causing CI jobs to be errnounysly canceled 