### PR TITLE
Update CHANGELOG for 0.57.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## x.x.x - 2025-x-x
+## 0.57.0 - 2025-11-12
 **Changes**
 - [Changed] Updated Stripe iOS SDK from 24.25.0 to 25.0.0
 - [Changed] Updated Stripe Android SDK from 21.29.+ to 22.0.+


### PR DESCRIPTION
- [x] Ensure the CHANGELOG is up to date with all relevant commits since the last release
- [x] Add the version number for this release & the date to the CHANGELOG, underneath "## Unreleased" 
  - e.g. "## 1.2.3 - 2022-02-14"
- [x] Update the README if necessary (this is only required when there are breaking changes in the release, such as dropping support for an iOS || Android version)