### PR TITLE
fix: prevent Android navigation bar overlap in Connect embedded components

### DIFF
--- a/example-stripe-connect/src/screens/ConnectScreen.tsx
+++ b/example-stripe-connect/src/screens/ConnectScreen.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { ActivityIndicator, StyleSheet, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import {
   ConnectComponentsProvider,
   loadConnectAndInitialize,
@@ -82,7 +83,9 @@ const ConnectScreen: React.FC<Props> = ({ children }) => {
 
   return (
     <ConnectComponentsProvider connectInstance={stripeConnectInstance}>
-      <View style={styles.container}>{children}</View>
+      <SafeAreaView style={styles.container} edges={['bottom']}>
+        {children}
+      </SafeAreaView>
     </ConnectComponentsProvider>
   );
 };


### PR DESCRIPTION
## Summary

Fixes Android navigation bar overlap issue in Connect embedded components (Payouts, Payments, Account Onboarding) when `edgeToEdgeEnabled: true` is set in app.json.

**Before**
![photo_4924696397831932843_y](https://github.com/user-attachments/assets/008f1262-912e-4d96-a95f-cc024016b887)

**After**
![photo_4924696397831932844_y](https://github.com/user-attachments/assets/84cbc84f-ec6d-4918-a5c3-864369be02eb)


## Problem

When rendering embedded Connect components on Android with edge-to-edge display enabled, bottom content was rendering behind the system navigation bar, making elements inaccessible to users.

**Root cause:**
- App has `edgeToEdgeEnabled: true` enabling Android's edge-to-edge display
- `ConnectScreen.tsx` used plain `View` instead of `SafeAreaView`
- Content rendered under the navigation bar

## Solution

Wrapped embedded components with `SafeAreaView` configured with `edges={['bottom']}` to:
- Apply bottom inset padding to avoid navigation bar overlap
- Prevent double padding at top (navigation header already provides spacing)
- Fix all 3 embedded components with single change at wrapper level

## Changes

**Modified:**
- `example-stripe-connect/src/screens/ConnectScreen.tsx`
  - Import `SafeAreaView` from `react-native-safe-area-context`
  - Replace `View` wrapper with `SafeAreaView` using `edges={['bottom']}`

## Testing

### Build and Run
\`\`\`bash
yarn run-example-android
\`\`\`

### Manual Testing Checklist
- [x] App builds successfully
- [x] App launches without crashes
- [ ] Navigate to /payouts - verify bottom content visible above nav bar
- [ ] Navigate to /payments - verify bottom content visible above nav bar
- [ ] Navigate to /account-onboarding - verify bottom content visible above nav bar
- [ ] Test with 3-button navigation
- [ ] Test with gesture navigation
- [ ] Verify no double padding with header shown
- [ ] Verify keyboard interaction still works
- [ ] Test on iOS for regressions

### Quality Checks
- [x] `yarn lint` passes
- [x] `yarn typescript` passes
- [x] Pre-commit hooks pass

## Consistency

Follows the same pattern already used in `SettingsScreen.tsx:126` which correctly uses `SafeAreaView`.

## Platform Impact

- **Android**: Fixes navigation bar overlap ✅
- **iOS**: SafeAreaView handles iOS safe areas automatically, no regressions expected
- **Future-proof**: New embedded components automatically get protection

🤖 Generated with [Claude Code](https://claude.com/claude-code)