### PR TITLE
Updates Stripe SDK to 24.21.0 and adds CryptoOnramp

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1685,13 +1685,13 @@ PODS:
     - ReactCommon/turbomodule/core
     - Yoga
   - SocketRocket (0.7.1)
-  - Stripe (24.20.0):
-    - StripeApplePay (= 24.20.0)
-    - StripeCore (= 24.20.0)
-    - StripePayments (= 24.20.0)
-    - StripePaymentsUI (= 24.20.0)
-    - StripeUICore (= 24.20.0)
-  - stripe-react-native (0.50.3):
+  - Stripe (24.21.0):
+    - StripeApplePay (= 24.21.0)
+    - StripeCore (= 24.21.0)
+    - StripePayments (= 24.21.0)
+    - StripePaymentsUI (= 24.21.0)
+    - StripeUICore (= 24.21.0)
+  - stripe-react-native (0.51.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1711,15 +1711,16 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - Stripe (~> 24.20.0)
-    - stripe-react-native/NewArch (= 0.50.3)
-    - StripeApplePay (~> 24.20.0)
-    - StripeFinancialConnections (~> 24.20.0)
-    - StripePayments (~> 24.20.0)
-    - StripePaymentSheet (~> 24.20.0)
-    - StripePaymentsUI (~> 24.20.0)
+    - Stripe (~> 24.21.0)
+    - stripe-react-native/NewArch (= 0.51.0)
+    - StripeApplePay (~> 24.21.0)
+    - StripeCryptoOnramp (~> 24.21.0)
+    - StripeFinancialConnections (~> 24.21.0)
+    - StripePayments (~> 24.21.0)
+    - StripePaymentSheet (~> 24.21.0)
+    - StripePaymentsUI (~> 24.21.0)
     - Yoga
-  - stripe-react-native/NewArch (0.50.3):
+  - stripe-react-native/NewArch (0.51.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1739,14 +1740,15 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - Stripe (~> 24.20.0)
-    - StripeApplePay (~> 24.20.0)
-    - StripeFinancialConnections (~> 24.20.0)
-    - StripePayments (~> 24.20.0)
-    - StripePaymentSheet (~> 24.20.0)
-    - StripePaymentsUI (~> 24.20.0)
+    - Stripe (~> 24.21.0)
+    - StripeApplePay (~> 24.21.0)
+    - StripeCryptoOnramp (~> 24.21.0)
+    - StripeFinancialConnections (~> 24.21.0)
+    - StripePayments (~> 24.21.0)
+    - StripePaymentSheet (~> 24.21.0)
+    - StripePaymentsUI (~> 24.21.0)
     - Yoga
-  - stripe-react-native/Tests (0.50.3):
+  - stripe-react-native/Tests (0.51.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1766,35 +1768,50 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - Stripe (~> 24.20.0)
-    - StripeApplePay (~> 24.20.0)
-    - StripeFinancialConnections (~> 24.20.0)
-    - StripePayments (~> 24.20.0)
-    - StripePaymentSheet (~> 24.20.0)
-    - StripePaymentsUI (~> 24.20.0)
+    - Stripe (~> 24.21.0)
+    - StripeApplePay (~> 24.21.0)
+    - StripeCryptoOnramp (~> 24.21.0)
+    - StripeFinancialConnections (~> 24.21.0)
+    - StripePayments (~> 24.21.0)
+    - StripePaymentSheet (~> 24.21.0)
+    - StripePaymentsUI (~> 24.21.0)
     - Yoga
-  - StripeApplePay (24.20.0):
-    - StripeCore (= 24.20.0)
-  - StripeCore (24.20.0)
-  - StripeFinancialConnections (24.20.0):
-    - StripeCore (= 24.20.0)
-    - StripeUICore (= 24.20.0)
-  - StripePayments (24.20.0):
-    - StripeCore (= 24.20.0)
-    - StripePayments/Stripe3DS2 (= 24.20.0)
-  - StripePayments/Stripe3DS2 (24.20.0):
-    - StripeCore (= 24.20.0)
-  - StripePaymentSheet (24.20.0):
-    - StripeApplePay (= 24.20.0)
-    - StripeCore (= 24.20.0)
-    - StripePayments (= 24.20.0)
-    - StripePaymentsUI (= 24.20.0)
-  - StripePaymentsUI (24.20.0):
-    - StripeCore (= 24.20.0)
-    - StripePayments (= 24.20.0)
-    - StripeUICore (= 24.20.0)
-  - StripeUICore (24.20.0):
-    - StripeCore (= 24.20.0)
+  - StripeApplePay (24.21.0):
+    - StripeCore (= 24.21.0)
+  - StripeCameraCore (24.21.0):
+    - StripeCore (= 24.21.0)
+  - StripeCore (24.21.0)
+  - StripeCryptoOnramp (24.21.0):
+    - StripeApplePay (= 24.21.0)
+    - StripeCore (= 24.21.0)
+    - StripeIdentity (= 24.21.0)
+    - StripePayments (= 24.21.0)
+    - StripePaymentSheet (= 24.21.0)
+    - StripePaymentsUI (= 24.21.0)
+    - StripeUICore (= 24.21.0)
+  - StripeFinancialConnections (24.21.0):
+    - StripeCore (= 24.21.0)
+    - StripeUICore (= 24.21.0)
+  - StripeIdentity (24.21.0):
+    - StripeCameraCore (= 24.21.0)
+    - StripeCore (= 24.21.0)
+    - StripeUICore (= 24.21.0)
+  - StripePayments (24.21.0):
+    - StripeCore (= 24.21.0)
+    - StripePayments/Stripe3DS2 (= 24.21.0)
+  - StripePayments/Stripe3DS2 (24.21.0):
+    - StripeCore (= 24.21.0)
+  - StripePaymentSheet (24.21.0):
+    - StripeApplePay (= 24.21.0)
+    - StripeCore (= 24.21.0)
+    - StripePayments (= 24.21.0)
+    - StripePaymentsUI (= 24.21.0)
+  - StripePaymentsUI (24.21.0):
+    - StripeCore (= 24.21.0)
+    - StripePayments (= 24.21.0)
+    - StripeUICore (= 24.21.0)
+  - StripeUICore (24.21.0):
+    - StripeCore (= 24.21.0)
   - Yoga (0.0.0)
 
 DEPENDENCIES:
@@ -1880,8 +1897,11 @@ SPEC REPOS:
     - SocketRocket
     - Stripe
     - StripeApplePay
+    - StripeCameraCore
     - StripeCore
+    - StripeCryptoOnramp
     - StripeFinancialConnections
+    - StripeIdentity
     - StripePayments
     - StripePaymentSheet
     - StripePaymentsUI
@@ -2044,81 +2064,84 @@ SPEC CHECKSUMS:
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: eb93e2f488219332457c3c4eafd2738ddc7e80b8
   hermes-engine: b417d2b2aee3b89b58e63e23a51e02be91dc876d
-  RCT-Folly: 36fe2295e44b10d831836cc0d1daec5f8abcf809
+  RCT-Folly: e78785aa9ba2ed998ea4151e314036f6c49e6d82
   RCTDeprecation: b2eecf2d60216df56bc5e6be5f063826d3c1ee35
   RCTRequired: 78522de7dc73b81f3ed7890d145fa341f5bb32ea
   RCTTypeSafety: c135dd2bf50402d87fd12884cbad5d5e64850edd
   React: b229c49ed5898dab46d60f61ed5a0bfa2ee2fadb
   React-callinvoker: 2ac508e92c8bd9cf834cc7d7787d94352e4af58f
-  React-Core: 13cdd1558d0b3f6d9d5a22e14d89150280e79f02
-  React-CoreModules: b07a6744f48305405e67c845ebf481b6551b712a
-  React-cxxreact: 1055a86c66ac35b4e80bd5fb766aed5f494dfff4
+  React-Core: 325b4f6d9162ae8b9a6ff42fe78e260eb124180d
+  React-CoreModules: 558041e5258f70cd1092f82778d07b8b2ff01897
+  React-cxxreact: 8fff17cbe76e6a8f9991b59552e1235429f9c74b
   React-debug: 0a5fcdbacc6becba0521e910c1bcfdb20f32a3f6
-  React-defaultsnativemodule: 4bb28fc97fee5be63a9ebf8f7a435cfe8ba69459
-  React-domnativemodule: b36a11c2597243d7563985028c51ece988d8ae33
-  React-Fabric: afc561718f25b2cd800b709d934101afe376a12c
-  React-FabricComponents: f4e0a4e18a27bf6d39cbf2a0b42f37a92fa4e37f
-  React-FabricImage: 37d8e8b672eda68a19d71143eb65148084efb325
+  React-defaultsnativemodule: 618dc50a0fad41b489997c3eb7aba3a74479fd14
+  React-domnativemodule: 7ba599afb6c2a7ec3eb6450153e2efe0b8747e9a
+  React-Fabric: 252112089d2c63308f4cbfade4010b6606db67d1
+  React-FabricComponents: 3c0f75321680d14d124438ab279c64ec2a3d13c4
+  React-FabricImage: 728b8061cdec2857ca885fd605ee03ad43ffca98
   React-featureflags: 19682e02ef5861d96b992af16a19109c3dfc1200
-  React-featureflagsnativemodule: d7cddf6d907b4e5ab84f9e744b7e88461656e48c
-  React-graphics: b0f78580cdaf5800d25437e3d41cc6c3d83b7aea
-  React-hermes: 71186f872c932e4574d5feb3ed754dda63a0b3bd
-  React-idlecallbacksnativemodule: dd2af19cdd3bc55149d17a2409ed72b694dfbe9c
-  React-ImageManager: a77dde8d5aa6a2b6962c702bf3a47695ef0aa32b
-  React-jserrorhandler: 9c14e89f12d5904257a79aaf84a70cd2e5ac07ba
-  React-jsi: 0775a66820496769ad83e629f0f5cce621a57fc7
-  React-jsiexecutor: 2cf5ba481386803f3c88b85c63fa102cba5d769e
-  React-jsinspector: 8052d532bb7a98b6e021755674659802fb140cc5
-  React-jsinspectortracing: bdd8fd0adcb4813663562e7874c5842449df6d8a
-  React-jsitracing: 2bab3bf55de3d04baf205def375fa6643c47c794
-  React-logger: 795cd5055782db394f187f9db0477d4b25b44291
-  React-Mapbuffer: 0502faf46cab8fb89cfc7bf3e6c6109b6ef9b5de
-  React-microtasksnativemodule: 663bc64e3a96c5fc91081923ae7481adc1359a78
-  react-native-safe-area-context: 9c33120e9eac7741a5364cc2d9f74665049b76b3
-  React-NativeModulesApple: 16fbd5b040ff6c492dacc361d49e63cba7a6a7a1
-  React-perflogger: ab51b7592532a0ea45bf6eed7e6cae14a368b678
-  React-performancetimeline: bc2e48198ec814d578ac8401f65d78a574358203
+  React-featureflagsnativemodule: 23528c7e7d50782b7ef0804168ba40bbaf1e86ab
+  React-graphics: fefe48f71bfe6f48fd037f59e8277b12e91b6be1
+  React-hermes: a9a0c8377627b5506ef9a7b6f60a805c306e3f51
+  React-idlecallbacksnativemodule: 7e2b6a3b70e042f89cd91dbd73c479bb39a72a7e
+  React-ImageManager: e3300996ac2e2914bf821f71e2f2c92ae6e62ae2
+  React-jserrorhandler: fa75876c662e5d7e79d6efc763fc9f4c88e26986
+  React-jsi: f3f51595cc4c089037b536368f016d4742bf9cf7
+  React-jsiexecutor: cca6c232db461e2fd213a11e9364cfa6fdaa20eb
+  React-jsinspector: 2bd4c9fddf189d6ec2abf4948461060502582bef
+  React-jsinspectortracing: a417d8a0ad481edaa415734b4dac81e3e5ee7dc6
+  React-jsitracing: 1ff7172c5b0522cbf6c98d82bdbb160e49b5804e
+  React-logger: 018826bfd51b9f18e87f67db1590bc510ad20664
+  React-Mapbuffer: 3c11cee7737609275c7b66bd0b1de475f094cedf
+  React-microtasksnativemodule: 843f352b32aacbe13a9c750190d34df44c3e6c2c
+  react-native-safe-area-context: 7e513d737b0b5c1d10bbe0e5fcc9f925a7be144c
+  React-NativeModulesApple: 88433b6946778bea9c153e27b671de15411bf225
+  React-perflogger: 9e8d3c0dc0194eb932162812a168aa5dc662f418
+  React-performancetimeline: 5a2d6efef52bdcefac079c7baa30934978acd023
   React-RCTActionSheet: 592674cf61142497e0e820688f5a696e41bf16dd
-  React-RCTAnimation: 8fbb8dba757b49c78f4db403133ab6399a4ce952
-  React-RCTAppDelegate: 7f88baa8cb4e5d6c38bb4d84339925c70c9ac864
-  React-RCTBlob: f89b162d0fe6b570a18e755eb16cbe356d3c6d17
-  React-RCTFabric: 8ad6d875abe6e87312cef90e4b15ef7f6bed72e6
-  React-RCTFBReactNativeSpec: 8c29630c2f379c729300e4c1e540f3d1b78d1936
-  React-RCTImage: ccac9969940f170503857733f9a5f63578e106e1
-  React-RCTLinking: d82427bbf18415a3732105383dff119131cadd90
-  React-RCTNetwork: 12ad4d0fbde939e00251ca5ca890da2e6825cc3c
-  React-RCTSettings: e7865bf9f455abf427da349c855f8644b5c39afa
-  React-RCTText: 2cdfd88745059ec3202a0842ea75a956c7d6f27d
-  React-RCTVibration: a3a1458e6230dfd64b3768ebc0a4aac430d9d508
+  React-RCTAnimation: e6d669872f9b3b4ab9527aab283b7c49283236b7
+  React-RCTAppDelegate: de2343fe08be4c945d57e0ecce44afcc7dd8fc03
+  React-RCTBlob: 3e2dce94c56218becc4b32b627fc2293149f798d
+  React-RCTFabric: cac2c033381d79a5956e08550b0220cb2d78ea93
+  React-RCTFBReactNativeSpec: d10ca5e0ccbfeac8c047361fedf8e4ac653887b6
+  React-RCTImage: dc04b176c022d12a8f55ae7a7279b1e091066ae0
+  React-RCTLinking: 88f5e37fe4f26fbc80791aa2a5f01baf9b9a3fd5
+  React-RCTNetwork: f213693565efbd698b8e9c18d700a514b49c0c8e
+  React-RCTSettings: a2d32a90c45a3575568cad850abc45924999b8a5
+  React-RCTText: 54cdcd1cbf6f6a91dc6317f5d2c2b7fc3f6bf7a0
+  React-RCTVibration: 11dae0e7f577b5807bb7d31e2e881eb46f854fd4
   React-rendererconsistency: 64e897e00d2568fd8dfe31e2496f80e85c0aaad1
-  React-rendererdebug: a3f6d3ae7d2fa0035885026756281c07ee32479e
+  React-rendererdebug: 41ce452460c44bba715d9e41d5493a96de277764
   React-rncore: 58748c2aa445f56b99e5118dad0aedb51c40ce9f
-  React-RuntimeApple: f0fda7bacabd32daa099cfda8f07466c30acd149
-  React-RuntimeCore: 683ee0b6a76d4b4bf6fbf83a541895b4887cc636
+  React-RuntimeApple: 7785ed0d8ae54da65a88736bb63ca97608a6d933
+  React-RuntimeCore: 6029ea70bc77f98cfd43ebe69217f14e93ba1f12
   React-runtimeexecutor: a188df372373baf5066e6e229177836488799f80
-  React-RuntimeHermes: 907c8e9bec13ea6466b94828c088c24590d4d0b6
-  React-runtimescheduler: a2e2a39125dd6426b5d8b773f689d660cd7c5f60
+  React-RuntimeHermes: a264609c28b796edfffc8ae4cb8fad1773ab948b
+  React-runtimescheduler: 23ec3a1e0fb1ec752d1a9c1fb15258c30bfc7222
   React-timing: bb220a53a795ed57976a4855c521f3de2f298fe5
-  React-utils: 300d8bbb6555dcffaca71e7a0663201b5c7edbbc
-  ReactAppDependencyProvider: f2e81d80afd71a8058589e19d8a134243fa53f17
-  ReactCodegen: a63a0ab6ae824aef2e8c744981edd718b16eb9f2
-  ReactCommon: 3d39389f8e2a2157d5c999f8fba57bd1c8f226f0
-  ReactNativeHost: 472eee4aad1fa9b3a265d2f5eb76eaa52ef75c1e
-  ReactTestApp-DevSupport: 0580b002f78d63804f1609dce622c4f54820f3c6
+  React-utils: 3b054aaebe658fc710a8d239d0e4b9fd3e0b78f9
+  ReactAppDependencyProvider: a1fb08dfdc7ebc387b2e54cfc9decd283ed821d8
+  ReactCodegen: 008c319179d681a6a00966edfc67fda68f9fbb2e
+  ReactCommon: 0c097b53f03d6bf166edbcd0915da32f3015dd90
+  ReactNativeHost: 2503667b2e20fff53f55c4f85d9c7e66e0f3d702
+  ReactTestApp-DevSupport: 881bdd4c9f703cf611e46715b8a5f27b2ff15e5d
   ReactTestApp-Resources: 49fb7249af8203b9c74fd85de8c6f5bbb77a41df
-  RNCPicker: ffbd7b9fc7c1341929e61dbef6219f7860f57418
-  RNScreens: 991214b4e69016c1ae32830d9cea31c9c9422367
+  RNCPicker: cfb51a08c6e10357d9a65832e791825b0747b483
+  RNScreens: 0d4cb9afe052607ad0aa71f645a88bb7c7f2e64c
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
-  Stripe: 517f6e3e25f01641be2adab3aa3d1f45d4d443c6
-  stripe-react-native: 487a98f3943e298687c86a4f561d71879cadf2c3
-  StripeApplePay: 78f0c4a2c2af7f03b298d2f9bc7a1a0044490923
-  StripeCore: 4430d270394b09c97dec8b2436228e76fcb3f84c
-  StripeFinancialConnections: efaf9a43bca22b6784da57eca99301598783e60f
-  StripePayments: db1f0a2e914a276028b23f5e1467e1e88f6a0238
-  StripePaymentSheet: 9c1c6d7c6498c8ba593e3b8690bf6fc79672ee91
-  StripePaymentsUI: d6b0285fdda8ac9cf8e83de423ca4efbf8b29439
-  StripeUICore: 31c439e9a03cd178415fa9dd65cc1ce71db260ec
-  Yoga: 9b7fb56e7b08cde60e2153344fa6afbd88e5d99f
+  Stripe: 54d3b21da68baa32827add90ee13990982eec9d2
+  stripe-react-native: fc20564c93e81efa4a6156a8f0a0d2918ecb22f5
+  StripeApplePay: 529732a498294f80a59cb48cbbf94d8e1c81e69c
+  StripeCameraCore: d374393b00085d49d781897edc52749e2ce683d8
+  StripeCore: dba38896a8c74dc04f9d66f912c362527d734a90
+  StripeCryptoOnramp: 132aa993fcd9acf6a6f39d37c7a62b4c685f421d
+  StripeFinancialConnections: 4aa34f6e9fdc8009d867053cfcff186f492c672b
+  StripeIdentity: bf917f2b0fad29528eec1a52d67cde93533cf56e
+  StripePayments: b9954a71703626ddc0430587aab33bee42df1b07
+  StripePaymentSheet: 69ec706a3a465dce8814c8898630719408b8d113
+  StripePaymentsUI: c67b161008e7027f0b51a9798b1cad1ada49d1a0
+  StripeUICore: 804cc10565d76a4887d16f2b1a84b683c00bbd50
+  Yoga: afd04ff05ebe0121a00c468a8a3c8080221cb14c
 
 PODFILE CHECKSUM: a2ed964678852d4cc306ff4add3e4fa90be77ea6
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "release": "./scripts/publish",
     "example": "yarn --cwd example",
     "pods": "cd example && npx pod-install --quiet",
-    "update-pods": "cd example/ios && pod update Stripe StripeApplePay StripeFinancialConnections StripePayments StripePaymentSheet StripePaymentsUI StripeCore StripeUICore",
+    "update-pods": "cd example/ios && pod update Stripe StripeApplePay StripeFinancialConnections StripePayments StripePaymentSheet StripePaymentsUI StripeCore StripeUICore StripeCryptoOnramp",
     "bootstrap": "yarn example && yarn && yarn pods",
     "bootstrap-no-pods": "yarn example && yarn",
     "docs": "yarn typedoc ./src/index.tsx --out ./docs/api-reference --tsconfig ./tsconfig.json --readme none --sort source-order",

--- a/stripe-react-native.podspec
+++ b/stripe-react-native.podspec
@@ -2,7 +2,7 @@ require 'json'
 
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 # Keep stripe_version in sync with https://github.com/stripe/stripe-identity-react-native/blob/main/stripe-identity-react-native.podspec
-stripe_version = '~> 24.20.0'
+stripe_version = '~> 24.21.0'
 
 fabric_enabled = ENV['RCT_NEW_ARCH_ENABLED'] == '1'
 
@@ -44,7 +44,8 @@ Pod::Spec.new do |s|
   s.dependency 'StripePaymentsUI', stripe_version
   s.dependency 'StripeApplePay', stripe_version
   s.dependency 'StripeFinancialConnections', stripe_version
-
+  s.dependency 'StripeCryptoOnramp', stripe_version
+  
   if fabric_enabled
     install_modules_dependencies(s)
 


### PR DESCRIPTION
## Summary
* Updates Stripe iOS SDK to 24.21.0
* Adds CryptoOnramp as a dependency.

## Motivation
This update includes work done for adding CryptoOnramp to the platform.

## Testing
`yarn run test` passes, and the example compiles.
Made sure importing StripeCryptoOnramp worked, and that files referenced in that framework were accessible.

## Documentation
Select one: 
- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
