### PR TITLE
fix: use unique FileProvider authority to avoid manifest conflicts

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -28,7 +28,7 @@
 
         <provider
             android:name="androidx.core.content.FileProvider"
-            android:authorities="${applicationId}.fileprovider"
+            android:authorities="${applicationId}.stripe.fileprovider"
             android:exported="false"
             android:grantUriPermissions="true">
             <meta-data

--- a/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
+++ b/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
@@ -1518,7 +1518,7 @@ class StripeSdkModule(
       val uri =
         androidx.core.content.FileProvider.getUriForFile(
           reactApplicationContext,
-          "${reactApplicationContext.packageName}.fileprovider",
+          "${reactApplicationContext.packageName}.stripe.fileprovider",
           file,
         )
 


### PR DESCRIPTION
## Summary

Fixes a manifest merge conflict that occurs when apps use both `@stripe/stripe-react-native` and other libraries that declare a generic `FileProvider` (e.g., `react-native-documents_viewer`).

## Changes

- Updated `AndroidManifest.xml` FileProvider authority from `${applicationId}.fileprovider` to `${applicationId}.stripe.fileprovider`
- Updated `StripeSdkModule.kt` to use the matching authority when sharing CSV exports via FileProvider

This makes the FileProvider authority unique to the Stripe SDK, preventing conflicts with other libraries.

## Test Plan

- [x] TypeScript compilation passes (`yarn typescript`)
- [x] Android linting passes (`yarn lint:android`)
- [x] Code formatting applied automatically via pre-commit hooks
- [x] Manual testing: Build example app alongside another library with FileProvider to verify no conflicts
- [x] Tested CSV export sharing functionality still works correctly

## Impact

- **Breaking change**: No - apps will continue to work without changes
- **Risk level**: Low - only affects FileProvider authority, which is only used for CSV export sharing feature
- **Rollout**: Safe to deploy immediately

Fixes #2307