### PR TITLE
v0.59.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 0.59.2 - 2026-03-04
+**Changes**
+- Updated Stripe iOS SDK from 25.6.+ to 25.7.+
+- Updated Stripe Android SDK from 22.7.+ to 22.8.+
+
 ## 0.59.1 - 2026-02-25
 **Fixes**
 * [Fixed] A build issue when using Xcode 16 ([#2323](https://github.com/stripe/stripe-react-native/issues/2323))


### PR DESCRIPTION
- [x] Ensure the CHANGELOG is up to date with all relevant commits since the last release
- [x] Add the version number for this release & the date to the CHANGELOG, underneath "## Unreleased" 
  - e.g. "## 1.2.3 - 2022-02-14"
- [x] Update the README if necessary (this is only required when there are breaking changes in the release, such as dropping support for an iOS || Android version)