### PR TITLE
Fix border radius not being applied to Apple Pay button

### DIFF
--- a/ios/ApplePayButtonManager.m
+++ b/ios/ApplePayButtonManager.m
@@ -5,7 +5,7 @@
 @interface RCT_EXTERN_MODULE(ApplePayButtonManager, RCTViewManager)
 RCT_EXPORT_VIEW_PROPERTY(type, NSNumber)
 RCT_EXPORT_VIEW_PROPERTY(buttonStyle, NSNumber)
-RCT_EXPORT_VIEW_PROPERTY(borderRadius, NSNumber)
+RCT_EXPORT_VIEW_PROPERTY(buttonBorderRadius, NSNumber)
 RCT_EXPORT_VIEW_PROPERTY(disabled, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(onShippingMethodSelectedAction, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onShippingContactSelectedAction, RCTDirectEventBlock)

--- a/ios/ApplePayButtonView.swift
+++ b/ios/ApplePayButtonView.swift
@@ -18,7 +18,7 @@ public class ApplePayButtonView: UIView {
     
     @objc public var type: NSNumber?
     @objc public var buttonStyle: NSNumber?
-    @objc public var borderRadius: NSNumber?
+    @objc public var buttonBorderRadius: NSNumber?
     @objc public var disabled = false
     
     @objc func handleApplePayButtonTapped() {
@@ -37,7 +37,7 @@ public class ApplePayButtonView: UIView {
         let paymentButtonStyle = PKPaymentButtonStyle(rawValue: self.buttonStyle as? Int ?? 2) ?? .black
         self.applePayButton = PKPaymentButton(paymentButtonType: paymentButtonType, paymentButtonStyle: paymentButtonStyle)
         if #available(iOS 12.0, *) {
-            self.applePayButton?.cornerRadius = self.borderRadius as? CGFloat ?? 4.0
+            self.applePayButton?.cornerRadius = self.buttonBorderRadius as? CGFloat ?? 4.0
         }
         
         if let applePayButton = self.applePayButton {

--- a/ios/NewArch/ApplePayButtonComponentView.mm
+++ b/ios/NewArch/ApplePayButtonComponentView.mm
@@ -96,7 +96,7 @@ using namespace facebook::react;
   _view.type = @(newViewProps.type);
   _view.buttonStyle = @(newViewProps.buttonStyle);
   _view.disabled = newViewProps.disabled;
-  _view.borderRadius = @(newViewProps.borderRadius);
+  _view.buttonBorderRadius = @(newViewProps.buttonBorderRadius);
 
   // Set the boolean flags from props
   _view.hasShippingMethodCallback = newViewProps.hasShippingMethodCallback;

--- a/src/components/PlatformPayButton.tsx
+++ b/src/components/PlatformPayButton.tsx
@@ -163,7 +163,7 @@ export function PlatformPayButton({
         <NativeApplePayButton
           type={type}
           buttonStyle={appearance}
-          borderRadius={borderRadius}
+          buttonBorderRadius={borderRadius}
           disabled={disabled ?? false}
           style={styles.nativeButtonStyle}
           {...callbackProps}

--- a/src/specs/NativeApplePayButton.ts
+++ b/src/specs/NativeApplePayButton.ts
@@ -26,7 +26,7 @@ export interface NativeProps extends ViewProps {
   disabled: boolean;
   type: Int32;
   buttonStyle: Int32;
-  borderRadius?: WithDefault<Int32, 4>;
+  buttonBorderRadius?: WithDefault<Int32, 4>;
   onShippingMethodSelectedAction?: DirectEventHandler<OnShippingMethodSelectedActionEvent>;
   onShippingContactSelectedAction?: DirectEventHandler<OnShippingContactSelectedActionEvent>;
   onCouponCodeEnteredAction?: DirectEventHandler<OnCouponCodeEnteredActionEvent>;


### PR DESCRIPTION
## Summary
Fix border radius not being applied to Apple Pay button

<img width="50%" height="50%" src="https://github.com/user-attachments/assets/dcf4896d-fd8e-4070-b716-6ced4896da8e" />

## Motivation
https://jira.corp.stripe.com/browse/RUN_MOBILESDK-4703
https://github.com/stripe/stripe-react-native/issues/2142

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [ ] I added automated tests
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
