### PR TITLE
Fix GooglePayButtonView layout measurement

### DIFF
--- a/android/src/main/java/com/reactnativestripesdk/GooglePayButtonView.kt
+++ b/android/src/main/java/com/reactnativestripesdk/GooglePayButtonView.kt
@@ -108,7 +108,7 @@ class GooglePayButtonView(
         MeasureSpec.makeMeasureSpec(width, MeasureSpec.EXACTLY),
         MeasureSpec.makeMeasureSpec(height, MeasureSpec.EXACTLY),
       )
-      button?.layout(left, top, right, bottom)
+      layout(left, top, right, bottom)
     }
 
   fun setType(type: Int) {


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
Fix the workaround for a React Native layout bug with native Android views.
See https://github.com/facebook/react-native/issues/17968#issuecomment-2065449875 for more context.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a link to the relevant issue, a code snippet, or an example project that demonstrates the bug. -->
#2071 

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [ ] I added automated tests
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.

## Recording
|Before | After |
| ------------- | ------------- |
|https://github.com/user-attachments/assets/2db6909c-f195-4131-a221-a2efd5533124| https://github.com/user-attachments/assets/fe4c9a99-765c-463b-93a1-52fef679bf29|