### PR TITLE
Removing the trailing comma resolves the build failure #2323

### DIFF
--- a/ios/PaymentMethodMessagingElementConfig.swift
+++ b/ios/PaymentMethodMessagingElementConfig.swift
@@ -103,12 +103,12 @@ internal class PaymentMethodMessagingElementConfig {
             }
         }
 
-        var configuration = PaymentMethodMessagingElement.Configuration(
+        let configuration = PaymentMethodMessagingElement.Configuration(
             amount: amount,
             currency: currency,
             locale: locale,
             countryCode: country,
-            paymentMethodTypes: paymentMethodTypes,
+            paymentMethodTypes: paymentMethodTypes
         )
 
         return (nil, configuration)


### PR DESCRIPTION
Update PaymentMethodMessagingElementConfig.swift

## Summary
Removes a trailing comma in PaymentMethodMessagingElement.Configuration initializer that causes a Swift compile error on Xcode 16.2.

## Motivation
Building the project on Xcode 16.2 fails with the following Swift error:
Unexpected ',' separator
The issue is triggered by a trailing comma in the initializer:
```
var configuration = PaymentMethodMessagingElement.Configuration(
    amount: amount,
    currency: currency,
    locale: locale,
    countryCode: country,
    paymentMethodTypes: paymentMethodTypes,
)
```
Removing the trailing comma resolves the build failure.
This PR fixes the issue reported here: https://github.com/stripe/stripe-react-native/issues/2323

## Testing
- [X] I tested this manually
- [ ] I added automated tests