### PR TITLE
Pass overrides for embedded components in stripe connect instance

### DIFF
--- a/src/connect/EmbeddedComponent.tsx
+++ b/src/connect/EmbeddedComponent.tsx
@@ -15,11 +15,12 @@ import {
 import type { WebView, WebViewMessageEvent } from 'react-native-webview';
 import pjson from '../../package.json';
 import NativeStripeSdk from '../specs/NativeStripeSdkModule';
-import {
-  ConnectComponentsPayload,
-  useConnectComponents,
-} from './ConnectComponentsProvider';
-import type { LoadError, LoaderStart } from './connectTypes';
+import { useConnectComponents } from './ConnectComponentsProvider';
+import type {
+  LoadError,
+  LoaderStart,
+  StripeConnectInitParams,
+} from './connectTypes';
 
 const DEVELOPMENT_MODE = false;
 const DEVELOPMENT_URL =
@@ -110,7 +111,7 @@ type EmbeddedComponentProps = CommonComponentProps & {
   callbacks?: Record<string, ((data: any) => void) | undefined>;
 };
 
-type ConnectComponentsPayloadInternal = ConnectComponentsPayload & {
+type StripeConnectInitParamsInternal = StripeConnectInitParams & {
   overrides?: Record<string, string>;
 };
 
@@ -166,10 +167,9 @@ export function EmbeddedComponent(props: EmbeddedComponentProps) {
     };
   }, []);
 
-  const { connectInstance, appearance, locale, overrides } =
-    useConnectComponents() as ConnectComponentsPayloadInternal;
-  const { fonts, publishableKey, fetchClientSecret } =
-    connectInstance.initParams;
+  const { connectInstance, appearance, locale } = useConnectComponents();
+  const { fonts, publishableKey, fetchClientSecret, overrides } =
+    connectInstance.initParams as StripeConnectInitParamsInternal;
 
   const {
     component,


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

These overrides are needed to authenticate with direct accounts. This is an internal API. With this PR we will pass the overrides with the rest of the auth props in the initialization of the stripe connect instance.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a link to the relevant issue, a code snippet, or an example project that demonstrates the bug. -->

This is required for the Dashboard app.

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [ ] I added automated tests
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
