### PR TITLE
Revert "Auto-hide card mandate disclaimer for user keys (MOTO)"

### DIFF
--- a/android/src/main/java/com/reactnativestripesdk/PaymentElementConfig.kt
+++ b/android/src/main/java/com/reactnativestripesdk/PaymentElementConfig.kt
@@ -7,7 +7,6 @@ import com.reactnativestripesdk.utils.getIntOr
 import com.reactnativestripesdk.utils.getLongOr
 import com.reactnativestripesdk.utils.getStringList
 import com.reactnativestripesdk.utils.isEmpty
-import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentelement.PaymentMethodOptionsSetupFutureUsagePreview
 import com.stripe.android.paymentsheet.CardFundingFilteringPrivatePreview
 import com.stripe.android.paymentsheet.PaymentSheet
@@ -76,13 +75,6 @@ private fun mapStringToLinkDisplay(value: String?): PaymentSheet.LinkConfigurati
     "automatic" -> PaymentSheet.LinkConfiguration.Display.Automatic
     "never" -> PaymentSheet.LinkConfiguration.Display.Never
     else -> PaymentSheet.LinkConfiguration.Display.Automatic
-  }
-
-internal fun computeTermsDisplayForUserKey(publishableKey: String): Map<PaymentMethod.Type, PaymentSheet.TermsDisplay> =
-  if (publishableKey.startsWith("uk_")) {
-    mapOf(PaymentMethod.Type.Card to PaymentSheet.TermsDisplay.NEVER)
-  } else {
-    emptyMap()
   }
 
 private val mapIntToButtonType =

--- a/android/src/main/java/com/reactnativestripesdk/PaymentSheetManager.kt
+++ b/android/src/main/java/com/reactnativestripesdk/PaymentSheetManager.kt
@@ -39,7 +39,6 @@ import com.reactnativestripesdk.utils.mapFromPaymentMethod
 import com.reactnativestripesdk.utils.mapToPreferredNetworks
 import com.reactnativestripesdk.utils.parseCustomPaymentMethods
 import com.stripe.android.ExperimentalAllowsRemovalOfLastSavedPaymentMethodApi
-import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.reactnative.ReactNativeSdkInternal
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentelement.ConfirmCustomPaymentMethodCallback
@@ -298,14 +297,6 @@ class PaymentSheetManager(
     configurationBuilder.paymentMethodLayout(
       mapToPaymentMethodLayout(arguments.getString("paymentMethodLayout")),
     )
-
-    val userKeyTermsDisplay =
-      computeTermsDisplayForUserKey(
-        PaymentConfiguration.getInstance(context).publishableKey,
-      )
-    if (userKeyTermsDisplay.isNotEmpty()) {
-      configurationBuilder.termsDisplay(userKeyTermsDisplay)
-    }
 
     paymentSheetConfiguration = configurationBuilder.build()
 

--- a/android/src/test/java/com/reactnativestripesdk/PaymentElementConfigTest.kt
+++ b/android/src/test/java/com/reactnativestripesdk/PaymentElementConfigTest.kt
@@ -3,7 +3,6 @@ package com.reactnativestripesdk
 import com.reactnativestripesdk.utils.PaymentSheetException
 import com.reactnativestripesdk.utils.readableArrayOf
 import com.reactnativestripesdk.utils.readableMapOf
-import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentelement.PaymentMethodOptionsSetupFutureUsagePreview
 import com.stripe.android.paymentsheet.CardFundingFilteringPrivatePreview
 import com.stripe.android.paymentsheet.PaymentSheet
@@ -1097,42 +1096,6 @@ class PaymentElementConfigTest {
       )
     val result = mapToAllowedCardFundingTypes(params)
     assertNull(result)
-  }
-
-  // ============================================
-  // computeTermsDisplayForUserKey Tests
-  // ============================================
-
-  @Test
-  fun computeTermsDisplayForUserKey_UserKey_ReturnsCardNever() {
-    val result = computeTermsDisplayForUserKey("uk_test_123")
-    assertEquals(1, result.size)
-    assertEquals(PaymentSheet.TermsDisplay.NEVER, result[PaymentMethod.Type.Card])
-  }
-
-  @Test
-  fun computeTermsDisplayForUserKey_LiveUserKey_ReturnsCardNever() {
-    val result = computeTermsDisplayForUserKey("uk_live_456")
-    assertEquals(1, result.size)
-    assertEquals(PaymentSheet.TermsDisplay.NEVER, result[PaymentMethod.Type.Card])
-  }
-
-  @Test
-  fun computeTermsDisplayForUserKey_PublishableKey_ReturnsEmpty() {
-    val result = computeTermsDisplayForUserKey("pk_test_123")
-    assertTrue(result.isEmpty())
-  }
-
-  @Test
-  fun computeTermsDisplayForUserKey_LivePublishableKey_ReturnsEmpty() {
-    val result = computeTermsDisplayForUserKey("pk_live_456")
-    assertTrue(result.isEmpty())
-  }
-
-  @Test
-  fun computeTermsDisplayForUserKey_EmptyKey_ReturnsEmpty() {
-    val result = computeTermsDisplayForUserKey("")
-    assertTrue(result.isEmpty())
   }
 
   @Test

--- a/ios/StripeSdkImpl+PaymentSheet.swift
+++ b/ios/StripeSdkImpl+PaymentSheet.swift
@@ -152,11 +152,6 @@ extension StripeSdkImpl {
           )
         }
 
-        let userKeyTermsDisplay = StripeSdkImpl.computeTermsDisplayForUserKey()
-        if !userKeyTermsDisplay.isEmpty {
-            configuration.termsDisplay = userKeyTermsDisplay
-        }
-
         return (nil, configuration)
     }
 
@@ -484,13 +479,6 @@ extension StripeSdkImpl {
         default:
             return .automatic
         }
-    }
-
-    internal static func computeTermsDisplayForUserKey() -> [STPPaymentMethodType: PaymentSheet.TermsDisplay] {
-        if STPAPIClient.shared.publishableKeyIsUserKey {
-            return [.card: .never]
-        }
-        return [:]
     }
 
     internal static func mapToLinkDisplay(value: String?) -> PaymentSheet.LinkConfiguration.Display {

--- a/ios/Tests/PaymentSheetUtilsTests.swift
+++ b/ios/Tests/PaymentSheetUtilsTests.swift
@@ -164,27 +164,6 @@ class PaymentSheetUtilsTests: XCTestCase {
         )
     }
 
-    // MARK: - computeTermsDisplayForUserKey Tests
-
-    func test_computeTermsDisplayForUserKey_userKey_setsCardToNever() {
-        STPAPIClient.shared.publishableKey = "uk_test_123"
-        let result = StripeSdkImpl.computeTermsDisplayForUserKey()
-        XCTAssertEqual(result.count, 1)
-        XCTAssertEqual(result[.card], .never)
-    }
-
-    func test_computeTermsDisplayForUserKey_publishableKey_returnsEmpty() {
-        STPAPIClient.shared.publishableKey = "pk_test_123"
-        let result = StripeSdkImpl.computeTermsDisplayForUserKey()
-        XCTAssertTrue(result.isEmpty)
-    }
-
-    func test_computeTermsDisplayForUserKey_liveUserKey_setsCardToNever() {
-        STPAPIClient.shared.publishableKey = "uk_live_456"
-        let result = StripeSdkImpl.computeTermsDisplayForUserKey()
-        XCTAssertEqual(result[.card], .never)
-    }
-
     // MARK: - computeCardBrandAcceptance Tests
 
     func test_computeCardBrandAcceptance_nilParams_returnsAll() {


### PR DESCRIPTION
Reverts stripe/stripe-react-native#2309

I left a comment [here](https://github.com/stripe/stripe-react-native/pull/2309#pullrequestreview-3821102261) that was ignored.

This change isn't needed, so reverting it.