### PR TITLE
native is a keyword so we have to call it reactnative

### DIFF
--- a/example/app.json
+++ b/example/app.json
@@ -33,7 +33,7 @@
     ]
   },
   "android": {
-    "package": "com.stripe.react.native",
+    "package": "com.stripe.reactnative",
     "metaData": [{
       "android:name": "com.google.android.gms.wallet.api.enabled",
       "android:value": "true"

--- a/example/package.json
+++ b/example/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
-    "android": "react-native run-android --active-arch-only --appId com.stripe.react.native",
+    "android": "react-native run-android --active-arch-only --appId com.stripe.reactnative",
     "build:android": "npm run mkdist && react-native bundle --entry-file index.js --platform android --dev false --bundle-output dist/main.android.jsbundle --assets-dest dist/res",
     "build:ios": "npm run mkdist && react-native bundle --entry-file index.js --platform ios --dev false --bundle-output dist/main.ios.jsbundle --assets-dest dist",
     "install-pods": "pod install --project-directory=ios",


### PR DESCRIPTION
There's been some change with the autolinking code generation in 0.81

## Summary
package is now com.stripe.reactnative instead of com.stripe.react.native

## Motivation
The example android app should compile

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [X] I tested this manually
- [ ] I added automated tests
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [X] This PR does not result in any developer-facing changes.
