### PR TITLE
Fix FC E2E Tests - Not Now Button Text Change

### DIFF
--- a/e2e-tests/android-only/financial-connections-session.yml
+++ b/e2e-tests/android-only/financial-connections-session.yml
@@ -1,0 +1,69 @@
+appId: ${APP_ID}
+---
+- launchApp:
+    clearState: true
+- tapOn: "Financial Connections"
+- tapOn: "Collect Bank Account"
+- assertVisible:
+    text: "Collect session"
+- tapOn:
+    text: "Collect session"
+    retryTapIfNoChange: false
+- tapOn:
+    # Accept Link terms
+    text: "Agree and continue"
+- assertVisible:
+    text: "Test (Non-OAuth)"
+- tapOn:
+    text: "Test (Non-OAuth)"
+
+# The first chrome instance in E2E emulator, welcome page must be dismissed.
+- tapOn:
+    # Dismiss Chrome onboarding screen (new arch)
+    text: "Use without an account"
+    optional: true
+- tapOn:
+    # Accept Chrome terms (old arch)
+    text: "Accept & continue"
+    optional: true
+- tapOn:
+    # Don't turn on Chrome sync (old arch)
+    text: "No thanks"
+    optional: true
+
+- extendedWaitUntil:
+    visible: "Connect account"
+    timeout: 30000
+- tapOn:
+    text: "Connect account"
+
+- assertVisible:
+    text: "Finish without saving"
+- tapOn:
+    text: "Finish without saving"
+
+- assertVisible:
+    text: "Back to Stripe Shop"
+    optional: true
+- tapOn:
+    text: "Back to Stripe Shop"
+    optional: true
+- assertVisible:
+    text: "Done"
+    optional: true
+- tapOn:
+    text: "Done"
+    optional: true
+- assertVisible:
+    text: "Back to Test Inc."
+    optional: true
+- tapOn:
+    text: "Back to Test Inc."
+    optional: true
+
+
+- assertVisible:
+    text: "Success"
+- tapOn:
+    text: "OK"
+    optional: true

--- a/e2e-tests/android-only/financial-connections-token.yml
+++ b/e2e-tests/android-only/financial-connections-token.yml
@@ -1,0 +1,68 @@
+appId: ${APP_ID}
+---
+- launchApp:
+    clearState: true
+- tapOn: "Financial Connections"
+- tapOn: "Collect Bank Account"
+- assertVisible:
+    text: "Collect token"
+- tapOn:
+    text: "Collect token"
+    retryTapIfNoChange: false
+- tapOn:
+    # Accept Link terms
+    text: "Agree and continue"
+- assertVisible:
+    text: "Test (Non-OAuth)"
+- tapOn:
+    text: "Test (Non-OAuth)"
+
+# The first chrome instance in E2E emulator, welcome page must be dismissed.
+- tapOn:
+    # Dismiss Chrome onboarding screen (new arch)
+    text: "Use without an account"
+    optional: true
+- tapOn:
+    # Accept Chrome terms (old arch)
+    text: "Accept & continue"
+    optional: true
+- tapOn:
+    # Don't turn on Chrome sync (old arch)
+    text: "No thanks"
+    optional: true
+
+- extendedWaitUntil:
+    visible: "Connect account"
+    timeout: 30000
+- tapOn:
+    text: "Connect account"
+
+- assertVisible:
+    text: "Finish without saving"
+- tapOn:
+    text: "Finish without saving"
+
+- assertVisible:
+    text: "Back to Stripe Shop"
+    optional: true
+- tapOn:
+    text: "Back to Stripe Shop"
+    optional: true
+- assertVisible:
+    text: "Done"
+    optional: true
+- tapOn:
+    text: "Done"
+    optional: true
+- assertVisible:
+    text: "Back to Test Inc."
+    optional: true
+- tapOn:
+    text: "Back to Test Inc."
+    optional: true
+
+- assertVisible:
+    text: "Success"
+- tapOn:
+    text: "OK"
+    optional: true

--- a/e2e-tests/ios-only/financial-connections-session.yml
+++ b/e2e-tests/ios-only/financial-connections-session.yml
@@ -1,0 +1,42 @@
+appId: ${APP_ID}
+---
+- launchApp:
+    clearState: true
+- tapOn: "Financial Connections"
+- tapOn: "Collect Bank Account"
+- assertVisible:
+    text: "Collect session"
+- tapOn:
+    id: "force_native_flow_switch"
+    optional: true
+- tapOn:
+    text: "Collect session"
+    retryTapIfNoChange: false
+- assertVisible:
+    text: "Agree and continue"
+- tapOn: "Agree and continue"
+- assertVisible:
+    text: "Test (Non-OAuth)"
+- tapOn: "Test (Non-OAuth)"
+- extendedWaitUntil:
+    # wait for the auth flow to finish
+    visible: "Select account"
+    timeout: 60000
+- assertVisible:
+    text: "Connect account"
+- tapOn: "Connect account"
+- tapOn:
+    # Hide the keyboard if it shows up
+    text: "Done"
+    optional: true
+- assertVisible:
+    text: "Finish without saving"
+- tapOn: "Finish without saving"
+- assertVisible:
+    text: "Done"
+- tapOn: "Done"
+- assertVisible:
+    text: "Success"
+- tapOn:
+    text: "OK"
+    optional: true

--- a/e2e-tests/ios-only/financial-connections-token.yml
+++ b/e2e-tests/ios-only/financial-connections-token.yml
@@ -1,0 +1,42 @@
+appId: ${APP_ID}
+---
+- launchApp:
+    clearState: true
+- tapOn: "Financial Connections"
+- tapOn: "Collect Bank Account"
+- assertVisible:
+    text: "Collect token"
+- tapOn:
+    id: "force_native_flow_switch"
+    optional: true
+- tapOn:
+    text: "Collect token"
+    retryTapIfNoChange: false
+- assertVisible:
+    text: "Agree and continue"
+- tapOn: "Agree and continue"
+- assertVisible:
+    text: "Test (Non-OAuth)"
+- tapOn: "Test (Non-OAuth)"
+- extendedWaitUntil:
+    # wait for the auth flow to finish
+    visible: "Select account"
+    timeout: 60000
+- assertVisible:
+    text: "Connect account"
+- tapOn: "Connect account"
+- tapOn:
+    # Hide the keyboard if it shows up
+    text: "Done"
+    optional: true
+- assertVisible:
+    text: "Finish without saving"
+- tapOn: "Finish without saving"
+- assertVisible:
+    text: "Done"
+- tapOn: "Done"
+- assertVisible:
+    text: "Success"
+- tapOn:
+    text: "OK"
+    optional: true


### PR DESCRIPTION
## Summary
We disabled these tests in #2282. The [fix](https://github.com/stripe/stripe-android/pull/12271) for these tests in the native SDKs was to reference the tag of the control instead of it's label. This isn't possible in the RN tests, so this PR merely updates the label text used in the test.

## Motivation
ir-exquisite-pitch

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [ ] I tested this manually
- [ ] I added automated tests
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
