### PR TITLE
Fix iOS build on new arch 0.81 with static linkage

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1691,7 +1691,7 @@ PODS:
     - StripePayments (= 24.23.0)
     - StripePaymentsUI (= 24.23.0)
     - StripeUICore (= 24.23.0)
-  - stripe-react-native (0.51.0):
+  - stripe-react-native (0.53.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1712,14 +1712,14 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Stripe (~> 24.23.0)
-    - stripe-react-native/NewArch (= 0.51.0)
+    - stripe-react-native/NewArch (= 0.53.0)
     - StripeApplePay (~> 24.23.0)
     - StripeFinancialConnections (~> 24.23.0)
     - StripePayments (~> 24.23.0)
     - StripePaymentSheet (~> 24.23.0)
     - StripePaymentsUI (~> 24.23.0)
     - Yoga
-  - stripe-react-native/NewArch (0.51.0):
+  - stripe-react-native/NewArch (0.53.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1746,7 +1746,7 @@ PODS:
     - StripePaymentSheet (~> 24.23.0)
     - StripePaymentsUI (~> 24.23.0)
     - Yoga
-  - stripe-react-native/Tests (0.51.0):
+  - stripe-react-native/Tests (0.53.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2110,7 +2110,7 @@ SPEC CHECKSUMS:
   RNScreens: 0d4cb9afe052607ad0aa71f645a88bb7c7f2e64c
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Stripe: 2306d32be47f9632942f3385e9c2bad31d6ddcab
-  stripe-react-native: d95f5aa4e5a2d4a0edc8b3ea06e3a55d33ad31eb
+  stripe-react-native: 5250f17648f652dd5c570e76bd8b7bca579a238d
   StripeApplePay: edf515972406df57bd860d5f00416a552be6a450
   StripeCore: ff6173a175acc7c4c25acc7cfabbade717dbc4de
   StripeFinancialConnections: 34a90401657135130fe5bfd93db5ac27c001ec65
@@ -2118,7 +2118,7 @@ SPEC CHECKSUMS:
   StripePaymentSheet: 1c04531a7eff2c721736fc7d433ee342a59fae0e
   StripePaymentsUI: 1cd35149b88de69c3364b4d1d4bb28c653c7d626
   StripeUICore: 539e667170d9c5c86c02a9c63f320d132c7c1b73
-  Yoga: 9b7fb56e7b08cde60e2153344fa6afbd88e5d99f
+  Yoga: afd04ff05ebe0121a00c468a8a3c8080221cb14c
 
 PODFILE CHECKSUM: a2ed964678852d4cc306ff4add3e4fa90be77ea6
 

--- a/ios/NewArch/AddToWalletButtonComponentView.mm
+++ b/ios/NewArch/AddToWalletButtonComponentView.mm
@@ -8,7 +8,6 @@
 #import <React/RCTConversions.h>
 #import <React/RCTFabricComponentsPlugins.h>
 
-#import "RCTFollyConvert.h"
 #import "StripeNewArchConversions.h"
 #import "StripeSwiftInterop.h"
 

--- a/ios/NewArch/AddressSheetViewComponentView.mm
+++ b/ios/NewArch/AddressSheetViewComponentView.mm
@@ -8,7 +8,6 @@
 #import <React/RCTConversions.h>
 #import <React/RCTFabricComponentsPlugins.h>
 
-#import "RCTFollyConvert.h"
 #import "StripeNewArchConversions.h"
 #import "StripeSwiftInterop.h"
 

--- a/ios/NewArch/ApplePayButtonComponentView.mm
+++ b/ios/NewArch/ApplePayButtonComponentView.mm
@@ -8,7 +8,7 @@
 #import <React/RCTConversions.h>
 #import <React/RCTFabricComponentsPlugins.h>
 
-#import "RCTFollyConvert.h"
+#import "StripeNewArchConversions.h"
 #import "StripeSwiftInterop.h"
 
 using namespace facebook::react;

--- a/ios/NewArch/AuBECSDebitFormComponentView.mm
+++ b/ios/NewArch/AuBECSDebitFormComponentView.mm
@@ -8,7 +8,6 @@
 #import <React/RCTConversions.h>
 #import <React/RCTFabricComponentsPlugins.h>
 
-#import "RCTFollyConvert.h"
 #import "StripeNewArchConversions.h"
 #import "StripeSwiftInterop.h"
 

--- a/ios/NewArch/CardFieldComponentView.mm
+++ b/ios/NewArch/CardFieldComponentView.mm
@@ -7,7 +7,6 @@
 
 #import <React/RCTConversions.h>
 #import <React/RCTFabricComponentsPlugins.h>
-#import "RCTFollyConvert.h"
 #import "StripeNewArchConversions.h"
 #import "StripeSwiftInterop.h"
 

--- a/ios/NewArch/CardFormComponentView.mm
+++ b/ios/NewArch/CardFormComponentView.mm
@@ -7,7 +7,6 @@
 
 #import <React/RCTConversions.h>
 #import <React/RCTFabricComponentsPlugins.h>
-#import "RCTFollyConvert.h"
 #import "StripeNewArchConversions.h"
 #import "StripeSwiftInterop.h"
 
@@ -68,7 +67,7 @@ using namespace stripe::react;
   _view.preferredNetworks = convertIntVectorToNSArray(newViewProps.preferredNetworks);
 
   [super updateProps:props oldProps:oldProps];
-  
+
   [_view didSetProps];
 }
 

--- a/ios/NewArch/EmbeddedPaymentElementViewComponentView.mm
+++ b/ios/NewArch/EmbeddedPaymentElementViewComponentView.mm
@@ -8,7 +8,7 @@
 #import <React/RCTConversions.h>
 #import <React/RCTFabricComponentsPlugins.h>
 
-#import "RCTFollyConvert.h"
+#import "StripeNewArchConversions.h"
 #import "StripeSwiftInterop.h"
 
 using namespace facebook::react;
@@ -70,8 +70,6 @@ using namespace facebook::react;
   [super prepareForRecycle];
   [self prepareView];
 }
-
-
 
 @end
 

--- a/ios/NewArch/StripeContainerComponentView.mm
+++ b/ios/NewArch/StripeContainerComponentView.mm
@@ -8,7 +8,7 @@
 #import <React/RCTConversions.h>
 #import <React/RCTFabricComponentsPlugins.h>
 
-#import "RCTFollyConvert.h"
+#import "StripeNewArchConversions.h"
 #import "StripeSwiftInterop.h"
 
 using namespace facebook::react;

--- a/ios/NewArch/StripeNewArchConversions.h
+++ b/ios/NewArch/StripeNewArchConversions.h
@@ -3,6 +3,20 @@
 #include <folly/dynamic.h>
 #include <vector>
 
+// This file was moved in RN 0.81. This includes it differently depending on linkage
+// and falls back to the old file for older RN versions.
+#if __has_include(<react/utils/FollyConvert.h>)
+  // static libs / header maps (no use_frameworks!)
+  #import <react/utils/FollyConvert.h>
+#elif __has_include("FollyConvert.h")
+  /// `use_frameworks! :linkage => :static` users will need to import FollyConvert this way
+  #import "FollyConvert.h"
+#elif __has_include("RCTFollyConvert.h")
+  #import "RCTFollyConvert.h"
+#else
+  #error "FollyConvert.h not found. Ensure React-utils & RCT-Folly pods are installed."
+#endif
+
 NS_ASSUME_NONNULL_BEGIN
 
 namespace stripe::react {

--- a/ios/NewArch/StripeNewArchConversions.mm
+++ b/ios/NewArch/StripeNewArchConversions.mm
@@ -1,10 +1,12 @@
+#import "StripeNewArchConversions.h"
+
 #import <Foundation/Foundation.h>
 #import <React/RCTConversions.h>
-#import "RCTFollyConvert.h"
 
 namespace stripe::react {
 
-NSArray<NSString *> * convertStringVectorToNSArray(const std::vector<std::string> &values) {
+NSArray<NSString *> *convertStringVectorToNSArray(const std::vector<std::string> &values)
+{
   NSMutableArray<NSString *> *result = [[NSMutableArray alloc] initWithCapacity:values.size()];
   for (const auto &value : values) {
     [result addObject:RCTNSStringFromString(value)];
@@ -12,7 +14,8 @@ NSArray<NSString *> * convertStringVectorToNSArray(const std::vector<std::string
   return result;
 }
 
-NSArray<NSNumber *> * convertIntVectorToNSArray(const std::vector<int> &values) {
+NSArray<NSNumber *> *convertIntVectorToNSArray(const std::vector<int> &values)
+{
   NSMutableArray<NSNumber *> *result = [[NSMutableArray alloc] initWithCapacity:values.size()];
   for (int value : values) {
     [result addObject:@(value)];
@@ -20,7 +23,7 @@ NSArray<NSNumber *> * convertIntVectorToNSArray(const std::vector<int> &values) 
   return result;
 }
 
-NSDictionary * _Nullable convertFollyDynamicToNSDictionaryOrNil(const folly::dynamic &dyn)
+NSDictionary *_Nullable convertFollyDynamicToNSDictionaryOrNil(const folly::dynamic &dyn)
 {
   switch (dyn.type()) {
     case folly::dynamic::OBJECT: {
@@ -39,9 +42,9 @@ NSDictionary * _Nullable convertFollyDynamicToNSDictionaryOrNil(const folly::dyn
   }
 }
 
-NSDictionary * convertFollyDynamicToNSDictionary(const folly::dynamic &dyn)
+NSDictionary *convertFollyDynamicToNSDictionary(const folly::dynamic &dyn)
 {
   return convertFollyDynamicToNSDictionaryOrNil(dyn) ?: [NSDictionary new];
 }
 
-}
+} // namespace stripe::react


### PR DESCRIPTION
## Summary

When using RN with `use_frameworks! :linkage => :static` the build fails with `'react/utils/FollyConvert.h' file not found`.

The fix is based on a similar issue in RN mapbox, which handles backwards compatibility properly: https://github.com/rnmapbox/maps/pull/3937.

## Motivation

Fixes #2065

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [ ] I added automated tests
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
