### PR TITLE
0.54.1 proposal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## x.x.x - x-x-x
 
+## 0.54.1 - 2025-10-01
+
+**Fixes**
+
+- [#2147](https://github.com/stripe/stripe-react-native/pull/2147) Fix Stripe UI errors when rotating screen
+
 ## 0.54.0 - 2025-09-29
 
 **Features**


### PR DESCRIPTION
- [X] Ensure the CHANGELOG is up to date with all relevant commits since the last release
- [X] Add the version number for this release & the date to the CHANGELOG, underneath "## Unreleased" 
  - e.g. "## 1.2.3 - 2022-02-14"
- [X] Update the README if necessary (this is only required when there are breaking changes in the release, such as dropping support for an iOS || Android version)