### PR TITLE
0.52.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## X.XX.X - XXXX-XX-XX
+## 0.52.0 - 2025-09-08
 **Features**
 - [#2079](https://github.com/stripe/stripe-react-native/pull/2079) Added support to differentiate between a user closing FlowController and selecting a payment option
 


### PR DESCRIPTION
- [ ] Ensure the CHANGELOG is up to date with all relevant commits since the last release
- [ ] Add the version number for this release & the date to the CHANGELOG, underneath "## Unreleased" 
  - e.g. "## 1.2.3 - 2022-02-14"
- [ ] Update the README if necessary (this is only required when there are breaking changes in the release, such as dropping support for an iOS || Android version)