### PR TITLE
Improve android ci build performance

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -67,8 +67,6 @@ jobs:
 
       - name: Cache Gradle build
         uses: gradle/actions/setup-gradle@v4
-        with:
-          cache-read-only: false
 
       - name: Build Android App
         run: |

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -89,13 +89,8 @@ jobs:
           distribution: 'zulu'
           java-version: '17'
 
-      - name: Gradle cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: gradle-${{ runner.os }}-${{ hashFiles('**/*.gradle*') }}-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}-${{ hashFiles('**/buildSrc/**/*.kt') }}
+      - name: Cache Gradle build
+        uses: gradle/actions/setup-gradle@v4
 
       - name: Check code formatting
         run: yarn format:android:check


### PR DESCRIPTION
## Summary

- Build before starting emulator.
- Remove `Delete unnecessary tools` step, doesn't seem to be needed and reduces time by 20s.
- Use `gradle/actions/setup-gradle` for caching instead of manual setup. It seems to perform a bit better.
- Pass extra flags to make gradle build faster.

## Motivation

Speedup the app build on Android to make e2e tests complete faster.

## Testing

Build app with full caches

Before:

- New arch: 8:03
- Old arch: 3:50

After:

- New arch: 2:34
- Old arch: 1:42

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
