### PR TITLE
Onramp: Update Onramp Module To Use RCTDeviceEventEmitter

### DIFF
--- a/android/src/oldarch/java/com/reactnativestripesdk/NativeOnrampSdkModuleSpec.java
+++ b/android/src/oldarch/java/com/reactnativestripesdk/NativeOnrampSdkModuleSpec.java
@@ -18,6 +18,7 @@ import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.modules.core.DeviceEventManagerModule;
 import com.facebook.react.turbomodule.core.interfaces.TurboModule;
 import javax.annotation.Nonnull;
 
@@ -33,8 +34,14 @@ public abstract class NativeOnrampSdkModuleSpec extends ReactContextBaseJavaModu
     return NAME;
   }
 
+  private void invoke(String eventName, Object params) {
+    getReactApplicationContext()
+      .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
+      .emit(eventName, params);
+  }
+
   protected final void emitOnCheckoutClientSecretRequested(ReadableMap value) {
-    mEventEmitterCallback.invoke("onCheckoutClientSecretRequested", value);
+    invoke("onCheckoutClientSecretRequested", value);
   }
 
   @ReactMethod


### PR DESCRIPTION
## Summary
Updates the OnrampSDKModuleSpec to use `RCTDeviceEventEmitter` instead of `mEventEmitterCallback`, similar to `NativeStripeSdkModuleSpec`.

## Motivation
This fixes an issue on the old architecture where `mEventEmitterCallback` does not exist.

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [ ] I added automated tests
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
