### PR TITLE
Refactor + unit tests payment sheet and embedded

### DIFF
--- a/android/src/androidTest/java/com/reactnativestripesdk/EmbeddedPaymentElementViewManagerTest.kt
+++ b/android/src/androidTest/java/com/reactnativestripesdk/EmbeddedPaymentElementViewManagerTest.kt
@@ -1,0 +1,169 @@
+package com.reactnativestripesdk
+
+import androidx.test.core.app.ApplicationProvider
+import com.facebook.react.soloader.OpenSourceMergedSoMapping
+import com.facebook.soloader.SoLoader
+import com.reactnativestripesdk.utils.readableMapOf
+import com.stripe.android.paymentelement.EmbeddedPaymentElement
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+class EmbeddedPaymentElementViewManagerTest {
+  @Before
+  fun setup() {
+    SoLoader.init(ApplicationProvider.getApplicationContext(), OpenSourceMergedSoMapping)
+  }
+
+  // ============================================
+  // mapToRowSelectionBehaviorType Tests
+  // ============================================
+
+  @Test
+  fun mapToRowSelectionBehaviorType_NullMap_DefaultsToDefault() {
+    val result = mapToRowSelectionBehaviorType(null)
+    assertEquals(RowSelectionBehaviorType.Default, result)
+  }
+
+  @Test
+  fun mapToRowSelectionBehaviorType_EmptyMap_DefaultsToDefault() {
+    val params = readableMapOf()
+    val result = mapToRowSelectionBehaviorType(params)
+    assertEquals(RowSelectionBehaviorType.Default, result)
+  }
+
+  @Test
+  fun mapToRowSelectionBehaviorType_NoRowSelectionBehaviorKey_DefaultsToDefault() {
+    val params =
+      readableMapOf(
+        "someOtherKey" to "value",
+      )
+    val result = mapToRowSelectionBehaviorType(params)
+    assertEquals(RowSelectionBehaviorType.Default, result)
+  }
+
+  @Test
+  fun mapToRowSelectionBehaviorType_TypeDefault() {
+    val params =
+      readableMapOf(
+        "rowSelectionBehavior" to
+          readableMapOf(
+            "type" to "default",
+          ),
+      )
+    val result = mapToRowSelectionBehaviorType(params)
+    assertEquals(RowSelectionBehaviorType.Default, result)
+  }
+
+  @Test
+  fun mapToRowSelectionBehaviorType_TypeImmediateAction() {
+    val params =
+      readableMapOf(
+        "rowSelectionBehavior" to
+          readableMapOf(
+            "type" to "immediateAction",
+          ),
+      )
+    val result = mapToRowSelectionBehaviorType(params)
+    assertEquals(RowSelectionBehaviorType.ImmediateAction, result)
+  }
+
+  @Test
+  fun mapToRowSelectionBehaviorType_InvalidType_DefaultsToDefault() {
+    val params =
+      readableMapOf(
+        "rowSelectionBehavior" to
+          readableMapOf(
+            "type" to "invalid",
+          ),
+      )
+    val result = mapToRowSelectionBehaviorType(params)
+    assertEquals(RowSelectionBehaviorType.Default, result)
+  }
+
+  @Test
+  fun mapToRowSelectionBehaviorType_NullType_DefaultsToDefault() {
+    val params =
+      readableMapOf(
+        "rowSelectionBehavior" to readableMapOf(),
+      )
+    val result = mapToRowSelectionBehaviorType(params)
+    assertEquals(RowSelectionBehaviorType.Default, result)
+  }
+
+  // ============================================
+  // mapToFormSheetAction Tests
+  // ============================================
+
+  @Test
+  fun mapToFormSheetAction_NullMap_DefaultsToContinue() {
+    val result = mapToFormSheetAction(null)
+    assertEquals(EmbeddedPaymentElement.FormSheetAction.Continue, result)
+  }
+
+  @Test
+  fun mapToFormSheetAction_EmptyMap_DefaultsToContinue() {
+    val params = readableMapOf()
+    val result = mapToFormSheetAction(params)
+    assertEquals(EmbeddedPaymentElement.FormSheetAction.Continue, result)
+  }
+
+  @Test
+  fun mapToFormSheetAction_NoFormSheetActionKey_DefaultsToContinue() {
+    val params =
+      readableMapOf(
+        "someOtherKey" to "value",
+      )
+    val result = mapToFormSheetAction(params)
+    assertEquals(EmbeddedPaymentElement.FormSheetAction.Continue, result)
+  }
+
+  @Test
+  fun mapToFormSheetAction_TypeContinue() {
+    val params =
+      readableMapOf(
+        "formSheetAction" to
+          readableMapOf(
+            "type" to "continue",
+          ),
+      )
+    val result = mapToFormSheetAction(params)
+    assertEquals(EmbeddedPaymentElement.FormSheetAction.Continue, result)
+  }
+
+  @Test
+  fun mapToFormSheetAction_TypeConfirm() {
+    val params =
+      readableMapOf(
+        "formSheetAction" to
+          readableMapOf(
+            "type" to "confirm",
+          ),
+      )
+    val result = mapToFormSheetAction(params)
+    assertEquals(EmbeddedPaymentElement.FormSheetAction.Confirm, result)
+  }
+
+  @Test
+  fun mapToFormSheetAction_InvalidType_DefaultsToContinue() {
+    val params =
+      readableMapOf(
+        "formSheetAction" to
+          readableMapOf(
+            "type" to "invalid",
+          ),
+      )
+    val result = mapToFormSheetAction(params)
+    assertEquals(EmbeddedPaymentElement.FormSheetAction.Continue, result)
+  }
+
+  @Test
+  fun mapToFormSheetAction_NullType_DefaultsToContinue() {
+    val params =
+      readableMapOf(
+        "formSheetAction" to readableMapOf(),
+      )
+    val result = mapToFormSheetAction(params)
+    assertEquals(EmbeddedPaymentElement.FormSheetAction.Continue, result)
+  }
+}

--- a/android/src/androidTest/java/com/reactnativestripesdk/PaymentElementConfigTest.kt
+++ b/android/src/androidTest/java/com/reactnativestripesdk/PaymentElementConfigTest.kt
@@ -1,0 +1,947 @@
+package com.reactnativestripesdk
+
+import androidx.test.core.app.ApplicationProvider
+import com.facebook.react.soloader.OpenSourceMergedSoMapping
+import com.facebook.soloader.SoLoader
+import com.reactnativestripesdk.utils.PaymentSheetException
+import com.reactnativestripesdk.utils.readableArrayOf
+import com.reactnativestripesdk.utils.readableMapOf
+import com.stripe.android.paymentelement.PaymentMethodOptionsSetupFutureUsagePreview
+import com.stripe.android.paymentsheet.PaymentSheet
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(PaymentMethodOptionsSetupFutureUsagePreview::class)
+class PaymentElementConfigTest {
+  @Before
+  fun setup() {
+    SoLoader.init(ApplicationProvider.getApplicationContext(), OpenSourceMergedSoMapping)
+  }
+
+  // ============================================
+  // buildIntentConfiguration Tests
+  // ============================================
+
+  @Test
+  fun buildIntentConfiguration_NullParams_ReturnsNull() {
+    val result = buildIntentConfiguration(null)
+    assertNull(result)
+  }
+
+  @Test(expected = PaymentSheetException::class)
+  fun buildIntentConfiguration_MissingMode_ThrowsException() {
+    val params = readableMapOf()
+    buildIntentConfiguration(params)
+  }
+
+  @Test
+  fun buildIntentConfiguration_WithPaymentMode_Success() {
+    val params =
+      readableMapOf(
+        "mode" to
+          readableMapOf(
+            "amount" to 1000,
+            "currencyCode" to "usd",
+          ),
+      )
+
+    val result = buildIntentConfiguration(params)
+
+    assertNotNull(result)
+    val mode = result?.mode as? PaymentSheet.IntentConfiguration.Mode.Payment
+    assertEquals(1000L, mode?.amount)
+    assertEquals("usd", mode?.currency)
+  }
+
+  @Test
+  fun buildIntentConfiguration_WithPaymentMethodTypes_Success() {
+    val params =
+      readableMapOf(
+        "mode" to
+          readableMapOf(
+            "amount" to 1000,
+            "currencyCode" to "usd",
+          ),
+        "paymentMethodTypes" to readableArrayOf("card", "klarna"),
+      )
+
+    val result = buildIntentConfiguration(params)
+
+    assertNotNull(result)
+    assertEquals(2, result?.paymentMethodTypes?.size)
+    assertEquals("card", result?.paymentMethodTypes?.get(0))
+    assertEquals("klarna", result?.paymentMethodTypes?.get(1))
+  }
+
+  @Test
+  fun buildIntentConfiguration_EmptyPaymentMethodTypes_ReturnsEmptyList() {
+    val params =
+      readableMapOf(
+        "mode" to
+          readableMapOf(
+            "amount" to 1000,
+            "currencyCode" to "usd",
+          ),
+      )
+
+    val result = buildIntentConfiguration(params)
+
+    assertNotNull(result)
+    assertEquals(0, result?.paymentMethodTypes?.size)
+  }
+
+  // ============================================
+  // buildIntentConfigurationMode Tests
+  // ============================================
+
+  @Test
+  fun buildIntentConfigurationMode_PaymentMode_MinimalParams() {
+    val params =
+      readableMapOf(
+        "mode" to
+          readableMapOf(
+            "amount" to 5000,
+            "currencyCode" to "eur",
+          ),
+      )
+
+    val result = buildIntentConfiguration(params)
+
+    val mode = result?.mode as? PaymentSheet.IntentConfiguration.Mode.Payment
+    assertNotNull(mode)
+    assertEquals(5000L, mode?.amount)
+    assertEquals("eur", mode?.currency)
+  }
+
+  @Test(expected = PaymentSheetException::class)
+  fun buildIntentConfigurationMode_PaymentMode_MissingCurrency_ThrowsException() {
+    val params =
+      readableMapOf(
+        "mode" to
+          readableMapOf(
+            "amount" to 5000,
+          ),
+      )
+
+    buildIntentConfiguration(params)
+  }
+
+  @Test
+  fun buildIntentConfigurationMode_PaymentMode_WithSetupFutureUsage() {
+    val params =
+      readableMapOf(
+        "mode" to
+          readableMapOf(
+            "amount" to 5000,
+            "currencyCode" to "usd",
+            "setupFutureUsage" to "OffSession",
+          ),
+      )
+
+    val result = buildIntentConfiguration(params)
+
+    assertNotNull(result?.mode as? PaymentSheet.IntentConfiguration.Mode.Payment)
+  }
+
+  @Test
+  fun buildIntentConfigurationMode_PaymentMode_WithCaptureMethod() {
+    val params =
+      readableMapOf(
+        "mode" to
+          readableMapOf(
+            "amount" to 5000,
+            "currencyCode" to "usd",
+            "captureMethod" to "Manual",
+          ),
+      )
+
+    val result = buildIntentConfiguration(params)
+
+    assertNotNull(result?.mode as? PaymentSheet.IntentConfiguration.Mode.Payment)
+  }
+
+  @Test
+  fun buildIntentConfigurationMode_PaymentMode_WithPaymentMethodOptions() {
+    val params =
+      readableMapOf(
+        "mode" to
+          readableMapOf(
+            "amount" to 5000,
+            "currencyCode" to "usd",
+            "paymentMethodOptions" to
+              readableMapOf(
+                "setupFutureUsageValues" to
+                  readableMapOf(
+                    "card" to "OffSession",
+                    "us_bank_account" to "OnSession",
+                  ),
+              ),
+          ),
+      )
+
+    val result = buildIntentConfiguration(params)
+
+    assertNotNull(result?.mode as? PaymentSheet.IntentConfiguration.Mode.Payment)
+  }
+
+  @Test
+  fun buildIntentConfigurationMode_SetupMode_Success() {
+    val params =
+      readableMapOf(
+        "mode" to
+          readableMapOf(
+            "setupFutureUsage" to "OffSession",
+          ),
+      )
+
+    val result = buildIntentConfiguration(params)
+
+    assertNotNull(result?.mode as? PaymentSheet.IntentConfiguration.Mode.Setup)
+  }
+
+  @Test
+  fun buildIntentConfigurationMode_SetupMode_WithCurrency() {
+    val params =
+      readableMapOf(
+        "mode" to
+          readableMapOf(
+            "setupFutureUsage" to "OnSession",
+            "currencyCode" to "gbp",
+          ),
+      )
+
+    val result = buildIntentConfiguration(params)
+    assertNotNull(result?.mode as? PaymentSheet.IntentConfiguration.Mode.Setup)
+  }
+
+  @Test(expected = PaymentSheetException::class)
+  fun buildIntentConfigurationMode_SetupMode_MissingSetupFutureUsage_ThrowsException() {
+    val params =
+      readableMapOf(
+        "mode" to readableMapOf(),
+      )
+
+    buildIntentConfiguration(params)
+  }
+
+  @Test
+  fun buildIntentConfigurationMode_PaymentMode_InvalidSetupFutureUsage_UsesNull() {
+    val params =
+      readableMapOf(
+        "mode" to
+          readableMapOf(
+            "amount" to 5000,
+            "currencyCode" to "usd",
+            "setupFutureUsage" to "Unknown",
+          ),
+      )
+
+    val result = buildIntentConfiguration(params)
+
+    assertNotNull(result?.mode as? PaymentSheet.IntentConfiguration.Mode.Payment)
+  }
+
+  @Test
+  fun buildIntentConfigurationMode_PaymentMode_InvalidCaptureMethod_DefaultsToAutomatic() {
+    val params =
+      readableMapOf(
+        "mode" to
+          readableMapOf(
+            "amount" to 5000,
+            "currencyCode" to "usd",
+            "captureMethod" to "InvalidMethod",
+          ),
+      )
+
+    val result = buildIntentConfiguration(params)
+
+    assertNotNull(result?.mode as? PaymentSheet.IntentConfiguration.Mode.Payment)
+  }
+
+  @Test
+  fun buildIntentConfigurationMode_PaymentMode_NullPaymentMethodOptions() {
+    val params =
+      readableMapOf(
+        "mode" to
+          readableMapOf(
+            "amount" to 5000,
+            "currencyCode" to "usd",
+            "paymentMethodOptions" to null,
+          ),
+      )
+
+    val result = buildIntentConfiguration(params)
+
+    assertNotNull(result?.mode as? PaymentSheet.IntentConfiguration.Mode.Payment)
+  }
+
+  @Test
+  fun buildIntentConfigurationMode_PaymentMode_EmptyPaymentMethodOptions() {
+    val params =
+      readableMapOf(
+        "mode" to
+          readableMapOf(
+            "amount" to 5000,
+            "currencyCode" to "usd",
+            "paymentMethodOptions" to
+              readableMapOf(
+                "setupFutureUsageValues" to readableMapOf(),
+              ),
+          ),
+      )
+
+    val result = buildIntentConfiguration(params)
+
+    assertNotNull(result?.mode as? PaymentSheet.IntentConfiguration.Mode.Payment)
+  }
+
+  @Test
+  fun buildIntentConfigurationMode_PaymentMode_InvalidPaymentMethodCodesInOptions() {
+    val params =
+      readableMapOf(
+        "mode" to
+          readableMapOf(
+            "amount" to 5000,
+            "currencyCode" to "usd",
+            "paymentMethodOptions" to
+              readableMapOf(
+                "setupFutureUsageValues" to
+                  readableMapOf(
+                    "invalid_code" to "OffSession",
+                    "another_invalid" to "OnSession",
+                  ),
+              ),
+          ),
+      )
+
+    val result = buildIntentConfiguration(params)
+
+    assertNotNull(result?.mode as? PaymentSheet.IntentConfiguration.Mode.Payment)
+  }
+
+  @Test(expected = PaymentSheetException::class)
+  fun buildIntentConfigurationMode_SetupMode_InvalidSetupFutureUsage_ThrowsException() {
+    val params =
+      readableMapOf(
+        "mode" to
+          readableMapOf(
+            "setupFutureUsage" to "Unknown",
+          ),
+      )
+
+    buildIntentConfiguration(params)
+  }
+
+  // ============================================
+  // buildLinkConfig Tests
+  // ============================================
+
+  @Test
+  fun buildLinkConfig_NullParams_ReturnsDefaultConfig() {
+    val result = buildLinkConfig(null)
+
+    assertNotNull(result)
+  }
+
+  @Test
+  fun buildLinkConfig_EmptyParams_ReturnsDefaultConfig() {
+    val params = readableMapOf()
+    val result = buildLinkConfig(params)
+
+    assertNotNull(result)
+  }
+
+  @Test
+  fun buildLinkConfig_DisplayAutomatic() {
+    val params =
+      readableMapOf(
+        "display" to "automatic",
+      )
+    val result = buildLinkConfig(params)
+
+    assertNotNull(result)
+  }
+
+  @Test
+  fun buildLinkConfig_DisplayNever() {
+    val params =
+      readableMapOf(
+        "display" to "never",
+      )
+    val result = buildLinkConfig(params)
+
+    assertNotNull(result)
+  }
+
+  @Test
+  fun buildLinkConfig_InvalidDisplay_DefaultsToAutomatic() {
+    val params =
+      readableMapOf(
+        "display" to "invalid_value",
+      )
+    val result = buildLinkConfig(params)
+
+    assertNotNull(result)
+  }
+
+  // ============================================
+  // buildGooglePayConfig Tests
+  // ============================================
+
+  @Test
+  fun buildGooglePayConfig_NullParams_ReturnsNull() {
+    val result = buildGooglePayConfig(null)
+    assertNull(result)
+  }
+
+  @Test
+  fun buildGooglePayConfig_EmptyParams_ReturnsNull() {
+    val params = readableMapOf()
+    val result = buildGooglePayConfig(params)
+    assertNull(result)
+  }
+
+  @Test
+  fun buildGooglePayConfig_MinimalParams_TestEnvironment() {
+    val params =
+      readableMapOf(
+        "merchantCountryCode" to "US",
+        "currencyCode" to "usd",
+        "testEnv" to true,
+      )
+
+    val result = buildGooglePayConfig(params)
+
+    assertNotNull(result)
+  }
+
+  @Test
+  fun buildGooglePayConfig_ProductionEnvironment() {
+    val params =
+      readableMapOf(
+        "merchantCountryCode" to "CA",
+        "currencyCode" to "cad",
+        "testEnv" to false,
+      )
+
+    val result = buildGooglePayConfig(params)
+
+    assertNotNull(result)
+  }
+
+  @Test
+  fun buildGooglePayConfig_WithAmount() {
+    val params =
+      readableMapOf(
+        "merchantCountryCode" to "US",
+        "currencyCode" to "usd",
+        "testEnv" to true,
+        "amount" to "2500",
+      )
+
+    val result = buildGooglePayConfig(params)
+
+    assertNotNull(result)
+  }
+
+  @Test
+  fun buildGooglePayConfig_WithInvalidAmount() {
+    val params =
+      readableMapOf(
+        "merchantCountryCode" to "US",
+        "currencyCode" to "usd",
+        "testEnv" to true,
+        "amount" to "not_a_number",
+      )
+
+    val result = buildGooglePayConfig(params)
+
+    assertNotNull(result)
+  }
+
+  @Test
+  fun buildGooglePayConfig_WithLabel() {
+    val params =
+      readableMapOf(
+        "merchantCountryCode" to "US",
+        "currencyCode" to "usd",
+        "testEnv" to true,
+        "label" to "Total",
+      )
+
+    val result = buildGooglePayConfig(params)
+
+    assertNotNull(result)
+  }
+
+  @Test
+  fun buildGooglePayConfig_TestEnvNotProvided_DefaultsToFalse() {
+    val params =
+      readableMapOf(
+        "merchantCountryCode" to "US",
+        "currencyCode" to "usd",
+      )
+
+    val result = buildGooglePayConfig(params)
+
+    assertNotNull(result)
+  }
+
+  @Test
+  fun buildGooglePayConfig_EmptyMerchantCountryCode() {
+    val params =
+      readableMapOf(
+        "merchantCountryCode" to "",
+        "currencyCode" to "usd",
+        "testEnv" to true,
+      )
+
+    val result = buildGooglePayConfig(params)
+
+    assertNotNull(result)
+  }
+
+  @Test
+  fun buildGooglePayConfig_EmptyCurrencyCode() {
+    val params =
+      readableMapOf(
+        "merchantCountryCode" to "US",
+        "currencyCode" to "",
+        "testEnv" to true,
+      )
+
+    val result = buildGooglePayConfig(params)
+
+    assertNotNull(result)
+  }
+
+  @Test
+  fun buildGooglePayConfig_MissingMerchantCountryCode() {
+    val params =
+      readableMapOf(
+        "currencyCode" to "usd",
+        "testEnv" to true,
+      )
+
+    val result = buildGooglePayConfig(params)
+
+    assertNotNull(result)
+  }
+
+  @Test
+  fun buildGooglePayConfig_MissingCurrencyCode() {
+    val params =
+      readableMapOf(
+        "merchantCountryCode" to "US",
+        "testEnv" to true,
+      )
+
+    val result = buildGooglePayConfig(params)
+
+    assertNotNull(result)
+  }
+
+  @Test
+  fun buildGooglePayConfig_ButtonTypes() {
+    val testCases =
+      listOf(
+        1 to PaymentSheet.GooglePayConfiguration.ButtonType.Buy,
+        6 to PaymentSheet.GooglePayConfiguration.ButtonType.Book,
+        5 to PaymentSheet.GooglePayConfiguration.ButtonType.Checkout,
+        4 to PaymentSheet.GooglePayConfiguration.ButtonType.Donate,
+        11 to PaymentSheet.GooglePayConfiguration.ButtonType.Order,
+        1000 to PaymentSheet.GooglePayConfiguration.ButtonType.Pay,
+        7 to PaymentSheet.GooglePayConfiguration.ButtonType.Subscribe,
+        1001 to PaymentSheet.GooglePayConfiguration.ButtonType.Plain,
+        9999 to PaymentSheet.GooglePayConfiguration.ButtonType.Pay, // Invalid defaults to Pay
+      )
+
+    for ((buttonTypeValue) in testCases) {
+      val params =
+        readableMapOf(
+          "merchantCountryCode" to "US",
+          "currencyCode" to "usd",
+          "testEnv" to true,
+          "buttonType" to buttonTypeValue,
+        )
+
+      val result = buildGooglePayConfig(params)
+
+      assertNotNull(result)
+    }
+  }
+
+  @Test
+  fun buildGooglePayConfig_CompleteConfig() {
+    val params =
+      readableMapOf(
+        "merchantCountryCode" to "GB",
+        "currencyCode" to "gbp",
+        "testEnv" to false,
+        "amount" to "10000",
+        "label" to "Order Total",
+        "buttonType" to 5,
+      )
+
+    val result = buildGooglePayConfig(params)
+
+    assertNotNull(result)
+  }
+
+  // ============================================
+  // buildCustomerConfiguration Tests
+  // ============================================
+
+  @Test
+  fun buildCustomerConfiguration_NullParams_ReturnsNull() {
+    val result = buildCustomerConfiguration(null)
+    assertNull(result)
+  }
+
+  @Test
+  fun buildCustomerConfiguration_EmptyParams_ReturnsNull() {
+    val params = readableMapOf()
+    val result = buildCustomerConfiguration(params)
+    assertNull(result)
+  }
+
+  @Test
+  fun buildCustomerConfiguration_OnlyCustomerId_ReturnsNull() {
+    val params =
+      readableMapOf(
+        "customerId" to "cus_123",
+      )
+
+    val result = buildCustomerConfiguration(params)
+    assertNull(result)
+  }
+
+  @Test
+  fun buildCustomerConfiguration_WithEphemeralKey_Success() {
+    val params =
+      readableMapOf(
+        "customerId" to "cus_123",
+        "customerEphemeralKeySecret" to "ek_test_123",
+      )
+
+    val result = buildCustomerConfiguration(params)
+
+    assertNotNull(result)
+  }
+
+  @Test
+  fun buildCustomerConfiguration_WithCustomerSession_Success() {
+    val params =
+      readableMapOf(
+        "customerId" to "cus_456",
+        "customerSessionClientSecret" to "cuss_test_456",
+      )
+
+    val result = buildCustomerConfiguration(params)
+
+    assertNotNull(result)
+  }
+
+  @Test(expected = PaymentSheetException::class)
+  fun buildCustomerConfiguration_BothSecretsProvided_ThrowsException() {
+    val params =
+      readableMapOf(
+        "customerId" to "cus_789",
+        "customerEphemeralKeySecret" to "ek_test_789",
+        "customerSessionClientSecret" to "cuss_test_789",
+      )
+
+    buildCustomerConfiguration(params)
+  }
+
+  @Test
+  fun buildCustomerConfiguration_OnlyEphemeralKey_NoCustomerId_ReturnsNull() {
+    val params =
+      readableMapOf(
+        "customerEphemeralKeySecret" to "ek_test_123",
+      )
+
+    val result = buildCustomerConfiguration(params)
+    assertNull(result)
+  }
+
+  @Test
+  fun buildCustomerConfiguration_OnlyCustomerSession_NoCustomerId_ReturnsNull() {
+    val params =
+      readableMapOf(
+        "customerSessionClientSecret" to "cuss_test_456",
+      )
+
+    val result = buildCustomerConfiguration(params)
+    assertNull(result)
+  }
+
+  // ============================================
+  // buildBillingDetails Tests
+  // ============================================
+
+  @Test
+  fun buildBillingDetails_NullMap_ReturnsNull() {
+    val result = buildBillingDetails(null)
+    assertNull(result)
+  }
+
+  @Test
+  fun buildBillingDetails_EmptyMap_ReturnsEmptyBillingDetails() {
+    val params = readableMapOf()
+
+    val result = buildBillingDetails(params)
+    assertNotNull(result)
+    assertNotNull(result!!.address)
+    assertNull(result.address?.city)
+    assertNull(result.address?.country)
+    assertNull(result.address?.line1)
+    assertNull(result.address?.line2)
+    assertNull(result.address?.postalCode)
+    assertNull(result.address?.state)
+    assertNull(result.email)
+    assertNull(result.name)
+    assertNull(result.phone)
+  }
+
+  @Test
+  fun buildBillingDetails_FullDetails_ReturnsComplete() {
+    val params =
+      readableMapOf(
+        "email" to "test@example.com",
+        "name" to "John Doe",
+        "phone" to "+1234567890",
+        "address" to
+          readableMapOf(
+            "city" to "San Francisco",
+            "country" to "US",
+            "line1" to "123 Main St",
+            "line2" to "Apt 4",
+            "postalCode" to "94111",
+            "state" to "CA",
+          ),
+      )
+
+    val result = buildBillingDetails(params)
+    assertNotNull(result)
+    assertEquals("test@example.com", result!!.email)
+    assertEquals("John Doe", result.name)
+    assertEquals("+1234567890", result.phone)
+    assertNotNull(result.address)
+    assertEquals("San Francisco", result.address?.city)
+    assertEquals("US", result.address?.country)
+    assertEquals("123 Main St", result.address?.line1)
+    assertEquals("Apt 4", result.address?.line2)
+    assertEquals("94111", result.address?.postalCode)
+    assertEquals("CA", result.address?.state)
+  }
+
+  @Test
+  fun buildBillingDetails_OnlyEmail_ReturnsPartialDetails() {
+    val params =
+      readableMapOf(
+        "email" to "test@example.com",
+      )
+
+    val result = buildBillingDetails(params)
+    assertNotNull(result)
+    assertEquals("test@example.com", result!!.email)
+    assertNull(result.name)
+    assertNull(result.phone)
+    assertNotNull(result.address)
+    assertNull(result.address?.city)
+  }
+
+  @Test
+  fun buildBillingDetails_OnlyName_ReturnsPartialDetails() {
+    val params =
+      readableMapOf(
+        "name" to "John Doe",
+      )
+
+    val result = buildBillingDetails(params)
+    assertNotNull(result)
+    assertNull(result!!.email)
+    assertEquals("John Doe", result.name)
+    assertNull(result.phone)
+  }
+
+  @Test
+  fun buildBillingDetails_OnlyPhone_ReturnsPartialDetails() {
+    val params =
+      readableMapOf(
+        "phone" to "+1234567890",
+      )
+
+    val result = buildBillingDetails(params)
+    assertNotNull(result)
+    assertNull(result!!.email)
+    assertNull(result.name)
+    assertEquals("+1234567890", result.phone)
+  }
+
+  @Test
+  fun buildBillingDetails_OnlyAddress_ReturnsPartialDetails() {
+    val params =
+      readableMapOf(
+        "address" to
+          readableMapOf(
+            "city" to "San Francisco",
+            "country" to "US",
+          ),
+      )
+
+    val result = buildBillingDetails(params)
+    assertNotNull(result)
+    assertNull(result!!.email)
+    assertNull(result.name)
+    assertNull(result.phone)
+    assertNotNull(result.address)
+    assertEquals("San Francisco", result.address?.city)
+    assertEquals("US", result.address?.country)
+    assertNull(result.address?.line1)
+  }
+
+  @Test
+  fun buildBillingDetails_PartialAddress_ReturnsPartialDetails() {
+    val params =
+      readableMapOf(
+        "email" to "test@example.com",
+        "address" to
+          readableMapOf(
+            "line1" to "123 Main St",
+            "postalCode" to "94111",
+          ),
+      )
+
+    val result = buildBillingDetails(params)
+    assertNotNull(result)
+    assertEquals("test@example.com", result!!.email)
+    assertNotNull(result.address)
+    assertNull(result.address?.city)
+    assertNull(result.address?.country)
+    assertEquals("123 Main St", result.address?.line1)
+    assertNull(result.address?.line2)
+    assertEquals("94111", result.address?.postalCode)
+    assertNull(result.address?.state)
+  }
+
+  @Test
+  fun buildBillingDetails_EmptyAddress_ReturnsEmptyAddressObject() {
+    val params =
+      readableMapOf(
+        "email" to "test@example.com",
+        "address" to readableMapOf(),
+      )
+
+    val result = buildBillingDetails(params)
+    assertNotNull(result)
+    assertEquals("test@example.com", result!!.email)
+    assertNotNull(result.address)
+    assertNull(result.address?.city)
+    assertNull(result.address?.country)
+    assertNull(result.address?.line1)
+    assertNull(result.address?.line2)
+    assertNull(result.address?.postalCode)
+    assertNull(result.address?.state)
+  }
+
+  @Test
+  fun buildBillingDetails_MixedFields_ReturnsPartialDetails() {
+    val params =
+      readableMapOf(
+        "name" to "Jane Smith",
+        "address" to
+          readableMapOf(
+            "country" to "CA",
+            "state" to "ON",
+          ),
+      )
+
+    val result = buildBillingDetails(params)
+    assertNotNull(result)
+    assertNull(result!!.email)
+    assertEquals("Jane Smith", result.name)
+    assertNull(result.phone)
+    assertNotNull(result.address)
+    assertNull(result.address?.city)
+    assertEquals("CA", result.address?.country)
+    assertNull(result.address?.line1)
+    assertNull(result.address?.line2)
+    assertNull(result.address?.postalCode)
+    assertEquals("ON", result.address?.state)
+  }
+
+  // ============================================
+  // buildBillingDetailsCollectionConfiguration Tests
+  // ============================================
+
+  @Test
+  fun buildBillingDetailsCollectionConfiguration_NullMap_ReturnsDefaults() {
+    val result = buildBillingDetailsCollectionConfiguration(null)
+    assertNotNull(result)
+  }
+
+  @Test
+  fun buildBillingDetailsCollectionConfiguration_EmptyMap_ReturnsDefaults() {
+    val params = readableMapOf()
+
+    val result = buildBillingDetailsCollectionConfiguration(params)
+    assertNotNull(result)
+  }
+
+  @Test
+  fun buildBillingDetailsCollectionConfiguration_AllFieldsSet_ReturnsComplete() {
+    val params =
+      readableMapOf(
+        "name" to "always",
+        "phone" to "never",
+        "email" to "automatic",
+        "address" to "full",
+        "attachDefaultsToPaymentMethod" to true,
+      )
+
+    val result = buildBillingDetailsCollectionConfiguration(params)
+    assertNotNull(result)
+  }
+
+  @Test
+  fun buildBillingDetailsCollectionConfiguration_PartialFields_ReturnsPartial() {
+    val params =
+      readableMapOf(
+        "name" to "always",
+        "address" to "never",
+      )
+
+    val result = buildBillingDetailsCollectionConfiguration(params)
+    assertNotNull(result)
+  }
+
+  @Test
+  fun buildBillingDetailsCollectionConfiguration_InvalidValues_DefaultsToAutomatic() {
+    val params =
+      readableMapOf(
+        "name" to "invalid",
+        "phone" to "wrong",
+        "email" to "bad",
+        "address" to "incorrect",
+      )
+
+    val result = buildBillingDetailsCollectionConfiguration(params)
+    assertNotNull(result)
+  }
+
+  @Test
+  fun buildBillingDetailsCollectionConfiguration_AttachDefaultsFalse() {
+    val params =
+      readableMapOf(
+        "attachDefaultsToPaymentMethod" to false,
+      )
+
+    val result = buildBillingDetailsCollectionConfiguration(params)
+    assertNotNull(result)
+  }
+}

--- a/android/src/androidTest/java/com/reactnativestripesdk/PaymentSheetManagerTest.kt
+++ b/android/src/androidTest/java/com/reactnativestripesdk/PaymentSheetManagerTest.kt
@@ -1,52 +1,529 @@
 package com.reactnativestripesdk
 
 import androidx.test.core.app.ApplicationProvider
-import com.facebook.react.bridge.Arguments
 import com.facebook.react.soloader.OpenSourceMergedSoMapping
 import com.facebook.soloader.SoLoader
+import com.reactnativestripesdk.utils.readableArrayOf
 import com.reactnativestripesdk.utils.readableMapOf
+import com.stripe.android.paymentelement.PaymentMethodOptionsSetupFutureUsagePreview
 import com.stripe.android.paymentsheet.PaymentSheet
-import org.junit.Assert
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Before
 import org.junit.Test
 
+@OptIn(PaymentMethodOptionsSetupFutureUsagePreview::class)
 class PaymentSheetManagerTest {
   @Before
   fun setup() {
     SoLoader.init(ApplicationProvider.getApplicationContext(), OpenSourceMergedSoMapping)
   }
 
+  // ============================================
+  // mapToCollectionMode Tests
+  // ============================================
+
   @Test
-  fun buildGooglePayConfig() {
-    val config =
-      PaymentSheetManager.buildGooglePayConfig(
-        readableMapOf(
-          "merchantCountryCode" to "US",
-          "currencyCode" to "USD",
-          "testEnv" to true,
-          "buttonType" to 4,
-        ),
-      )
-    Assert.assertEquals(
-      config,
-      PaymentSheet.GooglePayConfiguration(
-        environment = PaymentSheet.GooglePayConfiguration.Environment.Test,
-        countryCode = "US",
-        currencyCode = "USD",
-        buttonType = PaymentSheet.GooglePayConfiguration.ButtonType.Donate,
-      ),
+  fun mapToCollectionMode_ValidValues() {
+    assertEquals(
+      PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Automatic,
+      mapToCollectionMode("automatic"),
+    )
+    assertEquals(
+      PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Never,
+      mapToCollectionMode("never"),
+    )
+    assertEquals(
+      PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
+      mapToCollectionMode("always"),
     )
   }
 
   @Test
-  fun buildGooglePayConfig_returnsNull() {
-    val config = PaymentSheetManager.buildGooglePayConfig(null)
-    Assert.assertNull(config)
+  fun mapToCollectionMode_InvalidValue_DefaultsToAutomatic() {
+    assertEquals(
+      PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Automatic,
+      mapToCollectionMode("invalid"),
+    )
+    assertEquals(
+      PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Automatic,
+      mapToCollectionMode(""),
+    )
   }
 
   @Test
-  fun buildGooglePayConfig_returnsNullForEmptyBundle() {
-    val config = PaymentSheetManager.buildGooglePayConfig(Arguments.createMap())
-    Assert.assertNull(config)
+  fun mapToCollectionMode_NullValue_DefaultsToAutomatic() {
+    assertEquals(
+      PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Automatic,
+      mapToCollectionMode(null),
+    )
+  }
+
+  // ============================================
+  // mapToPaymentMethodLayout Tests
+  // ============================================
+
+  @Test
+  fun mapToPaymentMethodLayout_ValidValues() {
+    assertEquals(
+      PaymentSheet.PaymentMethodLayout.Horizontal,
+      mapToPaymentMethodLayout("Horizontal"),
+    )
+    assertEquals(
+      PaymentSheet.PaymentMethodLayout.Vertical,
+      mapToPaymentMethodLayout("Vertical"),
+    )
+    assertEquals(
+      PaymentSheet.PaymentMethodLayout.Automatic,
+      mapToPaymentMethodLayout("Automatic"),
+    )
+  }
+
+  @Test
+  fun mapToPaymentMethodLayout_InvalidValue_DefaultsToAutomatic() {
+    assertEquals(
+      PaymentSheet.PaymentMethodLayout.Automatic,
+      mapToPaymentMethodLayout("invalid"),
+    )
+    assertEquals(
+      PaymentSheet.PaymentMethodLayout.Automatic,
+      mapToPaymentMethodLayout(""),
+    )
+  }
+
+  @Test
+  fun mapToPaymentMethodLayout_NullValue_DefaultsToAutomatic() {
+    assertEquals(
+      PaymentSheet.PaymentMethodLayout.Automatic,
+      mapToPaymentMethodLayout(null),
+    )
+  }
+
+  // ============================================
+  // mapToAddressCollectionMode Tests
+  // ============================================
+
+  @Test
+  fun mapToAddressCollectionMode_ValidValues() {
+    assertEquals(
+      PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic,
+      mapToAddressCollectionMode("automatic"),
+    )
+    assertEquals(
+      PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Never,
+      mapToAddressCollectionMode("never"),
+    )
+    assertEquals(
+      PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full,
+      mapToAddressCollectionMode("full"),
+    )
+  }
+
+  @Test
+  fun mapToAddressCollectionMode_InvalidValue_DefaultsToAutomatic() {
+    assertEquals(
+      PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic,
+      mapToAddressCollectionMode("invalid"),
+    )
+    assertEquals(
+      PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic,
+      mapToAddressCollectionMode(""),
+    )
+  }
+
+  @Test
+  fun mapToAddressCollectionMode_NullValue_DefaultsToAutomatic() {
+    assertEquals(
+      PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic,
+      mapToAddressCollectionMode(null),
+    )
+  }
+
+  // ============================================
+  // mapToCardBrandCategory Tests
+  // ============================================
+
+  @Test
+  fun mapToCardBrandCategory_ValidValues() {
+    assertEquals(
+      PaymentSheet.CardBrandAcceptance.BrandCategory.Visa,
+      mapToCardBrandCategory("visa"),
+    )
+    assertEquals(
+      PaymentSheet.CardBrandAcceptance.BrandCategory.Mastercard,
+      mapToCardBrandCategory("mastercard"),
+    )
+    assertEquals(
+      PaymentSheet.CardBrandAcceptance.BrandCategory.Amex,
+      mapToCardBrandCategory("amex"),
+    )
+    assertEquals(
+      PaymentSheet.CardBrandAcceptance.BrandCategory.Discover,
+      mapToCardBrandCategory("discover"),
+    )
+  }
+
+  @Test
+  fun mapToCardBrandCategory_InvalidValue_ReturnsNull() {
+    assertEquals(null, mapToCardBrandCategory("invalid"))
+    assertEquals(null, mapToCardBrandCategory(""))
+    assertEquals(null, mapToCardBrandCategory("unknown"))
+  }
+
+  // ============================================
+  // mapToCardBrandAcceptance Tests
+  // ============================================
+
+  @Test
+  fun mapToCardBrandAcceptance_NullParams_ReturnsAll() {
+    val result = mapToCardBrandAcceptance(null)
+    assertNotNull(result)
+  }
+
+  @Test
+  fun mapToCardBrandAcceptance_NoCardBrandAcceptanceKey_ReturnsAll() {
+    val params =
+      readableMapOf(
+        "someOtherKey" to "value",
+      )
+    val result = mapToCardBrandAcceptance(params)
+    assertNotNull(result)
+  }
+
+  @Test
+  fun mapToCardBrandAcceptance_FilterAll() {
+    val params =
+      readableMapOf(
+        "cardBrandAcceptance" to
+          readableMapOf(
+            "filter" to "all",
+          ),
+      )
+    val result = mapToCardBrandAcceptance(params)
+    assertNotNull(result)
+  }
+
+  @Test
+  fun mapToCardBrandAcceptance_FilterAllowed_WithBrands() {
+    val params =
+      readableMapOf(
+        "cardBrandAcceptance" to
+          readableMapOf(
+            "filter" to "allowed",
+            "brands" to readableArrayOf("visa", "mastercard"),
+          ),
+      )
+    val result = mapToCardBrandAcceptance(params)
+    assertNotNull(result)
+  }
+
+  @Test
+  fun mapToCardBrandAcceptance_FilterAllowed_EmptyBrands_ReturnsAll() {
+    val params =
+      readableMapOf(
+        "cardBrandAcceptance" to
+          readableMapOf(
+            "filter" to "allowed",
+            "brands" to readableArrayOf(),
+          ),
+      )
+    val result = mapToCardBrandAcceptance(params)
+    assertNotNull(result)
+  }
+
+  @Test
+  fun mapToCardBrandAcceptance_FilterAllowed_NullBrands_ReturnsAll() {
+    val params =
+      readableMapOf(
+        "cardBrandAcceptance" to
+          readableMapOf(
+            "filter" to "allowed",
+          ),
+      )
+    val result = mapToCardBrandAcceptance(params)
+    assertNotNull(result)
+  }
+
+  @Test
+  fun mapToCardBrandAcceptance_FilterAllowed_InvalidBrands_ReturnsAll() {
+    val params =
+      readableMapOf(
+        "cardBrandAcceptance" to
+          readableMapOf(
+            "filter" to "allowed",
+            "brands" to readableArrayOf("invalid", "unknown"),
+          ),
+      )
+    val result = mapToCardBrandAcceptance(params)
+    assertNotNull(result)
+  }
+
+  @Test
+  fun mapToCardBrandAcceptance_FilterAllowed_MixedValidInvalidBrands() {
+    val params =
+      readableMapOf(
+        "cardBrandAcceptance" to
+          readableMapOf(
+            "filter" to "allowed",
+            "brands" to readableArrayOf("visa", "invalid", "amex"),
+          ),
+      )
+    val result = mapToCardBrandAcceptance(params)
+    assertNotNull(result)
+  }
+
+  @Test
+  fun mapToCardBrandAcceptance_FilterDisallowed_WithBrands() {
+    val params =
+      readableMapOf(
+        "cardBrandAcceptance" to
+          readableMapOf(
+            "filter" to "disallowed",
+            "brands" to readableArrayOf("amex", "discover"),
+          ),
+      )
+    val result = mapToCardBrandAcceptance(params)
+    assertNotNull(result)
+  }
+
+  @Test
+  fun mapToCardBrandAcceptance_FilterDisallowed_EmptyBrands_ReturnsAll() {
+    val params =
+      readableMapOf(
+        "cardBrandAcceptance" to
+          readableMapOf(
+            "filter" to "disallowed",
+            "brands" to readableArrayOf(),
+          ),
+      )
+    val result = mapToCardBrandAcceptance(params)
+    assertNotNull(result)
+  }
+
+  @Test
+  fun mapToCardBrandAcceptance_FilterDisallowed_NullBrands_ReturnsAll() {
+    val params =
+      readableMapOf(
+        "cardBrandAcceptance" to
+          readableMapOf(
+            "filter" to "disallowed",
+          ),
+      )
+    val result = mapToCardBrandAcceptance(params)
+    assertNotNull(result)
+  }
+
+  @Test
+  fun mapToCardBrandAcceptance_FilterDisallowed_InvalidBrands_ReturnsAll() {
+    val params =
+      readableMapOf(
+        "cardBrandAcceptance" to
+          readableMapOf(
+            "filter" to "disallowed",
+            "brands" to readableArrayOf("invalid", "unknown"),
+          ),
+      )
+    val result = mapToCardBrandAcceptance(params)
+    assertNotNull(result)
+  }
+
+  @Test
+  fun mapToCardBrandAcceptance_FilterDisallowed_MixedValidInvalidBrands() {
+    val params =
+      readableMapOf(
+        "cardBrandAcceptance" to
+          readableMapOf(
+            "filter" to "disallowed",
+            "brands" to readableArrayOf("mastercard", "invalid", "discover"),
+          ),
+      )
+    val result = mapToCardBrandAcceptance(params)
+    assertNotNull(result)
+  }
+
+  @Test
+  fun mapToCardBrandAcceptance_InvalidFilter_ReturnsAll() {
+    val params =
+      readableMapOf(
+        "cardBrandAcceptance" to
+          readableMapOf(
+            "filter" to "invalid",
+            "brands" to readableArrayOf("visa"),
+          ),
+      )
+    val result = mapToCardBrandAcceptance(params)
+    assertNotNull(result)
+  }
+
+  @Test
+  fun mapToCardBrandAcceptance_NullFilter_ReturnsAll() {
+    val params =
+      readableMapOf(
+        "cardBrandAcceptance" to
+          readableMapOf(
+            "brands" to readableArrayOf("visa"),
+          ),
+      )
+    val result = mapToCardBrandAcceptance(params)
+    assertNotNull(result)
+  }
+
+  // ============================================
+  // mapToSetupFutureUse Tests
+  // ============================================
+
+  @Test
+  fun mapToSetupFutureUse_ValidValues() {
+    assertEquals(
+      PaymentSheet.IntentConfiguration.SetupFutureUse.OffSession,
+      mapToSetupFutureUse("OffSession"),
+    )
+    assertEquals(
+      PaymentSheet.IntentConfiguration.SetupFutureUse.OnSession,
+      mapToSetupFutureUse("OnSession"),
+    )
+    assertEquals(
+      PaymentSheet.IntentConfiguration.SetupFutureUse.None,
+      mapToSetupFutureUse("None"),
+    )
+  }
+
+  @Test
+  fun mapToSetupFutureUse_InvalidValue_ReturnsNull() {
+    assertEquals(null, mapToSetupFutureUse("Unknown"))
+    assertEquals(null, mapToSetupFutureUse("OneTime"))
+    assertEquals(null, mapToSetupFutureUse("invalid"))
+    assertEquals(null, mapToSetupFutureUse(""))
+  }
+
+  @Test
+  fun mapToSetupFutureUse_NullValue_ReturnsNull() {
+    assertEquals(null, mapToSetupFutureUse(null))
+  }
+
+  // ============================================
+  // mapToCaptureMethod Tests
+  // ============================================
+
+  @Test
+  fun mapToCaptureMethod_ValidValues() {
+    assertEquals(
+      PaymentSheet.IntentConfiguration.CaptureMethod.Automatic,
+      mapToCaptureMethod("Automatic"),
+    )
+    assertEquals(
+      PaymentSheet.IntentConfiguration.CaptureMethod.Manual,
+      mapToCaptureMethod("Manual"),
+    )
+    assertEquals(
+      PaymentSheet.IntentConfiguration.CaptureMethod.AutomaticAsync,
+      mapToCaptureMethod("AutomaticAsync"),
+    )
+  }
+
+  @Test
+  fun mapToCaptureMethod_InvalidValue_DefaultsToAutomatic() {
+    assertEquals(
+      PaymentSheet.IntentConfiguration.CaptureMethod.Automatic,
+      mapToCaptureMethod("invalid"),
+    )
+    assertEquals(
+      PaymentSheet.IntentConfiguration.CaptureMethod.Automatic,
+      mapToCaptureMethod(""),
+    )
+  }
+
+  @Test
+  fun mapToCaptureMethod_NullValue_DefaultsToAutomatic() {
+    assertEquals(
+      PaymentSheet.IntentConfiguration.CaptureMethod.Automatic,
+      mapToCaptureMethod(null),
+    )
+  }
+
+  // ============================================
+  // mapToPaymentMethodOptions Tests
+  // ============================================
+
+  @Test
+  fun mapToPaymentMethodOptions_NullOptions_ReturnsNull() {
+    assertEquals(null, mapToPaymentMethodOptions(null))
+  }
+
+  @Test
+  fun mapToPaymentMethodOptions_ValidOptions() {
+    val options =
+      readableMapOf(
+        "setupFutureUsageValues" to
+          readableMapOf(
+            "card" to "OffSession",
+            "us_bank_account" to "OnSession",
+          ),
+      )
+
+    val result = mapToPaymentMethodOptions(options)
+
+    assertNotNull(result)
+  }
+
+  @Test
+  fun mapToPaymentMethodOptions_EmptyMap_ReturnsNull() {
+    val options =
+      readableMapOf(
+        "setupFutureUsageValues" to readableMapOf(),
+      )
+
+    val result = mapToPaymentMethodOptions(options)
+
+    assertEquals(null, result)
+  }
+
+  @Test
+  fun mapToPaymentMethodOptions_InvalidPaymentMethodCodes_ReturnsNull() {
+    val options =
+      readableMapOf(
+        "setupFutureUsageValues" to
+          readableMapOf(
+            "invalid_code" to "OffSession",
+            "another_invalid" to "OnSession",
+          ),
+      )
+
+    val result = mapToPaymentMethodOptions(options)
+
+    assertEquals(null, result)
+  }
+
+  @Test
+  fun mapToPaymentMethodOptions_MixedValidInvalidCodes() {
+    val options =
+      readableMapOf(
+        "setupFutureUsageValues" to
+          readableMapOf(
+            "card" to "OffSession",
+            "invalid_code" to "OnSession",
+            "us_bank_account" to "None",
+          ),
+      )
+
+    val result = mapToPaymentMethodOptions(options)
+
+    assertNotNull(result)
+  }
+
+  @Test
+  fun mapToPaymentMethodOptions_InvalidSetupFutureUsageValue_SkipsThatEntry() {
+    val options =
+      readableMapOf(
+        "setupFutureUsageValues" to
+          readableMapOf(
+            "card" to "InvalidValue",
+            "us_bank_account" to "OnSession",
+          ),
+      )
+
+    val result = mapToPaymentMethodOptions(options)
+
+    assertNotNull(result)
   }
 }

--- a/android/src/main/java/com/reactnativestripesdk/EmbeddedPaymentElementView.kt
+++ b/android/src/main/java/com/reactnativestripesdk/EmbeddedPaymentElementView.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.requiredHeight
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -22,7 +21,6 @@ import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.uimanager.ThemedReactContext
-import com.reactnativestripesdk.toWritableMap
 import com.reactnativestripesdk.utils.KeepJsAwakeTask
 import com.reactnativestripesdk.utils.mapFromConfirmationToken
 import com.reactnativestripesdk.utils.mapFromCustomPaymentMethod
@@ -196,7 +194,7 @@ class EmbeddedPaymentElementView(
                 val stripeSdkModule =
                   try {
                     requireStripeSdkModule()
-                  } catch (ex: IllegalArgumentException) {
+                  } catch (_: IllegalArgumentException) {
                     return@Builder CreateIntentResult.Failure(
                       cause =
                         Exception(
@@ -242,7 +240,7 @@ class EmbeddedPaymentElementView(
                 val stripeSdkModule =
                   try {
                     requireStripeSdkModule()
-                  } catch (ex: IllegalArgumentException) {
+                  } catch (_: IllegalArgumentException) {
                     return@Builder CreateIntentResult.Failure(
                       cause =
                         Exception(
@@ -295,9 +293,6 @@ class EmbeddedPaymentElementView(
       }
 
     val embedded = rememberEmbeddedPaymentElement(builder)
-    var height by remember {
-      mutableIntStateOf(0)
-    }
 
     // collect events: configure, confirm, clear
     LaunchedEffect(Unit) {
@@ -347,8 +342,6 @@ class EmbeddedPaymentElementView(
         requireStripeSdkModule().eventEmitter.emitEmbeddedPaymentElementDidUpdatePaymentOption(payload)
       }
     }
-
-    val density = LocalDensity.current
 
     Box {
       measuredEmbeddedElement(

--- a/android/src/main/java/com/reactnativestripesdk/PaymentElementConfig.kt
+++ b/android/src/main/java/com/reactnativestripesdk/PaymentElementConfig.kt
@@ -1,0 +1,226 @@
+package com.reactnativestripesdk
+
+import com.facebook.react.bridge.ReadableMap
+import com.reactnativestripesdk.utils.PaymentSheetException
+import com.reactnativestripesdk.utils.getBooleanOr
+import com.reactnativestripesdk.utils.getIntOr
+import com.reactnativestripesdk.utils.getStringList
+import com.reactnativestripesdk.utils.isEmpty
+import com.stripe.android.paymentelement.PaymentMethodOptionsSetupFutureUsagePreview
+import com.stripe.android.paymentsheet.PaymentSheet
+
+@Throws(PaymentSheetException::class)
+internal fun buildIntentConfiguration(intentConfigurationParams: ReadableMap?): PaymentSheet.IntentConfiguration? {
+  if (intentConfigurationParams == null) {
+    return null
+  }
+  val modeParams =
+    intentConfigurationParams.getMap("mode")
+      ?: throw PaymentSheetException(
+        "If `intentConfiguration` is provided, `intentConfiguration.mode` is required",
+      )
+
+  return PaymentSheet.IntentConfiguration(
+    mode = buildIntentConfigurationMode(modeParams),
+    paymentMethodTypes =
+      intentConfigurationParams.getStringList("paymentMethodTypes")?.toList()
+        ?: emptyList(),
+  )
+}
+
+@OptIn(PaymentMethodOptionsSetupFutureUsagePreview::class)
+private fun buildIntentConfigurationMode(modeParams: ReadableMap): PaymentSheet.IntentConfiguration.Mode =
+  if (modeParams.hasKey("amount")) {
+    val currencyCode =
+      modeParams.getString("currencyCode")
+        ?: throw PaymentSheetException(
+          "You must provide a value to intentConfiguration.mode.currencyCode",
+        )
+    PaymentSheet.IntentConfiguration.Mode.Payment(
+      amount = modeParams.getInt("amount").toLong(),
+      currency = currencyCode,
+      setupFutureUse = mapToSetupFutureUse(modeParams.getString("setupFutureUsage")),
+      captureMethod = mapToCaptureMethod(modeParams.getString("captureMethod")),
+      paymentMethodOptions = mapToPaymentMethodOptions(modeParams.getMap("paymentMethodOptions")),
+    )
+  } else {
+    val setupFutureUsage =
+      mapToSetupFutureUse(modeParams.getString("setupFutureUsage"))
+        ?: throw PaymentSheetException(
+          "You must provide a value to intentConfiguration.mode.setupFutureUsage",
+        )
+    PaymentSheet.IntentConfiguration.Mode.Setup(
+      currency = modeParams.getString("currencyCode"),
+      setupFutureUse = setupFutureUsage,
+    )
+  }
+
+internal fun buildLinkConfig(params: ReadableMap?): PaymentSheet.LinkConfiguration {
+  if (params == null) {
+    return PaymentSheet.LinkConfiguration()
+  }
+
+  val display = mapStringToLinkDisplay(params.getString("display"))
+
+  return PaymentSheet.LinkConfiguration(
+    display = display,
+  )
+}
+
+private fun mapStringToLinkDisplay(value: String?): PaymentSheet.LinkConfiguration.Display =
+  when (value) {
+    "automatic" -> PaymentSheet.LinkConfiguration.Display.Automatic
+    "never" -> PaymentSheet.LinkConfiguration.Display.Never
+    else -> PaymentSheet.LinkConfiguration.Display.Automatic
+  }
+
+private val mapIntToButtonType =
+  mapOf(
+    1 to PaymentSheet.GooglePayConfiguration.ButtonType.Buy,
+    6 to PaymentSheet.GooglePayConfiguration.ButtonType.Book,
+    5 to PaymentSheet.GooglePayConfiguration.ButtonType.Checkout,
+    4 to PaymentSheet.GooglePayConfiguration.ButtonType.Donate,
+    11 to PaymentSheet.GooglePayConfiguration.ButtonType.Order,
+    1000 to PaymentSheet.GooglePayConfiguration.ButtonType.Pay,
+    7 to PaymentSheet.GooglePayConfiguration.ButtonType.Subscribe,
+    1001 to PaymentSheet.GooglePayConfiguration.ButtonType.Plain,
+  )
+
+internal fun buildGooglePayConfig(params: ReadableMap?): PaymentSheet.GooglePayConfiguration? {
+  if (params == null || params.isEmpty()) {
+    return null
+  }
+
+  val countryCode = params.getString("merchantCountryCode").orEmpty()
+  val currencyCode = params.getString("currencyCode").orEmpty()
+  val testEnv = params.getBooleanOr("testEnv", false)
+  val amount = params.getString("amount")?.toLongOrNull()
+  val label = params.getString("label")
+  val buttonType =
+    mapIntToButtonType[params.getIntOr("buttonType", 0)]
+      ?: PaymentSheet.GooglePayConfiguration.ButtonType.Pay
+
+  return PaymentSheet.GooglePayConfiguration(
+    environment =
+      if (testEnv) {
+        PaymentSheet.GooglePayConfiguration.Environment.Test
+      } else {
+        PaymentSheet.GooglePayConfiguration.Environment.Production
+      },
+    countryCode = countryCode,
+    currencyCode = currencyCode,
+    amount = amount,
+    label = label,
+    buttonType = buttonType,
+  )
+}
+
+@Throws(PaymentSheetException::class)
+internal fun buildCustomerConfiguration(map: ReadableMap?): PaymentSheet.CustomerConfiguration? {
+  val customerId = map?.getString("customerId").orEmpty()
+  val customerEphemeralKeySecret = map?.getString("customerEphemeralKeySecret").orEmpty()
+  val customerSessionClientSecret = map?.getString("customerSessionClientSecret").orEmpty()
+  return if (customerSessionClientSecret.isNotEmpty() &&
+    customerEphemeralKeySecret.isNotEmpty()
+  ) {
+    throw PaymentSheetException(
+      "`customerEphemeralKeySecret` and `customerSessionClientSecret` cannot both be set",
+    )
+  } else if (customerId.isNotEmpty() && customerSessionClientSecret.isNotEmpty()) {
+    PaymentSheet.CustomerConfiguration.createWithCustomerSession(
+      id = customerId,
+      clientSecret = customerSessionClientSecret,
+    )
+  } else if (customerId.isNotEmpty() && customerEphemeralKeySecret.isNotEmpty()) {
+    PaymentSheet.CustomerConfiguration(
+      id = customerId,
+      ephemeralKeySecret = customerEphemeralKeySecret,
+    )
+  } else {
+    null
+  }
+}
+
+internal fun buildBillingDetails(map: ReadableMap?): PaymentSheet.BillingDetails? {
+  if (map == null) {
+    return null
+  }
+  val addressMap = map.getMap("address")
+  val address =
+    PaymentSheet.Address(
+      addressMap?.getString("city"),
+      addressMap?.getString("country"),
+      addressMap?.getString("line1"),
+      addressMap?.getString("line2"),
+      addressMap?.getString("postalCode"),
+      addressMap?.getString("state"),
+    )
+  return PaymentSheet.BillingDetails(
+    address,
+    map.getString("email"),
+    map.getString("name"),
+    map.getString("phone"),
+  )
+}
+
+internal fun buildBillingDetailsCollectionConfiguration(map: ReadableMap?): PaymentSheet.BillingDetailsCollectionConfiguration =
+  PaymentSheet.BillingDetailsCollectionConfiguration(
+    name = mapToCollectionMode(map?.getString("name")),
+    phone = mapToCollectionMode(map?.getString("phone")),
+    email = mapToCollectionMode(map?.getString("email")),
+    address = mapToAddressCollectionMode(map?.getString("address")),
+    attachDefaultsToPaymentMethod = map.getBooleanOr("attachDefaultsToPaymentMethod", false),
+  )
+
+internal fun mapToCollectionMode(str: String?): PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode =
+  when (str) {
+    "automatic" -> PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Automatic
+    "never" -> PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Never
+    "always" -> PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always
+    else -> PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Automatic
+  }
+
+internal fun mapToAddressCollectionMode(str: String?): PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode =
+  when (str) {
+    "automatic" ->
+      PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic
+
+    "never" -> PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Never
+    "full" -> PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full
+    else -> PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic
+  }
+
+internal fun mapToCardBrandAcceptance(params: ReadableMap?): PaymentSheet.CardBrandAcceptance {
+  val cardBrandAcceptanceParams = params?.getMap("cardBrandAcceptance") ?: return PaymentSheet.CardBrandAcceptance.all()
+  val filter = cardBrandAcceptanceParams.getString("filter") ?: return PaymentSheet.CardBrandAcceptance.all()
+
+  return when (filter) {
+    "all" -> PaymentSheet.CardBrandAcceptance.all()
+    "allowed" -> {
+      val brands = cardBrandAcceptanceParams.getStringList("brands") ?: return PaymentSheet.CardBrandAcceptance.all()
+      val brandCategories = brands.mapNotNull { mapToCardBrandCategory(it) }
+      if (brandCategories.isEmpty()) {
+        return PaymentSheet.CardBrandAcceptance.all()
+      }
+      PaymentSheet.CardBrandAcceptance.allowed(brandCategories)
+    }
+    "disallowed" -> {
+      val brands = cardBrandAcceptanceParams.getStringList("brands") ?: return PaymentSheet.CardBrandAcceptance.all()
+      val brandCategories = brands.mapNotNull { mapToCardBrandCategory(it) }
+      if (brandCategories.isEmpty()) {
+        return PaymentSheet.CardBrandAcceptance.all()
+      }
+      PaymentSheet.CardBrandAcceptance.disallowed(brandCategories)
+    }
+    else -> PaymentSheet.CardBrandAcceptance.all()
+  }
+}
+
+internal fun mapToCardBrandCategory(brand: String): PaymentSheet.CardBrandAcceptance.BrandCategory? =
+  when (brand) {
+    "visa" -> PaymentSheet.CardBrandAcceptance.BrandCategory.Visa
+    "mastercard" -> PaymentSheet.CardBrandAcceptance.BrandCategory.Mastercard
+    "amex" -> PaymentSheet.CardBrandAcceptance.BrandCategory.Amex
+    "discover" -> PaymentSheet.CardBrandAcceptance.BrandCategory.Discover
+    else -> null
+  }

--- a/android/src/main/java/com/reactnativestripesdk/PaymentSheetManager.kt
+++ b/android/src/main/java/com/reactnativestripesdk/PaymentSheetManager.kt
@@ -3,7 +3,6 @@ package com.reactnativestripesdk
 import android.annotation.SuppressLint
 import android.app.Activity
 import android.app.Application
-import android.content.Context
 import android.content.Intent
 import android.graphics.Bitmap
 import android.graphics.Canvas
@@ -14,7 +13,7 @@ import android.os.Handler
 import android.os.Looper
 import android.util.Base64
 import android.util.Log
-import androidx.appcompat.content.res.AppCompatResources
+import androidx.core.graphics.createBitmap
 import androidx.core.graphics.drawable.DrawableCompat
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.Promise
@@ -33,8 +32,8 @@ import com.reactnativestripesdk.utils.createError
 import com.reactnativestripesdk.utils.createResult
 import com.reactnativestripesdk.utils.forEachKey
 import com.reactnativestripesdk.utils.getBooleanOr
-import com.reactnativestripesdk.utils.getIntOr
-import com.reactnativestripesdk.utils.isEmpty
+import com.reactnativestripesdk.utils.getIntegerList
+import com.reactnativestripesdk.utils.getStringList
 import com.reactnativestripesdk.utils.mapFromConfirmationToken
 import com.reactnativestripesdk.utils.mapFromCustomPaymentMethod
 import com.reactnativestripesdk.utils.mapFromPaymentMethod
@@ -103,7 +102,7 @@ class PaymentSheetManager(
     val allowsDelayedPaymentMethods = arguments.getBooleanOr("allowsDelayedPaymentMethods", false)
     val billingDetailsMap = arguments.getMap("defaultBillingDetails")
     val billingConfigParams = arguments.getMap("billingDetailsCollectionConfiguration")
-    val paymentMethodOrder = arguments.getStringArrayList("paymentMethodOrder")
+    val paymentMethodOrder = arguments.getStringList("paymentMethodOrder")
     val allowsRemovalOfLastSavedPaymentMethod =
       arguments.getBooleanOr("allowsRemovalOfLastSavedPaymentMethod", true)
     paymentIntentClientSecret = arguments.getString("paymentIntentClientSecret").orEmpty()
@@ -144,7 +143,7 @@ class PaymentSheetManager(
       PaymentOptionResultCallback { paymentOptionResult ->
         val result =
           paymentOptionResult.paymentOption?.let {
-            val bitmap = getBitmapFromVectorDrawable(context, it.drawableResourceId)
+            val bitmap = getBitmapFromDrawable(it.icon())
             val imageString = getBase64FromBitmap(bitmap)
             val option: WritableMap = WritableNativeMap()
             option.putString("label", it.label)
@@ -252,36 +251,9 @@ class PaymentSheetManager(
           }
       }
 
-    val billingDetailsConfig =
-      PaymentSheet.BillingDetailsCollectionConfiguration(
-        name = mapToCollectionMode(billingConfigParams?.getString("name")),
-        phone = mapToCollectionMode(billingConfigParams?.getString("phone")),
-        email = mapToCollectionMode(billingConfigParams?.getString("email")),
-        address = mapToAddressCollectionMode(billingConfigParams?.getString("address")),
-        attachDefaultsToPaymentMethod =
-          billingConfigParams?.getBooleanOr("attachDefaultsToPaymentMethod", false) ?: false,
-      )
+    val billingDetailsConfig = buildBillingDetailsCollectionConfiguration(billingConfigParams)
 
-    var defaultBillingDetails: PaymentSheet.BillingDetails? = null
-    if (billingDetailsMap != null) {
-      val addressMap = billingDetailsMap.getMap("address")
-      val address =
-        PaymentSheet.Address(
-          addressMap?.getString("city"),
-          addressMap?.getString("country"),
-          addressMap?.getString("line1"),
-          addressMap?.getString("line2"),
-          addressMap?.getString("postalCode"),
-          addressMap?.getString("state"),
-        )
-      defaultBillingDetails =
-        PaymentSheet.BillingDetails(
-          address,
-          billingDetailsMap.getString("email"),
-          billingDetailsMap.getString("name"),
-          billingDetailsMap.getString("phone"),
-        )
-    }
+    val defaultBillingDetails = buildBillingDetails(billingDetailsMap)
     val configurationBuilder =
       PaymentSheet.Configuration
         .Builder(merchantDisplayName)
@@ -294,7 +266,7 @@ class PaymentSheetManager(
         .link(linkConfig)
         .billingDetailsCollectionConfiguration(billingDetailsConfig)
         .preferredNetworks(
-          mapToPreferredNetworks(arguments.getIntegerArrayList("preferredNetworks")),
+          mapToPreferredNetworks(arguments.getIntegerList("preferredNetworks")),
         ).allowsRemovalOfLastSavedPaymentMethod(allowsRemovalOfLastSavedPaymentMethod)
         .cardBrandAcceptance(mapToCardBrandAcceptance(arguments))
         .customPaymentMethods(parseCustomPaymentMethods(arguments.getMap("customPaymentMethodConfiguration")))
@@ -444,7 +416,7 @@ class PaymentSheetManager(
       PaymentSheet.FlowController.ConfigCallback { _, _ ->
         val result =
           flowController?.getPaymentOption()?.let {
-            val bitmap = getBitmapFromVectorDrawable(context, it.drawableResourceId)
+            val bitmap = getBitmapFromDrawable(it.icon())
             val imageString = getBase64FromBitmap(bitmap)
             val option: WritableMap = WritableNativeMap()
             option.putString("label", it.label)
@@ -571,152 +543,12 @@ class PaymentSheetManager(
   }
 
   companion object {
-    private val mapIntToButtonType =
-      mapOf(
-        1 to PaymentSheet.GooglePayConfiguration.ButtonType.Buy,
-        6 to PaymentSheet.GooglePayConfiguration.ButtonType.Book,
-        5 to PaymentSheet.GooglePayConfiguration.ButtonType.Checkout,
-        4 to PaymentSheet.GooglePayConfiguration.ButtonType.Donate,
-        11 to PaymentSheet.GooglePayConfiguration.ButtonType.Order,
-        1000 to PaymentSheet.GooglePayConfiguration.ButtonType.Pay,
-        7 to PaymentSheet.GooglePayConfiguration.ButtonType.Subscribe,
-        1001 to PaymentSheet.GooglePayConfiguration.ButtonType.Plain,
-      )
-
     internal fun createMissingInitError(): WritableMap =
       createError(
         PaymentSheetErrorType.Failed.toString(),
         "No payment sheet has been initialized yet. You must call `initPaymentSheet` before `presentPaymentSheet`.",
       )
-
-    internal fun buildGooglePayConfig(params: ReadableMap?): PaymentSheet.GooglePayConfiguration? {
-      if (params == null || params.isEmpty()) {
-        return null
-      }
-
-      val countryCode = params.getString("merchantCountryCode").orEmpty()
-      val currencyCode = params.getString("currencyCode").orEmpty()
-      val testEnv = params.getBoolean("testEnv")
-      val amount = params.getString("amount")?.toLongOrNull()
-      val label = params.getString("label")
-      val buttonType =
-        mapIntToButtonType.get(params.getIntOr("buttonType", 0))
-          ?: PaymentSheet.GooglePayConfiguration.ButtonType.Pay
-
-      return PaymentSheet.GooglePayConfiguration(
-        environment =
-          if (testEnv) {
-            PaymentSheet.GooglePayConfiguration.Environment.Test
-          } else {
-            PaymentSheet.GooglePayConfiguration.Environment.Production
-          },
-        countryCode = countryCode,
-        currencyCode = currencyCode,
-        amount = amount,
-        label = label,
-        buttonType = buttonType,
-      )
-    }
-
-    internal fun buildLinkConfig(params: ReadableMap?): PaymentSheet.LinkConfiguration {
-      if (params == null) {
-        return PaymentSheet.LinkConfiguration()
-      }
-
-      val display = mapStringToLinkDisplay(params.getString("display"))
-
-      return PaymentSheet.LinkConfiguration(
-        display = display,
-      )
-    }
-
-    private fun mapStringToLinkDisplay(value: String?): PaymentSheet.LinkConfiguration.Display =
-      when (value) {
-        "automatic" -> PaymentSheet.LinkConfiguration.Display.Automatic
-        "never" -> PaymentSheet.LinkConfiguration.Display.Never
-        else -> PaymentSheet.LinkConfiguration.Display.Automatic
-      }
-
-    @Throws(PaymentSheetException::class)
-    internal fun buildIntentConfiguration(intentConfigurationParams: ReadableMap?): PaymentSheet.IntentConfiguration? {
-      if (intentConfigurationParams == null) {
-        return null
-      }
-      val modeParams =
-        intentConfigurationParams.getMap("mode")
-          ?: throw PaymentSheetException(
-            "If `intentConfiguration` is provided, `intentConfiguration.mode` is required",
-          )
-
-      return PaymentSheet.IntentConfiguration(
-        mode = buildIntentConfigurationMode(modeParams),
-        paymentMethodTypes =
-          intentConfigurationParams.getStringArrayList("paymentMethodTypes")?.toList()
-            ?: emptyList(),
-      )
-    }
-
-    @OptIn(PaymentMethodOptionsSetupFutureUsagePreview::class)
-    private fun buildIntentConfigurationMode(modeParams: ReadableMap): PaymentSheet.IntentConfiguration.Mode =
-      if (modeParams.hasKey("amount")) {
-        val currencyCode =
-          modeParams.getString("currencyCode")
-            ?: throw PaymentSheetException(
-              "You must provide a value to intentConfiguration.mode.currencyCode",
-            )
-        PaymentSheet.IntentConfiguration.Mode.Payment(
-          amount = modeParams.getInt("amount").toLong(),
-          currency = currencyCode,
-          setupFutureUse = mapToSetupFutureUse(modeParams.getString("setupFutureUsage")),
-          captureMethod = mapToCaptureMethod(modeParams.getString("captureMethod")),
-          paymentMethodOptions = mapToPaymentMethodOptions(modeParams.getMap("paymentMethodOptions")),
-        )
-      } else {
-        val setupFutureUsage =
-          mapToSetupFutureUse(modeParams.getString("setupFutureUsage"))
-            ?: throw PaymentSheetException(
-              "You must provide a value to intentConfiguration.mode.setupFutureUsage",
-            )
-        PaymentSheet.IntentConfiguration.Mode.Setup(
-          currency = modeParams.getString("currencyCode"),
-          setupFutureUse = setupFutureUsage,
-        )
-      }
-
-    @Throws(PaymentSheetException::class)
-    internal fun buildCustomerConfiguration(map: ReadableMap?): PaymentSheet.CustomerConfiguration? {
-      val customerId = map?.getString("customerId").orEmpty()
-      val customerEphemeralKeySecret = map?.getString("customerEphemeralKeySecret").orEmpty()
-      val customerSessionClientSecret = map?.getString("customerSessionClientSecret").orEmpty()
-      return if (customerSessionClientSecret.isNotEmpty() &&
-        customerEphemeralKeySecret.isNotEmpty()
-      ) {
-        throw PaymentSheetException(
-          "`customerEphemeralKeySecret` and `customerSessionClientSecret` cannot both be set",
-        )
-      } else if (customerId.isNotEmpty() && customerSessionClientSecret.isNotEmpty()) {
-        PaymentSheet.CustomerConfiguration.createWithCustomerSession(
-          id = customerId,
-          clientSecret = customerSessionClientSecret,
-        )
-      } else if (customerId.isNotEmpty() && customerEphemeralKeySecret.isNotEmpty()) {
-        PaymentSheet.CustomerConfiguration(
-          id = customerId,
-          ephemeralKeySecret = customerEphemeralKeySecret,
-        )
-      } else {
-        null
-      }
-    }
   }
-}
-
-fun getBitmapFromVectorDrawable(
-  context: Context?,
-  drawableId: Int,
-): Bitmap? {
-  val drawable = AppCompatResources.getDrawable(context!!, drawableId) ?: return null
-  return getBitmapFromDrawable(drawable)
 }
 
 fun getBitmapFromDrawable(drawable: Drawable): Bitmap? {
@@ -725,11 +557,7 @@ fun getBitmapFromDrawable(drawable: Drawable): Bitmap? {
     return null
   }
   val bitmap =
-    Bitmap.createBitmap(
-      drawableCompat.intrinsicWidth,
-      drawableCompat.intrinsicHeight,
-      Bitmap.Config.ARGB_8888,
-    )
+    createBitmap(drawableCompat.intrinsicWidth, drawableCompat.intrinsicHeight)
   bitmap.eraseColor(Color.TRANSPARENT)
   val canvas = Canvas(bitmap)
   drawable.setBounds(0, 0, canvas.width, canvas.height)
@@ -747,14 +575,6 @@ fun getBase64FromBitmap(bitmap: Bitmap?): String? {
   return Base64.encodeToString(imageBytes, Base64.DEFAULT)
 }
 
-fun mapToCollectionMode(str: String?): PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode =
-  when (str) {
-    "automatic" -> PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Automatic
-    "never" -> PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Never
-    "always" -> PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always
-    else -> PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Automatic
-  }
-
 fun mapToPaymentMethodLayout(str: String?): PaymentSheet.PaymentMethodLayout =
   when (str) {
     "Horizontal" -> PaymentSheet.PaymentMethodLayout.Horizontal
@@ -762,17 +582,7 @@ fun mapToPaymentMethodLayout(str: String?): PaymentSheet.PaymentMethodLayout =
     else -> PaymentSheet.PaymentMethodLayout.Automatic
   }
 
-fun mapToAddressCollectionMode(str: String?): PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode =
-  when (str) {
-    "automatic" ->
-      PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic
-
-    "never" -> PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Never
-    "full" -> PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full
-    else -> PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic
-  }
-
-fun mapToSetupFutureUse(type: String?): PaymentSheet.IntentConfiguration.SetupFutureUse? =
+internal fun mapToSetupFutureUse(type: String?): PaymentSheet.IntentConfiguration.SetupFutureUse? =
   when (type) {
     "OffSession" -> PaymentSheet.IntentConfiguration.SetupFutureUse.OffSession
     "OnSession" -> PaymentSheet.IntentConfiguration.SetupFutureUse.OnSession
@@ -780,7 +590,7 @@ fun mapToSetupFutureUse(type: String?): PaymentSheet.IntentConfiguration.SetupFu
     else -> null
   }
 
-fun mapToCaptureMethod(type: String?): PaymentSheet.IntentConfiguration.CaptureMethod =
+internal fun mapToCaptureMethod(type: String?): PaymentSheet.IntentConfiguration.CaptureMethod =
   when (type) {
     "Automatic" -> PaymentSheet.IntentConfiguration.CaptureMethod.Automatic
     "Manual" -> PaymentSheet.IntentConfiguration.CaptureMethod.Manual
@@ -789,7 +599,7 @@ fun mapToCaptureMethod(type: String?): PaymentSheet.IntentConfiguration.CaptureM
   }
 
 @OptIn(PaymentMethodOptionsSetupFutureUsagePreview::class)
-fun mapToPaymentMethodOptions(options: ReadableMap?): PaymentSheet.IntentConfiguration.Mode.Payment.PaymentMethodOptions? {
+internal fun mapToPaymentMethodOptions(options: ReadableMap?): PaymentSheet.IntentConfiguration.Mode.Payment.PaymentMethodOptions? {
   val sfuMap = options?.getMap("setupFutureUsageValues")
   val paymentMethodToSfuMap = mutableMapOf<PaymentMethod.Type, PaymentSheet.IntentConfiguration.SetupFutureUse>()
   sfuMap?.forEachKey { code ->
@@ -807,38 +617,3 @@ fun mapToPaymentMethodOptions(options: ReadableMap?): PaymentSheet.IntentConfigu
     null
   }
 }
-
-fun mapToCardBrandAcceptance(params: ReadableMap?): PaymentSheet.CardBrandAcceptance {
-  val cardBrandAcceptanceParams = params?.getMap("cardBrandAcceptance") ?: return PaymentSheet.CardBrandAcceptance.all()
-  val filter = cardBrandAcceptanceParams.getString("filter") ?: return PaymentSheet.CardBrandAcceptance.all()
-
-  return when (filter) {
-    "all" -> PaymentSheet.CardBrandAcceptance.all()
-    "allowed" -> {
-      val brands = cardBrandAcceptanceParams.getStringArrayList("brands") ?: return PaymentSheet.CardBrandAcceptance.all()
-      val brandCategories = brands.mapNotNull { mapToCardBrandCategory(it) }
-      if (brandCategories.isEmpty()) {
-        return PaymentSheet.CardBrandAcceptance.all()
-      }
-      PaymentSheet.CardBrandAcceptance.allowed(brandCategories)
-    }
-    "disallowed" -> {
-      val brands = cardBrandAcceptanceParams.getStringArrayList("brands") ?: return PaymentSheet.CardBrandAcceptance.all()
-      val brandCategories = brands.mapNotNull { mapToCardBrandCategory(it) }
-      if (brandCategories.isEmpty()) {
-        return PaymentSheet.CardBrandAcceptance.all()
-      }
-      PaymentSheet.CardBrandAcceptance.disallowed(brandCategories)
-    }
-    else -> PaymentSheet.CardBrandAcceptance.all()
-  }
-}
-
-fun mapToCardBrandCategory(brand: String): PaymentSheet.CardBrandAcceptance.BrandCategory? =
-  when (brand) {
-    "visa" -> PaymentSheet.CardBrandAcceptance.BrandCategory.Visa
-    "mastercard" -> PaymentSheet.CardBrandAcceptance.BrandCategory.Mastercard
-    "amex" -> PaymentSheet.CardBrandAcceptance.BrandCategory.Amex
-    "discover" -> PaymentSheet.CardBrandAcceptance.BrandCategory.Discover
-    else -> null
-  }

--- a/android/src/main/java/com/reactnativestripesdk/customersheet/CustomerSheetManager.kt
+++ b/android/src/main/java/com/reactnativestripesdk/customersheet/CustomerSheetManager.kt
@@ -15,14 +15,12 @@ import com.facebook.react.bridge.WritableMap
 import com.facebook.react.bridge.WritableNativeMap
 import com.reactnativestripesdk.ReactNativeCustomerAdapter
 import com.reactnativestripesdk.ReactNativeCustomerSessionProvider
+import com.reactnativestripesdk.buildBillingDetails
+import com.reactnativestripesdk.buildBillingDetailsCollectionConfiguration
 import com.reactnativestripesdk.buildPaymentSheetAppearance
 import com.reactnativestripesdk.getBase64FromBitmap
 import com.reactnativestripesdk.getBitmapFromDrawable
-import com.reactnativestripesdk.getIntegerArrayList
-import com.reactnativestripesdk.getStringArrayList
-import com.reactnativestripesdk.mapToAddressCollectionMode
 import com.reactnativestripesdk.mapToCardBrandAcceptance
-import com.reactnativestripesdk.mapToCollectionMode
 import com.reactnativestripesdk.utils.CreateTokenErrorType
 import com.reactnativestripesdk.utils.ErrorType
 import com.reactnativestripesdk.utils.KeepJsAwakeTask
@@ -30,6 +28,8 @@ import com.reactnativestripesdk.utils.PaymentSheetAppearanceException
 import com.reactnativestripesdk.utils.StripeUIManager
 import com.reactnativestripesdk.utils.createError
 import com.reactnativestripesdk.utils.getBooleanOr
+import com.reactnativestripesdk.utils.getIntegerList
+import com.reactnativestripesdk.utils.getStringList
 import com.reactnativestripesdk.utils.mapFromPaymentMethod
 import com.reactnativestripesdk.utils.mapToPreferredNetworks
 import com.stripe.android.ExperimentalAllowsRemovalOfLastSavedPaymentMethodApi
@@ -66,7 +66,7 @@ class CustomerSheetManager(
     val billingConfigParams = arguments.getMap("billingDetailsCollectionConfiguration")
     val allowsRemovalOfLastSavedPaymentMethod =
       arguments.getBooleanOr("allowsRemovalOfLastSavedPaymentMethod", true)
-    val paymentMethodOrder = arguments.getStringArrayList("paymentMethodOrder")
+    val paymentMethodOrder = arguments.getStringList("paymentMethodOrder")
 
     val appearance =
       try {
@@ -83,7 +83,7 @@ class CustomerSheetManager(
         .googlePayEnabled(googlePayEnabled)
         .headerTextForSelectionScreen(headerTextForSelectionScreen)
         .preferredNetworks(
-          mapToPreferredNetworks(arguments.getIntegerArrayList("preferredNetworks")),
+          mapToPreferredNetworks(arguments.getIntegerList("preferredNetworks")),
         ).allowsRemovalOfLastSavedPaymentMethod(allowsRemovalOfLastSavedPaymentMethod)
         .cardBrandAcceptance(mapToCardBrandAcceptance(arguments))
 
@@ -295,33 +295,11 @@ class CustomerSheetManager(
     internal fun createMissingInitError(): WritableMap =
       createError(ErrorType.Failed.toString(), "No customer sheet has been initialized yet.")
 
-    internal fun createDefaultBillingDetails(map: ReadableMap): PaymentSheet.BillingDetails {
-      val addressMap = map.getMap("address")
-      val address =
-        PaymentSheet.Address(
-          addressMap?.getString("city"),
-          addressMap?.getString("country"),
-          addressMap?.getString("line1"),
-          addressMap?.getString("line2"),
-          addressMap?.getString("postalCode"),
-          addressMap?.getString("state"),
-        )
-      return PaymentSheet.BillingDetails(
-        address,
-        map.getString("email"),
-        map.getString("name"),
-        map.getString("phone"),
-      )
-    }
+    internal fun createDefaultBillingDetails(map: ReadableMap): PaymentSheet.BillingDetails =
+      buildBillingDetails(map) ?: PaymentSheet.BillingDetails()
 
     internal fun createBillingDetailsCollectionConfiguration(map: ReadableMap): PaymentSheet.BillingDetailsCollectionConfiguration =
-      PaymentSheet.BillingDetailsCollectionConfiguration(
-        name = mapToCollectionMode(map.getString("name")),
-        phone = mapToCollectionMode(map.getString("phone")),
-        email = mapToCollectionMode(map.getString("email")),
-        address = mapToAddressCollectionMode(map.getString("address")),
-        attachDefaultsToPaymentMethod = map.getBooleanOr("attachDefaultsToPaymentMethod", false),
-      )
+      buildBillingDetailsCollectionConfiguration(map)
 
     internal fun createCustomerAdapter(
       context: ReactApplicationContext,
@@ -404,7 +382,7 @@ class CustomerSheetManager(
         val onBehalfOf = bundle.getString("onBehalfOf")
         CustomerSheet.IntentConfiguration
           .Builder()
-          .paymentMethodTypes(bundle.getStringArrayList("paymentMethodTypes") ?: emptyList())
+          .paymentMethodTypes(bundle.getStringList("paymentMethodTypes") ?: emptyList())
           .apply {
             if (onBehalfOf != null) {
               this.onBehalfOf(onBehalfOf)

--- a/android/src/main/java/com/reactnativestripesdk/utils/Extensions.kt
+++ b/android/src/main/java/com/reactnativestripesdk/utils/Extensions.kt
@@ -74,4 +74,37 @@ fun ReadableArray.forEachMap(callback: (map: ReadableMap) -> Unit) {
   }
 }
 
+/**
+ * Returns a List of Strings if the key exists and points to an array of strings, or null otherwise.
+ */
+fun ReadableMap.getStringList(key: String): List<String>? {
+  if (!hasKey(key) || getType(key) != ReadableType.Array) return null
+  val array: ReadableArray = getArray(key) ?: return null
+
+  val result = mutableListOf<String>()
+  for (i in 0 until array.size()) {
+    // getString returns null if the element isn't actually a string
+    array.getString(i)?.let { result.add(it) }
+  }
+  return result
+}
+
+/**
+ * Returns a List of Ints if the key exists and points to an array of numbers, or null otherwise.
+ */
+fun ReadableMap.getIntegerList(key: String): List<Int>? {
+  if (!hasKey(key) || getType(key) != ReadableType.Array) return null
+  val array: ReadableArray = getArray(key) ?: return null
+
+  val result = mutableListOf<Int>()
+  for (i in 0 until array.size()) {
+    // getType check to skip non-number entries
+    if (array.getType(i) == ReadableType.Number) {
+      // if it's actually a float/double, this will truncate; adjust as needed
+      result.add(array.getInt(i))
+    }
+  }
+  return result
+}
+
 fun Dynamic.asMapOrNull(): ReadableMap? = if (this.type == ReadableType.Map) this.asMap() else null

--- a/android/src/main/java/com/reactnativestripesdk/utils/Mappers.kt
+++ b/android/src/main/java/com/reactnativestripesdk/utils/Mappers.kt
@@ -1146,3 +1146,24 @@ fun readableMapOf(vararg pairs: Pair<String, Any?>): ReadableMap =
       }
     }
   }
+
+fun readableArrayOf(vararg elements: Any?): ReadableArray =
+  Arguments.createArray().apply {
+    for (element in elements) {
+      when (element) {
+        null -> pushNull()
+        is String -> pushString(element)
+        is Boolean -> pushBoolean(element)
+        is Double -> pushDouble(element)
+        is Float -> pushDouble(element.toDouble())
+        is Int -> pushInt(element)
+        is Long -> pushInt(element.toInt())
+        is ReadableMap -> pushMap(element)
+        is ReadableArray -> pushArray(element)
+        else -> {
+          val valueType = element.javaClass.canonicalName
+          throw IllegalArgumentException("Illegal value type $valueType for array element")
+        }
+      }
+    }
+  }


### PR DESCRIPTION
## Summary

- Move functions that are used by both `EmbeddedPaymentElementViewManager` and `PaymentSheetManager` into a new file `PaymentElementConfig`. Also extract piece of codes that are duplicated into shared functions.
- Add unit tests.
- Fix potential bug in `buildGooglePayConfig` when `testEnv` is not passed.

#### Methodology to create tests

- Focus on testing mapping functions.
- Ask AI agent (in this case Claude Code) to use the typescript specs to help generate test cases. This actually found 1 bug where we didn't handle a missing key properly.
- Carefully review tests, since sometimes the generated tests are a bit useless or repetitive. Sadly a lot of fields are internal so there aren't much validation to be done on the stripe android sdk types.

## Motivation

- Refactor common code between payment sheet and embedded into a separate file.
- Add unit test coverage to mapper functions.

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [ ] I tested this manually
- [x] I added automated tests
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
