### PR TITLE
fix(ios): infoIconColor -> linkTextColor

### DIFF
--- a/ios/PaymentMethodMessagingElementConfig.swift
+++ b/ios/PaymentMethodMessagingElementConfig.swift
@@ -42,7 +42,7 @@ internal class PaymentMethodMessagingElementConfig {
         }
 
         if let linkTextColorHex = parseThemedColor(params: params, key: "linkTextColor") {
-            appearance.infoIconColor = linkTextColorHex
+            appearance.linkTextColor = linkTextColorHex
         }
 
         return appearance

--- a/ios/Tests/PaymentMethodMessagingElementConfigTests.swift
+++ b/ios/Tests/PaymentMethodMessagingElementConfigTests.swift
@@ -28,7 +28,7 @@ class PaymentMethodMessagingElementConfigTests: XCTestCase {
 
         // Verify colors
         XCTAssertNotNil(appearance.textColor)
-        XCTAssertNotNil(appearance.infoIconColor)
+        XCTAssertNotNil(appearance.linkTextColor)
     }
 
     func test_buildAppearanceFromParams_partialConfiguration() throws {
@@ -172,7 +172,7 @@ class PaymentMethodMessagingElementConfigTests: XCTestCase {
 
         let appearance = PaymentMethodMessagingElementConfig.buildAppearanceFromParams(params: params)
 
-        XCTAssertNotNil(appearance.infoIconColor)
+        XCTAssertNotNil(appearance.linkTextColor)
     }
 
     func test_buildAppearanceFromParams_themedColors() throws {
@@ -190,7 +190,7 @@ class PaymentMethodMessagingElementConfigTests: XCTestCase {
         let appearance = PaymentMethodMessagingElementConfig.buildAppearanceFromParams(params: params)
 
         XCTAssertNotNil(appearance.textColor)
-        XCTAssertNotNil(appearance.infoIconColor)
+        XCTAssertNotNil(appearance.linkTextColor)
     }
 
     func test_buildAppearanceFromParams_themedColorMissingDark() throws {


### PR DESCRIPTION
Updates the configuration to correctly parse and apply the link text color.

Ensures the correct appearance for the payment method messaging element.

## Summary
<!-- Simple summary of what was changed. -->

fixes: https://github.com/stripe/stripe-react-native/issues/2315

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a link to the relevant issue, a code snippet, or an example project that demonstrates the bug. -->

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [X] I tested this manually
- [ ] I added automated tests
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Documentation

Select one: 
- [X] I have added relevant documentation for my changes.
- [X] This PR does not result in any developer-facing changes.
