### PR TITLE
[Onramp] Adds `isAuthError` helper to SDK + sample `reAuth` error handler.

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -74,11 +74,3 @@ export const currentlyFocusedInput = () => {
     }
   }
 };
-
-export const isAuthError = (error: any): boolean => {
-  const stripeErrorCode = error?.stripeErrorCode;
-  if (stripeErrorCode === 'consumer_session_credentials_invalid') {
-    return true;
-  }
-  return false;
-};

--- a/src/hooks/useOnramp.tsx
+++ b/src/hooks/useOnramp.tsx
@@ -4,7 +4,6 @@ import type { Onramp, OnrampError, StripeError } from '../types';
 import type { PlatformPay } from '../types';
 import { useCallback } from 'react';
 import { addOnrampListener } from '../events';
-import { isAuthError as isAuthErrorHelper } from '../helpers';
 
 let onCheckoutClientSecretRequestedSubscription: EventSubscription | null =
   null;
@@ -148,7 +147,12 @@ export function useOnramp() {
   }, []);
 
   const _isAuthError = (error: any): boolean => {
-    return isAuthErrorHelper(error);
+    const stripeErrorCode = error?.stripeErrorCode;
+    const authErrorCodes = [
+      'consumer_session_credentials_invalid',
+      'consumer_session_expired',
+    ];
+    return authErrorCodes.includes(stripeErrorCode);
   };
 
   return {
@@ -262,6 +266,13 @@ export function useOnramp() {
      */
     logOut: _logOut,
 
+    /**
+     * Determines whether an error is an authentication-related error that requires re-authentication.
+     * Useful for implementing automatic re-authentication flows when sessions expire or become invalid.
+     *
+     * @param error The error object to check, typically from onramp method calls
+     * @returns True if the error indicates an authentication issue, false otherwise
+     */
     isAuthError: _isAuthError,
   };
 }


### PR DESCRIPTION
## Summary
- Adds `isAuthError` helper to the RN SDK.
- Adds `withReauth` sample to the Onramp Example screen.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a link to the relevant issue, a code snippet, or an example project that demonstrates the bug. -->

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
[reauthing.webm](https://github.com/user-attachments/assets/5688aea0-8524-4048-8a51-f569f8e7c6d1)

- [ ] I tested this manually
- [ ] I added automated tests
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
