### PR TITLE
fix: apply borderRadius to PlatformPayButton on iOS

### DIFF
--- a/ios/ApplePayButtonView.swift
+++ b/ios/ApplePayButtonView.swift
@@ -34,6 +34,12 @@ class ApplePayButtonView: UIView {
         if #available(iOS 12.0, *) {
             self.applePayButton?.cornerRadius = self.borderRadius as? CGFloat ?? 4.0
         }
+
+        // Apply corner radius to the button's layer for better visual effect
+        if let borderRadius = self.borderRadius as? CGFloat {
+            self.applePayButton?.layer.cornerRadius = borderRadius
+            self.applePayButton?.layer.masksToBounds = true
+        }
         
         if let applePayButton = self.applePayButton {
             applePayButton.isEnabled = !disabled


### PR DESCRIPTION
Fixes an issue where the borderRadius prop was not properly applied to the Apple Pay button on iOS. The existing implementation only used PKPaymentButton.cornerRadius which has limited visual effect. This change adds layer-based corner radius application using layer.cornerRadius and layer.masksToBounds for proper visual styling that matches the Android implementation.

🤖 Generated with [Claude Code](https://claude.ai/code)


Committed-By-Agent: claude

## Summary
<!-- Simple summary of what was changed. -->

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a link to the relevant issue, a code snippet, or an example project that demonstrates the bug. -->

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [ ] I tested this manually
- [ ] I added automated tests
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
