### PR TITLE
feat: add twint support on rn

### DIFF
--- a/example/src/screens/TwintPaymentScreen.tsx
+++ b/example/src/screens/TwintPaymentScreen.tsx
@@ -1,0 +1,80 @@
+import React, { useState } from 'react';
+import { Alert, StyleSheet, TextInput } from 'react-native';
+import { useConfirmPayment } from '@stripe/stripe-react-native';
+import Button from '../components/Button';
+import PaymentScreen from '../components/PaymentScreen';
+import { API_URL } from '../Config';
+import { colors } from '../colors';
+
+export default function TwintPaymentScreen() {
+  const [email, setEmail] = useState('');
+  const { confirmPayment, loading } = useConfirmPayment();
+
+  const fetchPaymentIntentClientSecret = async () => {
+    const response = await fetch(`${API_URL}/create-payment-intent`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        email,
+        currency: 'chf', // TWINT is Swiss, so CHF is typical
+        items: ['id-1'],
+        payment_method_types: ['twint'],
+      }),
+    });
+    const { clientSecret, error } = await response.json();
+    return { clientSecret, error };
+  };
+
+  const handlePayPress = async () => {
+    const { clientSecret, error: clientSecretError } =
+      await fetchPaymentIntentClientSecret();
+
+    if (clientSecretError) {
+      Alert.alert(`Error`, clientSecretError);
+      return;
+    }
+
+    const { error, paymentIntent } = await confirmPayment(clientSecret, {
+      paymentMethodType: 'Twint',
+    });
+
+    if (error) {
+      Alert.alert(`Error code: ${error.code}`, error.message);
+    } else if (paymentIntent) {
+      Alert.alert(
+        'Success',
+        `The payment was confirmed successfully! currency: ${paymentIntent.currency}`
+      );
+    }
+  };
+
+  return (
+    <PaymentScreen>
+      <TextInput
+        autoCapitalize="none"
+        placeholder="E-mail"
+        keyboardType="email-address"
+        onChange={(value) => setEmail(value.nativeEvent.text)}
+        style={styles.input}
+      />
+      <Button
+        variant="primary"
+        onPress={handlePayPress}
+        title="Pay with TWINT"
+        accessibilityLabel="Pay with TWINT"
+        loading={loading}
+      />
+    </PaymentScreen>
+  );
+}
+
+const styles = StyleSheet.create({
+  input: {
+    height: 44,
+    borderBottomColor: colors.slate,
+    borderBottomWidth: 1.5,
+    marginBottom: 20,
+  },
+});

--- a/src/types/PaymentIntent.ts
+++ b/src/types/PaymentIntent.ts
@@ -49,7 +49,8 @@ export type ConfirmParams =
   | PayPalParams
   | AffirmParams
   | CashAppParams
-  | RevolutPayParams;
+  | RevolutPayParams
+  | TwintParams;
 
 export type ConfirmOptions = PaymentMethod.ConfirmOptions;
 
@@ -290,6 +291,15 @@ export type CashAppParams = {
 
 export type RevolutPayParams = {
   paymentMethodType: 'RevolutPay';
+  paymentMethodData?: {
+    billingDetails?: BillingDetails;
+    mandateData?: MandateData;
+    metadata?: MetaData;
+  };
+};
+
+export type TwintParams = {
+  paymentMethodType: 'Twint';
   paymentMethodData?: {
     billingDetails?: BillingDetails;
     mandateData?: MandateData;


### PR DESCRIPTION
## Summary
Allow confirming TWINT payment on react native.

## Motivation
The react native stripe sdk does not allow payment method confirmation for twint currently and I want to have this feature for my app.

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [ ] I tested this manually
- [ ] I added automated tests
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
