### PR TITLE
CryptoOnramp SDK: Addresses Feedback from API Review

### DIFF
--- a/src/hooks/useOnramp.tsx
+++ b/src/hooks/useOnramp.tsx
@@ -174,8 +174,11 @@ export function useOnramp() {
     return NativeOnrampSdk.logout();
   }, []);
 
-  const _isAuthError = (error: any): boolean => {
+  const _isAuthError = (error?: StripeError<OnrampError>): boolean => {
     const stripeErrorCode = error?.stripeErrorCode;
+    if (stripeErrorCode == null) {
+      return false;
+    }
     const authErrorCodes = [
       'consumer_session_credentials_invalid',
       'consumer_session_expired',


### PR DESCRIPTION
## Summary
- Addresses comments on [2025-11-25 - Crypto Onramp RN SDK API Review](https://docs.google.com/document/d/1XcePxYNvt07bowyYq7FDhCSsqNbUl1_sb7M2ueiU91A/edit?tab=t.0#heading=h.570u4leviueu) that required code/documentation changes.
- See the last two items in the changelog of the document.

## Motivation
To help push the SDK update through API review.

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [ ] I added automated tests
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

To test manually, I manually resolved with an authentication error when canceling identity verification by making the following code change in `StripeSdkImpl.swift`:
```diff
- resolve(["error": Errors.createError(ErrorType.Canceled, "Identity verification was cancelled")["error"]!])
+ var error = Errors.createError(ErrorType.Failed, "Testing: Expired authentication session")["error"] as! [String: Any]
+ error["stripeErrorCode"] = "consumer_session_expired"
+ resolve(["error": error])
```
Then, I:
1.  ran the example app
2. initialized the SDK
3. authenticated manually with username/password
4. opened the "Verify Identity" collapsible section
5. tapped "Verify Idenity"
6. tapped the "Cancelled" option under "Terminate mobile SDK flow
7. Saw the OTP sheet reappear, and upon filling it out, saw the verify identity sheet reappear

## Documentation

Select one: 
- [x] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
