### PR TITLE
Fix OXXO E2E test on Android

### DIFF
--- a/e2e-tests/android-only/oxxo.yml
+++ b/e2e-tests/android-only/oxxo.yml
@@ -18,7 +18,7 @@ appId: ${APP_ID}
     when:
       platform: android
     commands:
-      - deviceKeyEvent: back
+      - pressKey: back
 - runFlow:
     when:
       platform: ios


### PR DESCRIPTION
## Summary
- Fixes a broken OXXO test on Android where the close button wasn't visible. So instead we just hit the 'back' button on the device.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a link to the relevant issue, a code snippet, or an example project that demonstrates the bug. -->

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [ ] I tested this manually
- [ ] I added automated tests
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
