### PR TITLE
0.54.0 propose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## x.x.x - x-x-x
 
+## 0.54.0 - 2025-09-29
+
 **Features**
 - [#2140](https://github.com/stripe/stripe-react-native/pull/2140) Added support for the Alma payment method
 


### PR DESCRIPTION
- [X] Ensure the CHANGELOG is up to date with all relevant commits since the last release
- [X] Add the version number for this release & the date to the CHANGELOG, underneath "## Unreleased" 
  - e.g. "## 1.2.3 - 2022-02-14"
- [X] Update the README if necessary (this is only required when there are breaking changes in the release, such as dropping support for an iOS || Android version)