### PR TITLE
Fix handling images with alpha in embedded android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Fixes**
 
 - [#2129](https://github.com/stripe/stripe-react-native/pull/2129) Fix iOS build on new arch 0.81 with static linkage
+- Embedded Payment Element rendering invalid payment option images on Android
 
 ## 0.53.0 - 2025-09-15
 

--- a/android/src/main/java/com/reactnativestripesdk/PaymentSheetFragment.kt
+++ b/android/src/main/java/com/reactnativestripesdk/PaymentSheetFragment.kt
@@ -693,7 +693,7 @@ fun getBitmapFromDrawable(drawable: Drawable): Bitmap? {
       drawableCompat.intrinsicHeight,
       Bitmap.Config.ARGB_8888,
     )
-  bitmap.eraseColor(Color.WHITE)
+  bitmap.eraseColor(Color.TRANSPARENT)
   val canvas = Canvas(bitmap)
   drawable.setBounds(0, 0, canvas.width, canvas.height)
   drawable.draw(canvas)


### PR DESCRIPTION
## Summary
- Fixes an issue where we were not handling images with alpha correctly in React Native

### Before
<img width="360" height="800" alt="Screenshot_1758291341" src="https://github.com/user-attachments/assets/e6cc7811-eacc-4384-9f45-176220480058" />

### After
<img width="360" height="800" alt="Screenshot_1758291291" src="https://github.com/user-attachments/assets/18f52ce8-e271-4f26-b047-438506d884db" />
