### PR TITLE
fix(android): uses unique authorities for file provider

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -27,8 +27,8 @@
         </activity>
 
         <provider
-            android:name="androidx.core.content.FileProvider"
-            android:authorities="${applicationId}.stripe.fileprovider"
+            android:name=".StripeFileProvider"
+            android:authorities="${applicationId}.fileprovider"
             android:exported="false"
             android:grantUriPermissions="true">
             <meta-data

--- a/android/src/main/java/com/reactnativestripesdk/StripeFileProvider.kt
+++ b/android/src/main/java/com/reactnativestripesdk/StripeFileProvider.kt
@@ -1,0 +1,12 @@
+package com.reactnativestripesdk
+
+import androidx.core.content.FileProvider
+
+/**
+ * Empty subclass of [FileProvider] used so this library's provider has a unique
+ * [android:name] in the manifest. That prevents the manifest merger from merging
+ * this provider with another library's FileProvider,
+ * which would cause an "Attribute provider@authorities value=... is also present at..."
+ * conflict.
+ */
+class StripeFileProvider : FileProvider()

--- a/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
+++ b/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
@@ -1518,7 +1518,7 @@ class StripeSdkModule(
       val uri =
         androidx.core.content.FileProvider.getUriForFile(
           reactApplicationContext,
-          "${reactApplicationContext.packageName}.stripe.fileprovider",
+          "${reactApplicationContext.packageName}.fileprovider",
           file,
         )
 


### PR DESCRIPTION
## Summary
- Use a library-specific FileProvider subclass (`StripeFileProvider`) in the Android manifest instead of the generic `androidx.core.content.FileProvider`. Giving this library's provider a unique `android:name` prevents the manifest merger from merging it with another library's FileProvider, which would cause an "Attribute provider@authorities value=... is also present at..." conflict.
- Authority remains `${applicationId}.fileprovider`; no changes to `StripeSdkModule.kt` or CSV export sharing.

fixes: https://github.com/stripe/stripe-react-native/issues/2307

## Motivation
When an app uses both `@stripe/stripe-react-native` and another library that declares a `FileProvider` (e.g. for document viewing), the Android manifest merger can report a conflict on the `android:authorities` attribute because both components use the same `FileProvider` class and similar or competing authorities. Using a dedicated subclass (`StripeFileProvider`) gives this library's provider a distinct `android:name`, so the merger keeps it separate and the conflict is resolved without requiring app-level `tools:replace` workarounds.

## Testing
- [x] I tested this manually
- [ ] I added automated tests
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Documentation

Select one:
- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
