### PR TITLE
Use regular java test instead of connected tests

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -95,7 +95,6 @@ android {
     versionCode 1
     versionName "1.0"
     vectorDrawables.useSupportLibrary = true
-    testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     consumerProguardFiles 'proguard-rules.txt'
     buildConfigField "boolean", "IS_NEW_ARCHITECTURE_ENABLED", isNewArchitectureEnabled().toString()
 
@@ -129,6 +128,16 @@ android {
       if (!isNewArchitectureEnabled()) {
         srcDirs += ["src/oldarch/java"]
       }
+    }
+  }
+
+  // When running tests on bitrise we need to make sure that the test artifacts are inside
+  // the root project directory (in that case example/android), or it won't be picked up.
+  testOptions {
+    unitTests.all { Test test ->
+      def outputRoot = rootProject.layout.buildDirectory.get().asFile
+      test.reports.junitXml.outputLocation.set(new File(outputRoot, "test-results/${test.name}"))
+      test.reports.html.outputLocation.set(new File(outputRoot, "reports/tests/${test.name}"))
     }
   }
 }
@@ -229,10 +238,10 @@ dependencies {
   // Users need to declare this dependency on their own, otherwise all methods are a no-op
   compileOnly 'com.stripe:stripe-android-issuing-push-provisioning:1.1.0'
 
-  androidTestImplementation "junit:junit:4.13"
-  androidTestImplementation "androidx.test:core:1.4.0"
-  androidTestImplementation 'androidx.test:runner:1.1.0'
-  androidTestImplementation "org.mockito:mockito-core:3.+"
+  testImplementation "junit:junit:4.13"
+  testImplementation "org.mockito:mockito-core:3.+"
+  testImplementation "org.robolectric:robolectric:4.10"
+  testImplementation "androidx.test:core:1.4.0"
 
   implementation "androidx.compose.ui:ui:1.7.8"
   implementation "androidx.compose.foundation:foundation-layout:1.7.8"

--- a/android/src/main/java/com/reactnativestripesdk/FinancialConnectionsSheetManager.kt
+++ b/android/src/main/java/com/reactnativestripesdk/FinancialConnectionsSheetManager.kt
@@ -6,7 +6,6 @@ import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.WritableArray
 import com.facebook.react.bridge.WritableMap
-import com.facebook.react.bridge.WritableNativeMap
 import com.reactnativestripesdk.utils.ErrorType
 import com.reactnativestripesdk.utils.StripeUIManager
 import com.reactnativestripesdk.utils.createError
@@ -105,7 +104,7 @@ class FinancialConnectionsSheetManager(
 
       is FinancialConnectionsSheetResult.Completed -> {
         promise?.resolve(
-          WritableNativeMap().also {
+          Arguments.createMap().also {
             it.putMap("session", mapFromSession(result.financialConnectionsSession))
           },
         )
@@ -115,13 +114,13 @@ class FinancialConnectionsSheetManager(
 
   companion object {
     private fun createTokenResult(result: FinancialConnectionsSheetForTokenResult.Completed): WritableMap =
-      WritableNativeMap().also {
+      Arguments.createMap().also {
         it.putMap("session", mapFromSession(result.financialConnectionsSession))
         it.putMap("token", mapFromToken(result.token))
       }
 
     private fun mapFromSession(financialConnectionsSession: FinancialConnectionsSession): WritableMap {
-      val session = WritableNativeMap()
+      val session = Arguments.createMap()
       session.putString("id", financialConnectionsSession.id)
       session.putString("clientSecret", financialConnectionsSession.clientSecret)
       session.putBoolean("livemode", financialConnectionsSession.livemode)
@@ -132,7 +131,7 @@ class FinancialConnectionsSheetManager(
     private fun mapFromAccountsList(accounts: FinancialConnectionsAccountList): ReadableArray {
       val results: WritableArray = Arguments.createArray()
       for (account in accounts.data) {
-        val map = WritableNativeMap()
+        val map = Arguments.createMap()
         map.putString("id", account.id)
         map.putBoolean("livemode", account.livemode)
         map.putString("displayName", account.displayName)
@@ -166,10 +165,10 @@ class FinancialConnectionsSheetManager(
       if (balance == null) {
         return null
       }
-      val map = WritableNativeMap()
+      val map = Arguments.createMap()
       map.putDouble("asOf", balance.asOf * 1000.0)
       map.putString("type", mapFromBalanceType(balance.type))
-      WritableNativeMap().also {
+      Arguments.createMap().also {
         for (entry in balance.current.entries) {
           it.putInt(entry.key, entry.value)
         }
@@ -181,9 +180,9 @@ class FinancialConnectionsSheetManager(
       return map
     }
 
-    private fun mapFromCashAvailable(balance: Balance): WritableNativeMap =
-      WritableNativeMap().also { cashMap ->
-        WritableNativeMap().also { availableMap ->
+    private fun mapFromCashAvailable(balance: Balance): WritableMap =
+      Arguments.createMap().also { cashMap ->
+        Arguments.createMap().also { availableMap ->
           balance.cash?.available?.entries?.let { entries ->
             for (entry in entries) {
               availableMap.putInt(entry.key, entry.value)
@@ -193,9 +192,9 @@ class FinancialConnectionsSheetManager(
         }
       }
 
-    private fun mapFromCreditUsed(balance: Balance): WritableNativeMap =
-      WritableNativeMap().also { creditMap ->
-        WritableNativeMap().also { usedMap ->
+    private fun mapFromCreditUsed(balance: Balance): WritableMap =
+      Arguments.createMap().also { creditMap ->
+        Arguments.createMap().also { usedMap ->
           balance.credit?.used?.entries?.let { entries ->
             for (entry in entries) {
               usedMap.putInt(entry.key, entry.value)
@@ -209,7 +208,7 @@ class FinancialConnectionsSheetManager(
       if (balanceRefresh == null) {
         return null
       }
-      val map = WritableNativeMap()
+      val map = Arguments.createMap()
       map.putString("status", mapFromBalanceRefreshStatus(balanceRefresh.status))
       map.putDouble("lastAttemptedAt", balanceRefresh.lastAttemptedAt * 1000.0)
       return map

--- a/android/src/main/java/com/reactnativestripesdk/GooglePayRequestHelper.kt
+++ b/android/src/main/java/com/reactnativestripesdk/GooglePayRequestHelper.kt
@@ -3,9 +3,9 @@ package com.reactnativestripesdk
 import android.app.Activity
 import android.content.Intent
 import androidx.fragment.app.FragmentActivity
+import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReadableMap
-import com.facebook.react.bridge.WritableNativeMap
 import com.google.android.gms.tasks.Task
 import com.google.android.gms.wallet.AutoResolveHelper
 import com.google.android.gms.wallet.PaymentData
@@ -165,7 +165,7 @@ class GooglePayRequestHelper {
       promise: Promise,
     ) {
       val paymentInformation = JSONObject(paymentData.toJson())
-      val promiseResult = WritableNativeMap()
+      val promiseResult = Arguments.createMap()
       stripe.createPaymentMethod(
         PaymentMethodCreateParams.createFromGooglePay(paymentInformation),
         callback =
@@ -193,7 +193,7 @@ class GooglePayRequestHelper {
     ) {
       val paymentInformation = JSONObject(paymentData.toJson())
       val googlePayResult = GooglePayResult.fromJson(paymentInformation)
-      val promiseResult = WritableNativeMap()
+      val promiseResult = Arguments.createMap()
       googlePayResult.token?.let {
         promiseResult.putMap("token", mapFromToken(it))
         if (googlePayResult.shippingInformation != null) {

--- a/android/src/main/java/com/reactnativestripesdk/PaymentSheetManager.kt
+++ b/android/src/main/java/com/reactnativestripesdk/PaymentSheetManager.kt
@@ -20,7 +20,6 @@ import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.WritableMap
-import com.facebook.react.bridge.WritableNativeMap
 import com.reactnativestripesdk.addresssheet.AddressSheetView
 import com.reactnativestripesdk.utils.ErrorType
 import com.reactnativestripesdk.utils.KeepJsAwakeTask
@@ -145,7 +144,7 @@ class PaymentSheetManager(
           paymentOptionResult.paymentOption?.let {
             val bitmap = getBitmapFromDrawable(it.icon())
             val imageString = getBase64FromBitmap(bitmap)
-            val option: WritableMap = WritableNativeMap()
+            val option: WritableMap = Arguments.createMap()
             option.putString("label", it.label)
             option.putString("image", imageString)
             val additionalFields: Map<String, Any> = mapOf("didCancel" to paymentOptionResult.didCancel)
@@ -190,7 +189,7 @@ class PaymentSheetManager(
             }
 
             is PaymentSheetResult.Completed -> {
-              resolvePaymentResult(WritableNativeMap())
+              resolvePaymentResult(Arguments.createMap())
               paymentSheet = null
               flowController = null
             }
@@ -326,7 +325,7 @@ class PaymentSheetManager(
             .confirmCustomPaymentMethodCallback(this)
             .build(activity, signal)
         }
-      initPromise.resolve(WritableNativeMap())
+      initPromise.resolve(Arguments.createMap())
     }
   }
 
@@ -418,11 +417,11 @@ class PaymentSheetManager(
           flowController?.getPaymentOption()?.let {
             val bitmap = getBitmapFromDrawable(it.icon())
             val imageString = getBase64FromBitmap(bitmap)
-            val option: WritableMap = WritableNativeMap()
+            val option: WritableMap = Arguments.createMap()
             option.putString("label", it.label)
             option.putString("image", imageString)
             createResult("paymentOption", option)
-          } ?: run { WritableNativeMap() }
+          } ?: run { Arguments.createMap() }
         initPromise.resolve(result)
       }
 

--- a/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
+++ b/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
@@ -18,7 +18,6 @@ import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.UiThreadUtil
 import com.facebook.react.bridge.WritableMap
-import com.facebook.react.bridge.WritableNativeMap
 import com.facebook.react.module.annotations.ReactModule
 import com.reactnativestripesdk.addresssheet.AddressLauncherManager
 import com.reactnativestripesdk.customersheet.CustomerSheetManager
@@ -502,7 +501,7 @@ class StripeSdkModule(
         object : ApiResultCallback<Token> {
           override fun onSuccess(result: Token) {
             val tokenId = result.id
-            val res = WritableNativeMap()
+            val res = Arguments.createMap()
             res.putString("tokenId", tokenId)
             promise.resolve(res)
           }
@@ -779,7 +778,7 @@ class StripeSdkModule(
                   expand = listOf("payment_method"),
                   object : ApiResultCallback<PaymentIntent> {
                     override fun onError(e: Exception) {
-                      promise.resolve(createResult("paymentIntent", WritableNativeMap()))
+                      promise.resolve(createResult("paymentIntent", Arguments.createMap()))
                     }
 
                     override fun onSuccess(result: PaymentIntent) {
@@ -799,7 +798,7 @@ class StripeSdkModule(
                   expand = listOf("payment_method"),
                   object : ApiResultCallback<SetupIntent> {
                     override fun onError(e: Exception) {
-                      promise.resolve(createResult("setupIntent", WritableNativeMap()))
+                      promise.resolve(createResult("setupIntent", Arguments.createMap()))
                     }
 
                     override fun onSuccess(result: SetupIntent) {
@@ -909,7 +908,7 @@ class StripeSdkModule(
       PushProvisioningProxy.isCardInWallet(it, last4) { isCardInWallet, token, error ->
         val result: WritableMap =
           error ?: run {
-            val map = WritableNativeMap()
+            val map = Arguments.createMap()
             map.putBoolean("isInWallet", isCardInWallet)
             map.putMap("token", token)
             map

--- a/android/src/main/java/com/reactnativestripesdk/addresssheet/AddressSheetView.kt
+++ b/android/src/main/java/com/reactnativestripesdk/addresssheet/AddressSheetView.kt
@@ -3,9 +3,9 @@ package com.reactnativestripesdk.addresssheet
 import android.annotation.SuppressLint
 import android.util.Log
 import android.widget.FrameLayout
+import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.WritableMap
-import com.facebook.react.bridge.WritableNativeMap
 import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.UIManagerHelper
 import com.reactnativestripesdk.buildPaymentSheetAppearance
@@ -172,14 +172,14 @@ class AddressSheetView(
     }
 
     internal fun buildResult(addressDetails: AddressDetails): WritableMap =
-      WritableNativeMap().apply {
+      Arguments.createMap().apply {
         putMap(
           "result",
-          WritableNativeMap().apply {
+          Arguments.createMap().apply {
             putString("name", addressDetails.name)
             putMap(
               "address",
-              WritableNativeMap().apply {
+              Arguments.createMap().apply {
                 putString("city", addressDetails.address?.city)
                 putString("country", addressDetails.address?.country)
                 putString("line1", addressDetails.address?.line1)

--- a/android/src/main/java/com/reactnativestripesdk/customersheet/CustomerSheetManager.kt
+++ b/android/src/main/java/com/reactnativestripesdk/customersheet/CustomerSheetManager.kt
@@ -12,7 +12,6 @@ import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.WritableMap
-import com.facebook.react.bridge.WritableNativeMap
 import com.reactnativestripesdk.ReactNativeCustomerAdapter
 import com.reactnativestripesdk.ReactNativeCustomerSessionProvider
 import com.reactnativestripesdk.buildBillingDetails
@@ -157,7 +156,7 @@ class CustomerSheetManager(
 
     customerSheet?.configure(configuration.build())
 
-    initPromise.resolve(WritableNativeMap())
+    initPromise.resolve(Arguments.createMap())
   }
 
   private fun handleResult(result: CustomerSheetResult) {

--- a/android/src/main/java/com/reactnativestripesdk/pushprovisioning/TapAndPayProxy.kt
+++ b/android/src/main/java/com/reactnativestripesdk/pushprovisioning/TapAndPayProxy.kt
@@ -2,9 +2,9 @@ package com.reactnativestripesdk.pushprovisioning
 
 import android.app.Activity
 import android.util.Log
+import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.WritableMap
-import com.facebook.react.bridge.WritableNativeMap
 import com.google.android.gms.tasks.Task
 import com.reactnativestripesdk.utils.createError
 
@@ -108,7 +108,7 @@ object TapAndPayProxy {
   }
 
   private fun mapFromTokenInfo(token: Any?): WritableMap {
-    val result = WritableNativeMap()
+    val result = Arguments.createMap()
     token?.let {
       try {
         val tokenInfoClass = Class.forName("com.google.android.gms.tapandpay.issuer.TokenInfo")

--- a/android/src/main/java/com/reactnativestripesdk/utils/Errors.kt
+++ b/android/src/main/java/com/reactnativestripesdk/utils/Errors.kt
@@ -1,7 +1,7 @@
 package com.reactnativestripesdk.utils
 
+import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.WritableMap
-import com.facebook.react.bridge.WritableNativeMap
 import com.stripe.android.core.exception.APIException
 import com.stripe.android.core.exception.AuthenticationException
 import com.stripe.android.core.exception.InvalidRequestException
@@ -66,8 +66,8 @@ internal fun mapError(
   type: String?,
   stripeErrorCode: String?,
 ): WritableMap {
-  val map: WritableMap = WritableNativeMap()
-  val details: WritableMap = WritableNativeMap()
+  val map: WritableMap = Arguments.createMap()
+  val details: WritableMap = Arguments.createMap()
   details.putString("code", code)
   details.putString("message", message)
   details.putString("localizedMessage", localizedMessage)

--- a/android/src/main/java/com/reactnativestripesdk/utils/Mappers.kt
+++ b/android/src/main/java/com/reactnativestripesdk/utils/Mappers.kt
@@ -6,7 +6,6 @@ import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.WritableArray
 import com.facebook.react.bridge.WritableMap
-import com.facebook.react.bridge.WritableNativeMap
 import com.stripe.android.PaymentAuthConfig
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsEvent
 import com.stripe.android.model.Address
@@ -34,7 +33,7 @@ internal fun createResult(
   value: WritableMap,
   additionalFields: Map<String, Any>? = null,
 ): WritableMap {
-  val map = WritableNativeMap()
+  val map = Arguments.createMap()
   map.putMap(key, value)
   additionalFields?.let { map.merge(it.toReadableMap()) }
   return map
@@ -44,9 +43,9 @@ internal fun createCanAddCardResult(
   canAddCard: Boolean,
   status: String? = null,
   token: WritableMap? = null,
-): WritableNativeMap {
-  val result = WritableNativeMap()
-  val details = WritableNativeMap()
+): WritableMap {
+  val result = Arguments.createMap()
+  val details = Arguments.createMap()
   result.putBoolean("canAddCard", canAddCard)
   if (status != null) {
     details.putString("status", status)
@@ -92,8 +91,8 @@ internal fun mapToReturnURL(urlScheme: String?): String? {
 }
 
 internal fun mapIntentShipping(shipping: PaymentIntent.Shipping): WritableMap {
-  val map: WritableMap = WritableNativeMap()
-  val address: WritableMap = WritableNativeMap()
+  val map: WritableMap = Arguments.createMap()
+  val address: WritableMap = Arguments.createMap()
 
   address.putString("city", shipping.address.city)
   address.putString("country", shipping.address.country)
@@ -186,8 +185,8 @@ internal fun mapToPaymentMethodType(type: String?): PaymentMethod.Type? =
   }
 
 internal fun mapFromBillingDetails(billingDatails: PaymentMethod.BillingDetails?): WritableMap {
-  val details: WritableMap = WritableNativeMap()
-  val address: WritableMap = WritableNativeMap()
+  val details: WritableMap = Arguments.createMap()
+  val address: WritableMap = Arguments.createMap()
 
   address.putString("country", billingDatails?.address?.country)
   address.putString("city", billingDatails?.address?.city)
@@ -265,7 +264,7 @@ internal fun mapFromBankAccount(bankAccount: BankAccount?): WritableMap? {
     return null
   }
 
-  val bankAccountMap: WritableMap = WritableNativeMap()
+  val bankAccountMap: WritableMap = Arguments.createMap()
   bankAccountMap.putString("id", bankAccount.id)
   bankAccountMap.putString("bankName", bankAccount.bankName)
   bankAccountMap.putString("accountHolderName", bankAccount.accountHolderName)
@@ -312,13 +311,13 @@ internal fun mapFromUSBankAccountType(type: PaymentMethod.USBankAccount.USBankAc
   }
 
 internal fun mapFromCard(card: Card?): WritableMap? {
-  val cardMap: WritableMap = WritableNativeMap()
+  val cardMap: WritableMap = Arguments.createMap()
 
   if (card == null) {
     return null
   }
 
-  val address: WritableMap = WritableNativeMap()
+  val address: WritableMap = Arguments.createMap()
 
   cardMap.putString("country", card.country)
   cardMap.putString("brand", mapCardBrand(card.brand))
@@ -346,7 +345,7 @@ internal fun mapFromCard(card: Card?): WritableMap? {
 }
 
 internal fun mapFromToken(token: Token): WritableMap {
-  val tokenMap: WritableMap = WritableNativeMap()
+  val tokenMap: WritableMap = Arguments.createMap()
   tokenMap.putString("id", token.id)
   tokenMap.putString("created", token.created.time.toString())
   tokenMap.putString("type", mapTokenType(token.type))
@@ -359,7 +358,7 @@ internal fun mapFromToken(token: Token): WritableMap {
 }
 
 internal fun mapFromPaymentMethod(paymentMethod: PaymentMethod): WritableMap {
-  val pm: WritableMap = WritableNativeMap()
+  val pm: WritableMap = Arguments.createMap()
 
   pm.putString("id", paymentMethod.id)
   pm.putString("paymentMethodType", mapPaymentMethodType(paymentMethod.type))
@@ -368,7 +367,7 @@ internal fun mapFromPaymentMethod(paymentMethod: PaymentMethod): WritableMap {
   pm.putMap("billingDetails", mapFromBillingDetails(paymentMethod.billingDetails))
   pm.putMap(
     "Card",
-    WritableNativeMap().also {
+    Arguments.createMap().also {
       it.putString("brand", mapCardBrand(paymentMethod.card?.brand))
       it.putString("country", paymentMethod.card?.country)
       paymentMethod.card?.expiryYear?.let { year -> it.putInt("expYear", year) }
@@ -386,7 +385,7 @@ internal fun mapFromPaymentMethod(paymentMethod: PaymentMethod): WritableMap {
       )
       it.putMap(
         "threeDSecureUsage",
-        WritableNativeMap().also { threeDSecureUsageMap ->
+        Arguments.createMap().also { threeDSecureUsageMap ->
           threeDSecureUsageMap.putBoolean(
             "isSupported",
             paymentMethod.card?.threeDSecureUsage?.isSupported ?: false,
@@ -397,7 +396,7 @@ internal fun mapFromPaymentMethod(paymentMethod: PaymentMethod): WritableMap {
   )
   pm.putMap(
     "SepaDebit",
-    WritableNativeMap().also {
+    Arguments.createMap().also {
       it.putString("bankCode", paymentMethod.sepaDebit?.bankCode)
       it.putString("country", paymentMethod.sepaDebit?.country)
       it.putString("fingerprint", paymentMethod.sepaDebit?.fingerprint)
@@ -406,7 +405,7 @@ internal fun mapFromPaymentMethod(paymentMethod: PaymentMethod): WritableMap {
   )
   pm.putMap(
     "BacsDebit",
-    WritableNativeMap().also {
+    Arguments.createMap().also {
       it.putString("fingerprint", paymentMethod.bacsDebit?.fingerprint)
       it.putString("last4", paymentMethod.bacsDebit?.last4)
       it.putString("sortCode", paymentMethod.bacsDebit?.sortCode)
@@ -414,7 +413,7 @@ internal fun mapFromPaymentMethod(paymentMethod: PaymentMethod): WritableMap {
   )
   pm.putMap(
     "AuBecsDebit",
-    WritableNativeMap().also {
+    Arguments.createMap().also {
       it.putString("bsbNumber", paymentMethod.bacsDebit?.sortCode)
       it.putString("fingerprint", paymentMethod.bacsDebit?.fingerprint)
       it.putString("last4", paymentMethod.bacsDebit?.last4)
@@ -422,22 +421,22 @@ internal fun mapFromPaymentMethod(paymentMethod: PaymentMethod): WritableMap {
   )
   pm.putMap(
     "Ideal",
-    WritableNativeMap().also {
+    Arguments.createMap().also {
       it.putString("bankName", paymentMethod.ideal?.bank)
       it.putString("bankIdentifierCode", paymentMethod.ideal?.bankIdentifierCode)
     },
   )
   pm.putMap(
     "Fpx",
-    WritableNativeMap().also {
+    Arguments.createMap().also {
       it.putString("accountHolderType", paymentMethod.fpx?.accountHolderType)
       it.putString("bank", paymentMethod.fpx?.bank)
     },
   )
-  pm.putMap("Upi", WritableNativeMap().also { it.putString("vpa", paymentMethod.upi?.vpa) })
+  pm.putMap("Upi", Arguments.createMap().also { it.putString("vpa", paymentMethod.upi?.vpa) })
   pm.putMap(
     "USBankAccount",
-    WritableNativeMap().also {
+    Arguments.createMap().also {
       it.putString("routingNumber", paymentMethod.usBankAccount?.routingNumber)
       it.putString(
         "accountType",
@@ -463,7 +462,7 @@ internal fun mapFromPaymentMethod(paymentMethod: PaymentMethod): WritableMap {
 }
 
 internal fun mapFromPaymentIntentResult(paymentIntent: PaymentIntent): WritableMap {
-  val map: WritableMap = WritableNativeMap()
+  val map: WritableMap = Arguments.createMap()
   map.putString("id", paymentIntent.id)
   map.putString("clientSecret", paymentIntent.clientSecret)
   map.putBoolean("livemode", paymentIntent.isLiveMode)
@@ -490,7 +489,7 @@ internal fun mapFromPaymentIntentResult(paymentIntent: PaymentIntent): WritableM
   map.putNull("canceledAt")
 
   paymentIntent.lastPaymentError?.let {
-    val paymentError: WritableMap = WritableNativeMap()
+    val paymentError: WritableMap = Arguments.createMap()
     paymentError.putString("code", it.code)
     paymentError.putString("message", it.message)
     paymentError.putString("type", mapFromPaymentIntentLastErrorType(it.type))
@@ -521,8 +520,8 @@ internal fun mapFromMicrodepositType(type: MicrodepositType): String =
 internal fun mapNextAction(
   type: NextActionType?,
   data: NextActionData?,
-): WritableNativeMap? {
-  val nextActionMap = WritableNativeMap()
+): WritableMap? {
+  val nextActionMap = Arguments.createMap()
   when (type) {
     NextActionType.RedirectToUrl -> {
       (data as? NextActionData.RedirectToUrl)?.let {
@@ -858,7 +857,7 @@ fun mapToUICustomization(params: ReadableMap): PaymentAuthConfig.Stripe3ds2UiCus
 }
 
 internal fun mapFromSetupIntentResult(setupIntent: SetupIntent): WritableMap {
-  val map: WritableMap = WritableNativeMap()
+  val map: WritableMap = Arguments.createMap()
   val paymentMethodTypes: WritableArray = Arguments.createArray()
   map.putString("id", setupIntent.id)
   map.putString("status", mapIntentStatus(setupIntent.status))
@@ -875,7 +874,7 @@ internal fun mapFromSetupIntentResult(setupIntent: SetupIntent): WritableMap {
   map.putMap("nextAction", mapNextAction(setupIntent.nextActionType, setupIntent.nextActionData))
 
   setupIntent.lastSetupError?.let {
-    val setupError: WritableMap = WritableNativeMap()
+    val setupError: WritableMap = Arguments.createMap()
     setupError.putString("code", it.code)
     setupError.putString("message", it.message)
     setupError.putString("type", mapFromSetupIntentLastErrorType(it.type))
@@ -913,15 +912,15 @@ fun mapToPaymentIntentFutureUsage(type: String?): ConfirmPaymentIntentParams.Set
   }
 
 internal fun mapFromShippingContact(googlePayResult: GooglePayResult): WritableMap {
-  val map = WritableNativeMap()
+  val map = Arguments.createMap()
   map.putString("emailAddress", googlePayResult.email)
-  val name = WritableNativeMap()
+  val name = Arguments.createMap()
   googlePayResult.name
   name.putString("givenName", googlePayResult.shippingInformation?.name)
   map.putMap("name", name)
   googlePayResult.shippingInformation?.phone?.let { map.putString("phoneNumber", it) }
     ?: run { map.putString("phoneNumber", googlePayResult.phoneNumber) }
-  val postalAddress = WritableNativeMap()
+  val postalAddress = Arguments.createMap()
   postalAddress.putString("city", googlePayResult.shippingInformation?.address?.city)
   postalAddress.putString("country", googlePayResult.shippingInformation?.address?.country)
   postalAddress.putString("postalCode", googlePayResult.shippingInformation?.address?.postalCode)
@@ -1046,10 +1045,10 @@ internal fun mapFromCustomPaymentMethod(
   customPaymentMethod: PaymentSheet.CustomPaymentMethod,
   billingDetails: PaymentMethod.BillingDetails,
 ): WritableMap =
-  WritableNativeMap().apply {
+  Arguments.createMap().apply {
     putMap(
       "customPaymentMethod",
-      WritableNativeMap().apply {
+      Arguments.createMap().apply {
         putString("id", customPaymentMethod.id)
       },
     )
@@ -1058,7 +1057,7 @@ internal fun mapFromCustomPaymentMethod(
 
 @SuppressLint("RestrictedApi")
 internal fun mapFromConfirmationToken(confirmationToken: ConfirmationToken): WritableMap {
-  val token: WritableMap = WritableNativeMap()
+  val token: WritableMap = Arguments.createMap()
 
   token.putString("id", confirmationToken.id)
   token.putDouble("created", confirmationToken.created.toDouble())
@@ -1071,7 +1070,7 @@ internal fun mapFromConfirmationToken(confirmationToken: ConfirmationToken): Wri
 
   // PaymentMethodPreview
   confirmationToken.paymentMethodPreview?.let { preview ->
-    val paymentMethodPreview = WritableNativeMap()
+    val paymentMethodPreview = Arguments.createMap()
     paymentMethodPreview.putString("type", mapPaymentMethodType(preview.type))
     paymentMethodPreview.putMap("billingDetails", mapFromBillingDetails(preview.billingDetails))
     paymentMethodPreview.putString("allowRedisplay", mapFromAllowRedisplay(preview.allowRedisplay))
@@ -1083,12 +1082,12 @@ internal fun mapFromConfirmationToken(confirmationToken: ConfirmationToken): Wri
 
   // Shipping details
   confirmationToken.shipping?.let { shippingDetails ->
-    val shipping = WritableNativeMap()
+    val shipping = Arguments.createMap()
     shipping.putString("name", shippingDetails.name)
     shipping.putString("phone", shippingDetails.phone)
 
     shippingDetails.address?.let { address ->
-      val addressMap = WritableNativeMap()
+      val addressMap = Arguments.createMap()
       addressMap.putString("city", address.city)
       addressMap.putString("country", address.country)
       addressMap.putString("line1", address.line1)
@@ -1097,7 +1096,7 @@ internal fun mapFromConfirmationToken(confirmationToken: ConfirmationToken): Wri
       addressMap.putString("state", address.state)
       shipping.putMap("address", addressMap)
     } ?: run {
-      shipping.putMap("address", WritableNativeMap())
+      shipping.putMap("address", Arguments.createMap())
     }
 
     token.putMap("shipping", shipping)

--- a/android/src/test/java/com/facebook/testutils/shadows/ShadowArguments.kt
+++ b/android/src/test/java/com/facebook/testutils/shadows/ShadowArguments.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.testutils.shadows
+
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.JavaOnlyArray
+import com.facebook.react.bridge.JavaOnlyMap
+import com.facebook.react.bridge.WritableArray
+import com.facebook.react.bridge.WritableMap
+import org.robolectric.annotation.Implementation
+import org.robolectric.annotation.Implements
+
+@Implements(Arguments::class)
+class ShadowArguments {
+  companion object {
+    @JvmStatic
+    @Implementation
+    fun createArray(): WritableArray = JavaOnlyArray()
+
+    @JvmStatic
+    @Implementation
+    fun createMap(): WritableMap = JavaOnlyMap()
+  }
+}

--- a/android/src/test/java/com/reactnativestripesdk/EmbeddedPaymentElementViewManagerTest.kt
+++ b/android/src/test/java/com/reactnativestripesdk/EmbeddedPaymentElementViewManagerTest.kt
@@ -1,20 +1,14 @@
 package com.reactnativestripesdk
 
-import androidx.test.core.app.ApplicationProvider
-import com.facebook.react.soloader.OpenSourceMergedSoMapping
-import com.facebook.soloader.SoLoader
 import com.reactnativestripesdk.utils.readableMapOf
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import org.junit.Assert.assertEquals
-import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 
+@RunWith(RobolectricTestRunner::class)
 class EmbeddedPaymentElementViewManagerTest {
-  @Before
-  fun setup() {
-    SoLoader.init(ApplicationProvider.getApplicationContext(), OpenSourceMergedSoMapping)
-  }
-
   // ============================================
   // mapToRowSelectionBehaviorType Tests
   // ============================================

--- a/android/src/test/java/com/reactnativestripesdk/PaymentElementConfigTest.kt
+++ b/android/src/test/java/com/reactnativestripesdk/PaymentElementConfigTest.kt
@@ -1,8 +1,5 @@
 package com.reactnativestripesdk
 
-import androidx.test.core.app.ApplicationProvider
-import com.facebook.react.soloader.OpenSourceMergedSoMapping
-import com.facebook.soloader.SoLoader
 import com.reactnativestripesdk.utils.PaymentSheetException
 import com.reactnativestripesdk.utils.readableArrayOf
 import com.reactnativestripesdk.utils.readableMapOf
@@ -11,16 +8,13 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
-import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 
+@RunWith(RobolectricTestRunner::class)
 @OptIn(PaymentMethodOptionsSetupFutureUsagePreview::class)
 class PaymentElementConfigTest {
-  @Before
-  fun setup() {
-    SoLoader.init(ApplicationProvider.getApplicationContext(), OpenSourceMergedSoMapping)
-  }
-
   // ============================================
   // buildIntentConfiguration Tests
   // ============================================

--- a/android/src/test/java/com/reactnativestripesdk/PaymentSheetAppearanceTest.kt
+++ b/android/src/test/java/com/reactnativestripesdk/PaymentSheetAppearanceTest.kt
@@ -1,28 +1,20 @@
 package com.reactnativestripesdk
 
+import android.content.Context
 import android.graphics.Color
 import androidx.test.core.app.ApplicationProvider
-import com.facebook.react.bridge.BridgeReactContext
-import com.facebook.react.bridge.JavaOnlyMap
+import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.ReadableMap
-import com.facebook.react.soloader.OpenSourceMergedSoMapping
-import com.facebook.soloader.SoLoader
 import com.stripe.android.paymentsheet.PaymentSheet
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
-import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 
+@RunWith(RobolectricTestRunner::class)
 class PaymentSheetAppearanceTest {
-  private val context =
-    BridgeReactContext(
-      ApplicationProvider.getApplicationContext(),
-    )
-
-  @Before
-  fun setup() {
-    SoLoader.init(context, OpenSourceMergedSoMapping)
-  }
+  private val context = ApplicationProvider.getApplicationContext<Context>()
 
   @Test
   fun testFullAppearanceConfiguration() {
@@ -692,7 +684,7 @@ class PaymentSheetAppearanceTest {
   }
 
   private fun jsonObjectToMap(jsonObject: JSONObject): ReadableMap {
-    val map = JavaOnlyMap()
+    val map = Arguments.createMap()
     val keys = jsonObject.keys()
     while (keys.hasNext()) {
       val key = keys.next()

--- a/android/src/test/java/com/reactnativestripesdk/PaymentSheetManagerTest.kt
+++ b/android/src/test/java/com/reactnativestripesdk/PaymentSheetManagerTest.kt
@@ -1,24 +1,18 @@
 package com.reactnativestripesdk
 
-import androidx.test.core.app.ApplicationProvider
-import com.facebook.react.soloader.OpenSourceMergedSoMapping
-import com.facebook.soloader.SoLoader
 import com.reactnativestripesdk.utils.readableArrayOf
 import com.reactnativestripesdk.utils.readableMapOf
 import com.stripe.android.paymentelement.PaymentMethodOptionsSetupFutureUsagePreview
 import com.stripe.android.paymentsheet.PaymentSheet
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
-import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 
+@RunWith(RobolectricTestRunner::class)
 @OptIn(PaymentMethodOptionsSetupFutureUsagePreview::class)
 class PaymentSheetManagerTest {
-  @Before
-  fun setup() {
-    SoLoader.init(ApplicationProvider.getApplicationContext(), OpenSourceMergedSoMapping)
-  }
-
   // ============================================
   // mapToCollectionMode Tests
   // ============================================

--- a/android/src/test/java/com/reactnativestripesdk/addresssheet/AddressSheetViewTest.kt
+++ b/android/src/test/java/com/reactnativestripesdk/addresssheet/AddressSheetViewTest.kt
@@ -1,9 +1,5 @@
 package com.reactnativestripesdk.addresssheet
 
-import androidx.test.core.app.ApplicationProvider
-import com.facebook.react.bridge.WritableNativeMap
-import com.facebook.react.soloader.OpenSourceMergedSoMapping
-import com.facebook.soloader.SoLoader
 import com.reactnativestripesdk.utils.readableMapOf
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
@@ -13,9 +9,11 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
-import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 
+@RunWith(RobolectricTestRunner::class)
 class AddressSheetViewTest {
   private val testCity = "testCity"
   private val testCountry = "testCountry"
@@ -25,11 +23,6 @@ class AddressSheetViewTest {
   private val testState = "testState"
   private val testName = "testName"
   private val testPhone = "testPhone"
-
-  @Before
-  fun setup() {
-    SoLoader.init(ApplicationProvider.getApplicationContext(), OpenSourceMergedSoMapping)
-  }
 
   @Test
   fun buildAddressDetails_Default() {
@@ -296,16 +289,13 @@ class AddressSheetViewTest {
 
   @Test
   fun buildAdditionalFieldsConfiguration_EmptyMap_ReturnsDefaults() {
-    val result = AddressSheetView.buildAdditionalFieldsConfiguration(WritableNativeMap())
+    val result = AddressSheetView.buildAdditionalFieldsConfiguration(readableMapOf())
     assertNotNull(result)
   }
 
   @Test
   fun buildAdditionalFieldsConfiguration_PhoneRequired() {
-    val params =
-      WritableNativeMap().also {
-        it.putString("phoneNumber", "required")
-      }
+    val params = readableMapOf("phoneNumber" to "required")
 
     val result = AddressSheetView.buildAdditionalFieldsConfiguration(params)
     assertNotNull(result)
@@ -313,10 +303,7 @@ class AddressSheetViewTest {
 
   @Test
   fun buildAdditionalFieldsConfiguration_PhoneOptional() {
-    val params =
-      WritableNativeMap().also {
-        it.putString("phoneNumber", "optional")
-      }
+    val params = readableMapOf("phoneNumber" to "optional")
 
     val result = AddressSheetView.buildAdditionalFieldsConfiguration(params)
     assertNotNull(result)
@@ -324,10 +311,7 @@ class AddressSheetViewTest {
 
   @Test
   fun buildAdditionalFieldsConfiguration_PhoneHidden() {
-    val params =
-      WritableNativeMap().also {
-        it.putString("phoneNumber", "hidden")
-      }
+    val params = readableMapOf("phoneNumber" to "hidden")
 
     val result = AddressSheetView.buildAdditionalFieldsConfiguration(params)
     assertNotNull(result)
@@ -336,10 +320,7 @@ class AddressSheetViewTest {
   @Test
   fun buildAdditionalFieldsConfiguration_WithCheckboxLabel() {
     val label = "custom label"
-    val params =
-      WritableNativeMap().also {
-        it.putString("checkboxLabel", label)
-      }
+    val params = readableMapOf("checkboxLabel" to label)
 
     val result = AddressSheetView.buildAdditionalFieldsConfiguration(params)
     assertNotNull(result)
@@ -348,11 +329,7 @@ class AddressSheetViewTest {
   @Test
   fun buildAdditionalFieldsConfiguration_FullConfig() {
     val label = "Accept terms and conditions"
-    val params =
-      WritableNativeMap().also {
-        it.putString("phoneNumber", "required")
-        it.putString("checkboxLabel", label)
-      }
+    val params = readableMapOf("phoneNumber" to "required", "checkboxLabel" to label)
 
     val result = AddressSheetView.buildAdditionalFieldsConfiguration(params)
     assertNotNull(result)
@@ -360,10 +337,7 @@ class AddressSheetViewTest {
 
   @Test
   fun buildAdditionalFieldsConfiguration_InvalidPhoneValue_DefaultsToHidden() {
-    val params =
-      WritableNativeMap().also {
-        it.putString("phoneNumber", "invalid")
-      }
+    val params = readableMapOf("phoneNumber" to "invalid")
 
     val result = AddressSheetView.buildAdditionalFieldsConfiguration(params)
     assertNotNull(result)

--- a/android/src/test/java/com/reactnativestripesdk/mappers/MappersTest.kt
+++ b/android/src/test/java/com/reactnativestripesdk/mappers/MappersTest.kt
@@ -1,10 +1,7 @@
 package com.reactnativestripesdk.mappers
 
 import android.annotation.SuppressLint
-import androidx.test.core.app.ApplicationProvider
-import com.facebook.react.bridge.WritableNativeMap
-import com.facebook.react.soloader.OpenSourceMergedSoMapping
-import com.facebook.soloader.SoLoader
+import com.facebook.react.bridge.WritableMap
 import com.reactnativestripesdk.utils.createCanAddCardResult
 import com.reactnativestripesdk.utils.mapToAddress
 import com.reactnativestripesdk.utils.mapToBillingDetails
@@ -19,16 +16,13 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
-import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 
 @SuppressLint("RestrictedApi")
+@RunWith(RobolectricTestRunner::class)
 class MappersTest {
-  @Before
-  fun setup() {
-    SoLoader.init(ApplicationProvider.getApplicationContext(), OpenSourceMergedSoMapping)
-  }
-
   @Test
   fun createCanAddCardResult_NoStatus() {
     val result =
@@ -45,11 +39,12 @@ class MappersTest {
 
   @Test
   fun createCanAddCardResult_WithToken() {
+    val tokenMap = readableMapOf("key" to "value") as WritableMap
     val result =
       createCanAddCardResult(
         true,
         "CARD_ALREADY_EXISTS",
-        WritableNativeMap().also { it.putString("key", "value") },
+        tokenMap,
       )
     Assert.assertTrue(result.getBoolean("canAddCard"))
     val details = result.getMap("details")

--- a/android/src/test/java/com/reactnativestripesdk/mappers/PaymentOptionDisplayDataMapperTest.kt
+++ b/android/src/test/java/com/reactnativestripesdk/mappers/PaymentOptionDisplayDataMapperTest.kt
@@ -10,20 +10,14 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.sp
-import androidx.test.core.app.ApplicationProvider
-import com.facebook.react.soloader.OpenSourceMergedSoMapping
-import com.facebook.soloader.SoLoader
 import com.reactnativestripesdk.toHtmlString
 import org.junit.Assert
-import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 
+@RunWith(RobolectricTestRunner::class)
 class PaymentOptionDisplayDataMapperTest {
-  @Before
-  fun setup() {
-    SoLoader.init(ApplicationProvider.getApplicationContext(), OpenSourceMergedSoMapping)
-  }
-
   @Test
   fun toHtmlString_PlainText() {
     val annotatedString = AnnotatedString("Simple text")

--- a/android/src/test/java/com/reactnativestripesdk/pushprovisioning/PushProvisioningProxyTest.kt
+++ b/android/src/test/java/com/reactnativestripesdk/pushprovisioning/PushProvisioningProxyTest.kt
@@ -4,7 +4,10 @@ import androidx.test.core.app.ApplicationProvider
 import com.facebook.react.bridge.BridgeReactContext
 import org.junit.Assert
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 
+@RunWith(RobolectricTestRunner::class)
 class PushProvisioningProxyTest {
   private val reactApplicationContext =
     BridgeReactContext(

--- a/android/src/test/resources/robolectric.properties
+++ b/android/src/test/resources/robolectric.properties
@@ -1,0 +1,2 @@
+sdk=28
+shadows=com.facebook.testutils.shadows.ShadowArguments

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -106,17 +106,16 @@ workflows:
   unit-test-android:
     before_run:
       - _prepare_android
-      - _start_android_emulator
     steps:
       - script@1:
           title: Check Android Code Formatting
           inputs:
             - content: yarn format:android:check
-      - script@1:
-          title: Run Android unit tests
-          timeout: 1200
+      - android-unit-test:
           inputs:
-            - content: yarn test:unit:android
+            - project_location: $BITRISE_SOURCE_DIR/example/android
+            - module: stripe_stripe-react-native
+            - variant: debug
       - save-gradle-cache@1:
           is_always_run: true
       - deploy-to-bitrise-io@2:

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test:e2e:ios": "bash ./scripts/run-maestro-tests ios",
     "test:e2e:android": "bash ./scripts/run-maestro-tests android",
     "test:unit:ios": "xcodebuild test -workspace example/ios/example.xcworkspace -destination 'platform=iOS Simulator,name=iPhone 16 Pro Max' -scheme stripe-react-native-Unit-Tests",
-    "test:unit:android": "cd example/android && ./gradlew connectedAndroidTest",
+    "test:unit:android": "cd example/android && ./gradlew :stripe_stripe-react-native:testDebugUnitTest",
     "test-ios": "maestro test -e APP_ID=com.stripe.react.native",
     "test-android": "maestro test -e APP_ID=com.stripe.react.native",
     "format:android:check": "cd android && ./gradlew spotlessCheck",


### PR DESCRIPTION
## Summary

Use regular android unit tests instead of connected tests. This avoids having to build the full app and run an emulator. We can also use the bitrise built in task for android unit tests which gives nice reporting like we have for iOS.

The reason connected tests had to be used is because of ReadableNativeMap, which uses jni, which requires using connected tests.

I used the same technique as the react native unit tests, where they mock the Arguments class to return Java only versions of these classes. This required replacing all places where we created NativeMaps directly with `Arguments.createMap`.

This cuts down time to run android tests from ~6 minutes to ~3.5 minutes. Not the main motivation for this, but nice added bonus, especially as we add more tests and it could become longer to run.

## Motivation

Improve unit test infra.

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [ ] I tested this manually
- [x] I added automated tests
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
