### PR TITLE
Allow CI to update the stripe-ios pods to a branch

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -86,6 +86,7 @@ workflows:
       - NEW_ARCH_ENABLED: true
     before_run:
       - _prepare_ios
+      - _install_pods
     steps:
       - script@1:
           title: Check iOS Code Formatting
@@ -93,10 +94,6 @@ workflows:
             - content: |
                 brew install swiftlint
                 yarn format:ios:check
-      - script@1:
-          title: Install Pods
-          inputs:
-            - content: yarn pods
       - xcode-test@4:
           title: Xcode Test for iOS
           inputs:
@@ -118,11 +115,8 @@ workflows:
   build-ios-xcode-16:
     before_run:
       - _prepare_ios
+      - _install_pods
     steps:
-      - script@1:
-          title: Install Pods
-          inputs:
-            - content: yarn pods
       - xcode-build-for-test@2:
           title: Build iOS (Xcode 16)
           inputs:
@@ -400,6 +394,37 @@ workflows:
           inputs:
             - command: bootstrap-no-pods
 
+  _build_js_bundle:
+    steps:
+      - script@1:
+          title: Build App JS Bundle
+          inputs:
+            - content: yarn example build:ios
+
+  _install_pods:
+    steps:
+      - script@1:
+          title: Install Pods
+          inputs:
+            - content: |
+                if [ -n "$OVERRIDE_STRIPE_IOS_VERSION_GIT_BRANCH" ]; then
+                  echo "Overriding Stripe iOS SDK to use branch: $OVERRIDE_STRIPE_IOS_VERSION_GIT_BRANCH"
+
+                  # Extract pod names from update-pods script (includes transitive deps)
+                  STRIPE_PODS=$(grep '"update-pods"' package.json | sed 's/.*pod update //' | sed 's/",$//')
+
+                  PODFILE="example/ios/Podfile"
+                  echo "" >> "$PODFILE"
+                  echo "# Override Stripe iOS SDK pods to use git branch" >> "$PODFILE"
+                  echo "$STRIPE_PODS" | tr ' ' '\n' | while read pod; do
+                    [ -n "$pod" ] && echo "pod '$pod', :git => 'https://github.com/stripe/stripe-ios.git', :branch => '$OVERRIDE_STRIPE_IOS_VERSION_GIT_BRANCH'" >> "$PODFILE"
+                  done
+
+                  yarn update-pods
+                else
+                  yarn pods
+                fi
+
   _prepare_android:
     before_run:
       - _prepare_js_env
@@ -499,16 +524,9 @@ workflows:
   _e2e_build_ios:
     before_run:
       - _prepare_ios
+      - _build_js_bundle
+      - _install_pods
     steps:
-      # Note this must run before installing pods.
-      - script@1:
-          title: Build App JS Bundle
-          inputs:
-            - content: yarn example build:ios
-      - script@1:
-          title: Install Pods
-          inputs:
-            - content: yarn pods
       - script@1:
           title: Build iOS App (Release, Simulator)
           timeout: 1800


### PR DESCRIPTION
OVERRIDE_STRIPE_IOS_VERSION_GIT_BRANCH


## Motivation
Let's us run the tests against a stripe-ios e.g. release branch or master, to ensure it doesn't break stripe-react-native.

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [ ] I added automated tests
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

test 1, breaking a public API - fails as expected: https://app.bitrise.io/build/7a9dc43f-2161-47b0-81ea-8118c0354c26 
test 2, reverted to normal - passes as expected: https://app.bitrise.io/app/cf3f9f9d-0fa5-484a-a09b-5649a1512f6b/pipelines/2eeddcdc-40c1-434d-92e3-2a73eb2ffad8?tab=workflows

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
