### PR TITLE
fix: add explicit permissions to generate-docs workflow

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -9,6 +9,8 @@ jobs:
   generate-docs:
     name: generate-docs
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
       - name: checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Resolves CWE-276 security alert by adding explicit permissions block with contents: read. This follows the principle of least privilege for GitHub Actions workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Committed-By-Agent: claude

## Summary
<!-- Simple summary of what was changed. -->

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a link to the relevant issue, a code snippet, or an example project that demonstrates the bug. -->
https://jira.corp.stripe.com/browse/RUN_MOBILESDK-4765

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [ ] I tested this manually
- [ ] I added automated tests
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
