### PR TITLE
Re-enable FC tests on iOS by forcing native flow

### DIFF
--- a/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
+++ b/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
@@ -1299,6 +1299,14 @@ class StripeSdkModule(
     // noop, iOS only
   }
 
+  @ReactMethod
+  override fun setFinancialConnectionsForceNativeFlow(
+    enabled: Boolean,
+    promise: Promise,
+  ) {
+    // noop, iOS only
+  }
+
   override fun addListener(eventType: String?) {
     // noop, iOS only
   }

--- a/android/src/oldarch/java/com/reactnativestripesdk/NativeStripeSdkModuleSpec.java
+++ b/android/src/oldarch/java/com/reactnativestripesdk/NativeStripeSdkModuleSpec.java
@@ -318,6 +318,10 @@ public abstract class NativeStripeSdkModuleSpec extends ReactContextBaseJavaModu
 
   @ReactMethod
   @DoNotStrip
+  public abstract void setFinancialConnectionsForceNativeFlow(boolean enabled, Promise promise);
+
+  @ReactMethod
+  @DoNotStrip
   public abstract void addListener(String eventType);
 
   @ReactMethod

--- a/e2e-tests/ios-only/financial-connections-session.yml
+++ b/e2e-tests/ios-only/financial-connections-session.yml
@@ -7,6 +7,9 @@ appId: ${APP_ID}
 - assertVisible:
     text: "Collect session"
 - tapOn:
+    id: "force_native_flow_switch"
+    optional: true
+- tapOn:
     text: "Collect session"
     retryTapIfNoChange: false
 - assertVisible:

--- a/e2e-tests/ios-only/financial-connections-token.yml
+++ b/e2e-tests/ios-only/financial-connections-token.yml
@@ -7,6 +7,9 @@ appId: ${APP_ID}
 - assertVisible:
     text: "Collect token"
 - tapOn:
+    id: "force_native_flow_switch"
+    optional: true
+- tapOn:
     text: "Collect token"
     retryTapIfNoChange: false
 - assertVisible:

--- a/example/src/screens/CollectBankAccountScreen.tsx
+++ b/example/src/screens/CollectBankAccountScreen.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { Alert } from 'react-native';
+import { Alert, Platform, View, Text, Switch } from 'react-native';
 import { useFinancialConnectionsSheet } from '@stripe/stripe-react-native';
+import { setFinancialConnectionsForceNativeFlow } from '@stripe/stripe-react-native/src/functions';
 import Button from '../components/Button';
 import PaymentScreen from '../components/PaymentScreen';
 import { API_URL } from '../Config';
@@ -8,6 +9,7 @@ import type { FinancialConnectionsEvent } from '@stripe/stripe-react-native/src/
 
 export default function CollectBankAccountScreen() {
   const [clientSecret, setClientSecret] = React.useState('');
+  const [forceNativeFlow, setForceNativeFlow] = React.useState(false);
   const {
     loading,
     collectBankAccountToken,
@@ -16,6 +18,20 @@ export default function CollectBankAccountScreen() {
 
   React.useEffect(() => {
     fetchClientSecret();
+  }, []);
+
+  React.useEffect(() => {
+    if (Platform.OS === 'ios') {
+      setFinancialConnectionsForceNativeFlow(forceNativeFlow);
+    }
+  }, [forceNativeFlow]);
+
+  React.useEffect(() => {
+    return () => {
+      if (Platform.OS === 'ios') {
+        setFinancialConnectionsForceNativeFlow(false);
+      }
+    };
   }, []);
 
   const fetchClientSecret = async () => {
@@ -83,6 +99,24 @@ export default function CollectBankAccountScreen() {
 
   return (
     <PaymentScreen paymentMethod="us_bank_account">
+      {Platform.OS === 'ios' && (
+        <View
+          style={{
+            marginBottom: 16,
+            flexDirection: 'row',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+          }}
+        >
+          <Text>Force native flow</Text>
+          <Switch
+            value={forceNativeFlow}
+            onValueChange={setForceNativeFlow}
+            accessibilityLabel="Force native flow"
+            testID="force_native_flow_switch"
+          />
+        </View>
+      )}
       <Button
         variant="primary"
         onPress={handleCollectTokenPress}

--- a/ios/StripeSdk.mm
+++ b/ios/StripeSdk.mm
@@ -354,6 +354,13 @@ RCT_EXPORT_METHOD(updatePlatformPaySheet:(nonnull NSArray *)summaryItems
                                       rejecter:reject];
 }
 
+RCT_EXPORT_METHOD(setFinancialConnectionsForceNativeFlow:(BOOL)enabled
+                                                 resolve:(nonnull RCTPromiseResolveBlock)resolve
+                                                  reject:(nonnull RCTPromiseRejectBlock)reject)
+{
+  [StripeSdkImpl.shared setFinancialConnectionsForceNativeFlow:enabled resolver:resolve rejecter:reject];
+}
+
 RCT_EXPORT_METHOD(verifyMicrodeposits:(BOOL)isPaymentIntent
                          clientSecret:(nonnull NSString *)clientSecret
                                params:(nonnull NSDictionary *)params

--- a/ios/StripeSdkImpl.swift
+++ b/ios/StripeSdkImpl.swift
@@ -1,6 +1,7 @@
 import PassKit
 @_spi(DashboardOnly) @_spi(STP) import Stripe
 @_spi(EmbeddedPaymentElementPrivateBeta) import StripePaymentSheet
+@_spi(STP) import StripePayments
 import StripeFinancialConnections
 import Foundation
 
@@ -1147,6 +1148,16 @@ public class StripeSdkImpl: NSObject, UIAdaptivePresentationControllerDelegate {
             }
         }
 #endif
+    }
+
+    @objc(setFinancialConnectionsForceNativeFlow:resolver:rejecter:)
+    public func setFinancialConnectionsForceNativeFlow(
+        enabled: Bool,
+        resolver resolve: @escaping RCTPromiseResolveBlock,
+        rejecter reject: @escaping RCTPromiseRejectBlock
+    ) {
+        UserDefaults.standard.set(enabled, forKey: "FINANCIAL_CONNECTIONS_EXAMPLE_APP_ENABLE_NATIVE")
+        resolve(nil)
     }
 
     public func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -893,3 +893,14 @@ export const openPlatformPaySetup = async (): Promise<void> => {
     await NativeStripeSdk.openApplePaySetup();
   }
 };
+
+export const setFinancialConnectionsForceNativeFlow = async (
+  enabled: boolean
+): Promise<void> => {
+  if (Platform.OS !== 'ios') return;
+  try {
+    await NativeStripeSdk.setFinancialConnectionsForceNativeFlow(enabled);
+  } catch (_) {
+    // no-op
+  }
+};

--- a/src/specs/NativeStripeSdkModule.ts
+++ b/src/specs/NativeStripeSdkModule.ts
@@ -184,6 +184,8 @@ export interface Spec extends TurboModule {
   ): Promise<void>;
   clearEmbeddedPaymentOption(viewTag: Int32): Promise<void>;
 
+  setFinancialConnectionsForceNativeFlow(enabled: boolean): Promise<void>;
+
   // Events
   addListener: (eventType: string) => void;
   removeListeners: (count: number) => void;


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

This pull request [re-enables](https://github.com/stripe/stripe-react-native/pull/1963) the Financial Connections tests on iOS by forcing the native flow for the test merchant.

We use the native flow instead of the web flow to reduce flakiness. Both flows are transparent to the caller; the main purpose of these tests is to confirm that the interface between React Native and Swift code works as intended. Proper end-to-end tests of the Financial Connections SDK exist in the native repos.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a link to the relevant issue, a code snippet, or an example project that demonstrates the bug. -->

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [ ] I added automated tests
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
