### PR TITLE
fix: propagate FlowController configuration errors on Android

### DIFF
--- a/android/src/main/java/com/reactnativestripesdk/PaymentSheetManager.kt
+++ b/android/src/main/java/com/reactnativestripesdk/PaymentSheetManager.kt
@@ -434,40 +434,7 @@ class PaymentSheetManager(
   private fun configureFlowController() {
     val onFlowControllerConfigure =
       PaymentSheet.FlowController.ConfigCallback { success, error ->
-        if (!success) {
-          initPromise.resolve(
-            createError(
-              PaymentSheetErrorType.Failed.toString(),
-              error?.message ?: "Failed to configure payment sheet",
-            )
-          )
-          return@ConfigCallback
-        }
-        flowController?.getPaymentOption()?.let { paymentOption ->
-          // Launch async job to convert drawable, but resolve promise synchronously
-          CoroutineScope(Dispatchers.Default).launch {
-            val imageString =
-              try {
-                convertDrawableToBase64(paymentOption.icon())
-              } catch (e: Exception) {
-                val result =
-                  createError(
-                    PaymentSheetErrorType.Failed.toString(),
-                    "Failed to process payment option image: ${e.message}",
-                  )
-                initPromise.resolve(result)
-                return@launch
-              }
-
-            val option: WritableMap = Arguments.createMap()
-            option.putString("label", paymentOption.label)
-            option.putString("image", imageString)
-            val result = createResult("paymentOption", option)
-            initPromise.resolve(result)
-          }
-        } ?: run {
-          initPromise.resolve(Arguments.createMap())
-        }
+        handleFlowControllerConfigured(success, error, initPromise, flowController)
       }
 
     if (!paymentIntentClientSecret.isNullOrEmpty()) {
@@ -727,5 +694,46 @@ internal fun mapToPaymentMethodOptions(options: ReadableMap?): PaymentSheet.Inte
     )
   } else {
     null
+  }
+}
+
+internal fun handleFlowControllerConfigured(
+  success: Boolean,
+  error: Throwable?,
+  promise: Promise,
+  flowController: PaymentSheet.FlowController?,
+) {
+  if (!success) {
+    promise.resolve(
+      createError(
+        PaymentSheetErrorType.Failed.toString(),
+        error?.message ?: "Failed to configure payment sheet",
+      ),
+    )
+    return
+  }
+  flowController?.getPaymentOption()?.let { paymentOption ->
+    CoroutineScope(Dispatchers.Default).launch {
+      val imageString =
+        try {
+          convertDrawableToBase64(paymentOption.icon())
+        } catch (e: Exception) {
+          val result =
+            createError(
+              PaymentSheetErrorType.Failed.toString(),
+              "Failed to process payment option image: ${e.message}",
+            )
+          promise.resolve(result)
+          return@launch
+        }
+
+      val option: WritableMap = Arguments.createMap()
+      option.putString("label", paymentOption.label)
+      option.putString("image", imageString)
+      val result = createResult("paymentOption", option)
+      promise.resolve(result)
+    }
+  } ?: run {
+    promise.resolve(Arguments.createMap())
   }
 }


### PR DESCRIPTION
## Summary

On Android, the `FlowController.ConfigCallback` in `configureFlowController()` discards both the `success` and `error` parameters (`{ _, _ -> ...}`). When configuration fails, `initPaymentSheet` silently resolves as success, and calling `presentPaymentSheet()` afterward crashes with:

> FlowController must be successfully initialized using configureWithPaymentIntent(), configureWithSetupIntent() or configureWithIntentConfiguration() before calling presentPaymentOptions().

This is particularly reproducible when using `customFlow: true` with `intentConfiguration` (deferred intent), but affects any `initPaymentSheet` flow where `configureWithIntentConfiguration()` returns an error.

The iOS implementation already handles this correctly by checking the `Result` type and propagating errors back to JS.

## Motivation

Without this fix, JS callers of `initPaymentSheet` have no way to detect configuration failures on Android. The promise always resolves successfully, leading to a crash on `presentPaymentSheet()` instead of a graceful error that the app can handle.

## Changes

**`PaymentSheetManager.kt`**: Check the `success` boolean in `ConfigCallback`. On failure, resolve `initPromise` with the error (using the existing `createError` helper) and return early, matching the behavior the iOS side already has.

## Test plan

1. Call `initPaymentSheet` with a configuration that will fail (e.g., invalid intent configuration)
2. **Before fix**: `initPaymentSheet` resolves with no error; `presentPaymentSheet()` crashes
3. **After fix**: `initPaymentSheet` resolves with an error object containing the failure message