### PR TITLE
chore: record failures for e2e tests

### DIFF
--- a/e2e-tests/rn-arch.yml
+++ b/e2e-tests/rn-arch.yml
@@ -7,11 +7,11 @@ appId: ${APP_ID}
     when:
       true: ${NEW_ARCH == 'true'}
     commands:
-      - assertVisible: 'zzzz'
+      - assertVisible: 'New arch enabled: true'
       - assertVisible: 'Bridgeless enabled: true'
 - runFlow:
     when:
       true: ${NEW_ARCH == 'false'}
     commands:
-      - assertVisible: 'zzzz'
+      - assertVisible: 'New arch enabled: false'
       - assertVisible: 'Bridgeless enabled: false'

--- a/example/src/screens/AlipayPaymentScreen.tsx
+++ b/example/src/screens/AlipayPaymentScreen.tsx
@@ -18,7 +18,7 @@ export default function AlipayPaymentScreen() {
       },
       body: JSON.stringify({
         email,
-        currency: 'usd',
+        currency: 'cny',
         items: ['id-1'],
         payment_method_types: ['alipay'],
       }),

--- a/scripts/run-maestro-tests
+++ b/scripts/run-maestro-tests
@@ -4,12 +4,13 @@ set -uo pipefail
 
 PLATFORM=""
 RECORD_ON_FAILURE=false
-RECORDING_PID=""
+IS_RECORDING=false
+NEW_ARCH_ENABLED=${NEW_ARCH_ENABLED:-false}
 
 stop_recording() {
   local recording_dir=$1
 
-  if [ -n "${RECORDING_PID:-}" ]; then
+  if [ "$IS_RECORDING" = true ]; then
     echo "Stopping recording..."
 
     if [ "$PLATFORM" = "android" ]; then
@@ -22,7 +23,7 @@ stop_recording() {
       killall -SIGINT simctl || true
     fi
 
-    RECORDING_PID=""
+    IS_RECORDING=false
     echo "Recording saved to $recording_dir/recording.mp4"
   fi
 }
@@ -35,22 +36,22 @@ start_recording() {
 
   if [ "$PLATFORM" = "android" ]; then
     adb shell "screenrecord --bugreport /data/local/tmp/recording.mp4 & echo \$! > /data/local/tmp/recording_pid.txt" &
-    RECORDING_PID="android"
+    IS_RECORDING=true
   elif [ "$PLATFORM" = "ios" ]; then
     xcrun simctl io booted recordVideo --codec=h264 -f "$recording_dir/recording.mp4" &
-    RECORDING_PID="ios"
+    IS_RECORDING=true
   fi
 }
 
 cleanup() {
-  if [ -n "${RECORDING_PID:-}" ]; then
+  if [ "$IS_RECORDING" = true ]; then
     echo "Interrupt cleanup - stopping recording..."
     if [ "$PLATFORM" = "android" ]; then
       adb shell "kill -2 \$(cat /data/local/tmp/recording_pid.txt)" 2>/dev/null || true
     elif [ "$PLATFORM" = "ios" ]; then
       killall -SIGINT simctl || true
     fi
-    RECORDING_PID=""
+    IS_RECORDING=false
   fi
 }
 
@@ -99,9 +100,6 @@ fi
 
 failedTests=()
 failedFinancialConnectionsTests=()
-
-# Set defaults for optional environment variables
-NEW_ARCH_ENABLED=${NEW_ARCH_ENABLED:-false}
 
 # Ensure artifacts directory exists even if shard has no tests
 mkdir -p e2e-artifacts


### PR DESCRIPTION
## Summary

Record a video of individual e2e tests during retries. To avoid too much overhead we only record retries.

## Motivation

Sometimes it is pretty hard to debug what is happening from just the failure screenshot and logs. This adds video recording.

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [ ] I tested this manually
- [ ] I added automated tests
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
