### PR TITLE
fix: add missing await to NativeStripeSdk.initialise calls

### DIFF
--- a/src/components/StripeProvider.tsx
+++ b/src/components/StripeProvider.tsx
@@ -45,7 +45,7 @@ export const initStripe = async (params: InitStripeParams): Promise<void> => {
   }
 
   const extendedParams: InitialiseParams = { ...params, appInfo };
-  NativeStripeSdk.initialise(extendedParams);
+  await NativeStripeSdk.initialise(extendedParams);
 };
 
 /**
@@ -81,25 +81,29 @@ export function StripeProvider({
     if (!publishableKey) {
       return;
     }
-    if (isAndroid) {
-      NativeStripeSdk.initialise({
-        publishableKey,
-        appInfo,
-        stripeAccountId,
-        threeDSecureParams,
-        urlScheme,
-        setReturnUrlSchemeOnAndroid,
-      });
-    } else {
-      NativeStripeSdk.initialise({
-        publishableKey,
-        appInfo,
-        stripeAccountId,
-        threeDSecureParams,
-        merchantIdentifier,
-        urlScheme,
-      });
-    }
+    const initializeStripe = async () => {
+      if (isAndroid) {
+        await NativeStripeSdk.initialise({
+          publishableKey,
+          appInfo,
+          stripeAccountId,
+          threeDSecureParams,
+          urlScheme,
+          setReturnUrlSchemeOnAndroid,
+        });
+      } else {
+        await NativeStripeSdk.initialise({
+          publishableKey,
+          appInfo,
+          stripeAccountId,
+          threeDSecureParams,
+          merchantIdentifier,
+          urlScheme,
+        });
+      }
+    };
+
+    initializeStripe();
   }, [
     publishableKey,
     merchantIdentifier,


### PR DESCRIPTION
## Summary
The initialise method is async and returns a Promise, but it wasn't being awaited. 

Changes:
- Added await to initStripe function call to NativeStripeSdk.initialise
- Wrapped useEffect initialization in async IIFE 
- Both Android and iOS initialization paths now properly await completion


## Motivation
This could cause race conditions where subsequent Stripe operations might be called before initialization completes.

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [ ] I tested this manually
- [ ] I added automated tests
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
