### PR TITLE
chore: fix jest mocks

### DIFF
--- a/jest/mock.js
+++ b/jest/mock.js
@@ -267,6 +267,31 @@ const StripeConstants = {
       Failed: 'failed',
     },
   },
+
+  PaymentIntent: {
+    Status: {
+      Succeeded: 'Succeeded',
+      RequiresPaymentMethod: 'RequiresPaymentMethod',
+      RequiresConfirmation: 'RequiresConfirmation',
+      Canceled: 'Canceled',
+      Processing: 'Processing',
+      RequiresAction: 'RequiresAction',
+      RequiresCapture: 'RequiresCapture',
+      Unknown: 'Unknown',
+    },
+  },
+
+  SetupIntent: {
+    Status: {
+      Succeeded: 'Succeeded',
+      RequiresPaymentMethod: 'RequiresPaymentMethod',
+      RequiresConfirmation: 'RequiresConfirmation',
+      Canceled: 'Canceled',
+      Processing: 'Processing',
+      RequiresAction: 'RequiresAction',
+      Unknown: 'Unknown',
+    },
+  },
 };
 
 // EmbeddedPaymentElement constants and enums for testing
@@ -376,23 +401,3 @@ module.exports = {
   PlatformPayButton: () => 'PlatformPayButton',
   useStripe: jest.fn(() => mockFunctions),
 };
-
-// Mock NativeStripeSdkModule with getConstants for system info
-jest.mock('./src/specs/NativeStripeSdkModule', () => ({
-  default: {
-    getConstants: jest.fn(() => ({
-      API_VERSIONS: {
-        CORE: '2024-12-15',
-        ISSUING: '2024-12-15',
-      },
-      SYSTEM_INFO: {
-        sdkVersion: '1.0.0',
-        osVersion: '18.0',
-        deviceType: 'iPhone14,5',
-        appName: 'TestApp',
-        appVersion: '1.0.0',
-      },
-    })),
-    openAuthenticatedWebView: jest.fn(),
-  },
-}));


### PR DESCRIPTION
## Summary
- Add `PaymentIntent.Status` and `SetupIntent.Status` to the Jest mock `StripeConstants` so unit tests can use intent status values (e.g. `Succeeded`, `RequiresPaymentMethod`, `RequiresAction`) when testing code that depends on them.
- Remove the global `jest.mock('./src/specs/NativeStripeSdkModule')` from the Jest mock. Tests that need a `NativeStripeSdkModule` mock already define it locally in their own files.

## Motivation
- **Intent status constants:** Code and examples use `PaymentIntent.Status` and `SetupIntent.Status` (e.g. `PaymentIntent.Status.Succeeded`, `SetupIntent.Status.RequiresConfirmation`). Without these in the mock, any test that runs under the global mock and touches that code would miss these constants or fail. Exposing them in `StripeConstants` keeps the mock aligned with the public API and supports tests that assert on intent statuses.
- **NativeStripeSdkModule mock removal:** The global mock was redundant and could conflict with tests that mock `NativeStripeSdkModule` themselves (e.g. in `connect/__tests__/`). Relying on per-file mocks where needed avoids global override and keeps test setup clearer.

## Testing
- [x] I tested this manually
- [ ] I added automated tests
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Documentation

Select one:
- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
