### PR TITLE
chore: cleanup build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,10 +1,10 @@
 buildscript {
   // Buildscript is evaluated before everything else so we can't use getExtOrDefault
-  def kotlin_version = rootProject.ext.has('kotlinVersion')
-    ? rootProject.ext.get('kotlinVersion')
-    : project.properties['StripeSdk_kotlinVersion']
+  def kotlinVersion = rootProject.ext.has("kotlinVersion")
+    ? rootProject.ext.get("kotlinVersion")
+    : project.properties["StripeSdk_kotlinVersion"]
 
-  def kotlinMajor = kotlin_version.tokenize('\\.')[0].toInteger()
+  def kotlinMajor = kotlinVersion.tokenize("\\.")[0].toInteger()
 
   repositories {
     google()
@@ -12,28 +12,28 @@ buildscript {
   }
 
   dependencies {
-    classpath 'com.android.tools.build:gradle:7.2.2'
+    classpath "com.android.tools.build:gradle:7.2.2"
     // noinspection DifferentKotlinGradleVersion
-    classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    classpath 'com.diffplug.spotless:spotless-plugin-gradle:6.25.0'
+    classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
+    classpath "com.diffplug.spotless:spotless-plugin-gradle:6.25.0"
     // only use this old compose-compiler plugin when Kotlin >= 2.0
     if (kotlinMajor >= 2) {
-      classpath "org.jetbrains.kotlin:compose-compiler-gradle-plugin:$kotlin_version"
+      classpath "org.jetbrains.kotlin:compose-compiler-gradle-plugin:$kotlinVersion"
     }
   }
 }
 
 if (project == rootProject) {
-  apply from: 'spotless.gradle'
+  apply from: "spotless.gradle"
   return
 }
 
 def getExtOrDefault(name) {
-  return rootProject.ext.has(name) ? rootProject.ext.get(name) : project.properties['StripeSdk_' + name]
+  return rootProject.ext.has(name) ? rootProject.ext.get(name) : project.properties["StripeSdk_" + name]
 }
 
 def getExtOrIntegerDefault(name) {
-  return rootProject.ext.has(name) ? rootProject.ext.get(name) : (project.properties['StripeSdk_' + name]).toInteger()
+  return rootProject.ext.has(name) ? rootProject.ext.get(name) : (project.properties["StripeSdk_" + name]).toInteger()
 }
 
 def isNewArchitectureEnabled() {
@@ -54,22 +54,19 @@ def reactNativeArchitectures() {
   ]
 }
 
-def kotlin_version = rootProject.ext.has('kotlinVersion')
-    ? rootProject.ext.get('kotlinVersion')
-    : project.properties['StripeSdk_kotlinVersion']
-def kotlinMajor = kotlin_version.tokenize('\\.')[0].toInteger()
+def kotlinVersion = getExtOrDefault("kotlinVersion")
+def kotlinMajor = kotlinVersion.tokenize("\\.")[0].toInteger()
 
-apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-parcelize'
+apply plugin: "com.android.library"
+apply plugin: "kotlin-android"
+apply plugin: "kotlin-parcelize"
 // Only apply the compose plugin if we have the old compose-compiler on the classpath
 if (kotlinMajor >= 2) {
-  apply plugin: 'org.jetbrains.kotlin.plugin.compose'
+  apply plugin: "org.jetbrains.kotlin.plugin.compose"
 }
-//apply plugin: 'kotlin-android-extensions'
 
 if (isNewArchitectureEnabled()) {
-  apply plugin: 'com.facebook.react'
+  apply plugin: "com.facebook.react"
 }
 
 android {
@@ -78,7 +75,7 @@ android {
     buildConfig true
   }
 
-  compileSdkVersion getExtOrIntegerDefault('compileSdkVersion')
+  compileSdkVersion getExtOrIntegerDefault("compileSdkVersion")
 
   // Used to override the NDK path/version on internal CI or by allowing
   // users to customize the NDK path/version from their root project (e.g. for M1 support)
@@ -90,12 +87,12 @@ android {
   }
 
   defaultConfig {
-    minSdkVersion getExtOrIntegerDefault('minSdkVersion')
-    targetSdkVersion getExtOrIntegerDefault('targetSdkVersion')
+    minSdkVersion getExtOrIntegerDefault("minSdkVersion")
+    targetSdkVersion getExtOrIntegerDefault("targetSdkVersion")
     versionCode 1
     versionName "1.0"
     vectorDrawables.useSupportLibrary = true
-    consumerProguardFiles 'proguard-rules.txt'
+    consumerProguardFiles "proguard-rules.txt"
     buildConfigField "boolean", "IS_NEW_ARCHITECTURE_ENABLED", isNewArchitectureEnabled().toString()
 
     ndk {
@@ -103,16 +100,10 @@ android {
     }
   }
 
-  buildTypes {
-    release {
-      minifyEnabled false
-    }
-  }
-
   lintOptions {
-    disable 'GradleCompatible'
+    disable "GradleCompatible"
     textReport true
-    textOutput 'stdout'
+    textOutput "stdout"
   }
 
   compileOptions {
@@ -151,98 +142,28 @@ android {
 repositories {
   mavenCentral()
   google()
-
-  def found = false
-  def defaultDir = null
-  def androidSourcesName = 'React Native sources'
-
-  if (rootProject.ext.has('reactNativeAndroidRoot')) {
-    defaultDir = rootProject.ext.get('reactNativeAndroidRoot')
-  } else {
-    defaultDir = new File(
-      projectDir,
-      '/../../../node_modules/react-native/android'
-    )
-  }
-
-  if (defaultDir.exists()) {
-    maven {
-      url defaultDir.toString()
-      name androidSourcesName
-    }
-
-    logger.info(":${project.name}:reactNativeAndroidRoot ${defaultDir.canonicalPath}")
-    found = true
-  } else {
-    def parentDir = rootProject.projectDir
-
-    1.upto(5, {
-      if (found) return true
-      parentDir = parentDir.parentFile
-
-      def androidSourcesDir = new File(
-        parentDir,
-        'node_modules/react-native'
-      )
-
-      def androidPrebuiltBinaryDir = new File(
-        parentDir,
-        'node_modules/react-native/android'
-      )
-
-      if (androidPrebuiltBinaryDir.exists()) {
-        maven {
-          url androidPrebuiltBinaryDir.toString()
-          name androidSourcesName
-        }
-
-        logger.info(":${project.name}:reactNativeAndroidRoot ${androidPrebuiltBinaryDir.canonicalPath}")
-        found = true
-      } else if (androidSourcesDir.exists()) {
-        maven {
-          url androidSourcesDir.toString()
-          name androidSourcesName
-        }
-
-        logger.info(":${project.name}:reactNativeAndroidRoot ${androidSourcesDir.canonicalPath}")
-        found = true
-      }
-    })
-  }
-
-  if (!found) {
-    throw new GradleException(
-      "${project.name}: unable to locate React Native android sources. " +
-        "Ensure you have you installed React Native as a dependency in your project and try again."
-    )
-  }
 }
 
-def stripe_version = getExtOrDefault('stripeVersion')
+def stripeVersion = getExtOrDefault("stripeVersion")
 
 dependencies {
   // noinspection GradleDynamicVersion
-  api 'com.facebook.react:react-native:+'
-  implementation 'com.github.bumptech.glide:glide:4.12.0'
-  implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+  api "com.facebook.react:react-native:+"
+  implementation "com.github.bumptech.glide:glide:4.12.0"
+  implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
   implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.3.1"
-  implementation("com.stripe:stripe-android:$stripe_version") {
-    exclude group: 'androidx.emoji2', module: 'emoji2'
-  }
-  implementation("com.stripe:financial-connections:$stripe_version") {
-    exclude group: 'androidx.emoji2', module: 'emoji2'
-  }
-  implementation('androidx.emoji2:emoji2:1.3.0').force // Avoid using 1.4.0 since that requires targetSdkVersion 34
-  implementation 'com.google.android.material:material:1.3.0'
-  implementation 'androidx.appcompat:appcompat:1.4.1'
-  implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-  implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.0'
+  implementation("com.stripe:stripe-android:$stripeVersion")
+  implementation("com.stripe:financial-connections:$stripeVersion")
+  implementation "com.google.android.material:material:1.3.0"
+  implementation "androidx.appcompat:appcompat:1.4.1"
+  implementation "androidx.legacy:legacy-support-v4:1.0.0"
+  implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.0"
 
   // play-services-wallet is already included in stripe-android
   compileOnly "com.google.android.gms:play-services-wallet:19.3.0"
 
   // Users need to declare this dependency on their own, otherwise all methods are a no-op
-  compileOnly 'com.stripe:stripe-android-issuing-push-provisioning:1.1.0'
+  compileOnly "com.stripe:stripe-android-issuing-push-provisioning:1.1.0"
 
   testImplementation "junit:junit:4.13"
   testImplementation "org.mockito:mockito-core:3.+"

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "!android/.gradle",
     "!android/build",
     "!android/src/androidTest",
+    "!android/lint-rules",
     "!ios/build",
     "!ios/Tests",
     "!**/__tests__",


### PR DESCRIPTION
## Summary

Remove things that are no longer needed in build.gradle.

- `minifyEnabled` has no effect in a library
- Remove code trying to locate react-native, the react native gradle plugin now handles this automatically
- Minor style cleanup
- Unrelated, but added `!android/lint-rules` to npm package so the new lint rule is not packaged

## Motivation

Cleanup build.gradle

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [ ] I added automated tests
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

Tested using the new project script with version 0.76 to make sure old RN versions still work.

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
