### PR TITLE
Fix `EmbeddedPaymentElement` not rendering in `FlatList`

### DIFF
--- a/src/types/EmbeddedPaymentElement.tsx
+++ b/src/types/EmbeddedPaymentElement.tsx
@@ -404,7 +404,9 @@ export function useEmbeddedPaymentElement(
   const [element, setElement] = useState<EmbeddedPaymentElement | null>(null);
   const [paymentOption, setPaymentOption] =
     useState<PaymentOptionDisplayData | null>(null);
-  const [height, setHeight] = useState<number | undefined>();
+  const [height, setHeight] = useState<number | undefined>(
+    isAndroid ? 1 : undefined
+  );
   const viewRef = useRef<React.ComponentRef<HostComponent<NativeProps>>>(null);
   const [loadingError, setLoadingError] = useState<Error | null>(null);
 


### PR DESCRIPTION
## Summary
Fix `EmbeddedPaymentElement` not rendering in `FlatList`

## Motivation
Ensures `FlatList` can be used to render `EmbeddedPaymentElement` in the footer.

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [ ] I added automated tests
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
