### PR TITLE
fix: use NSInteger for STPPaymentStatus in StripeSwiftInterop.h

### DIFF
--- a/ios/StripeSwiftInterop.h
+++ b/ios/StripeSwiftInterop.h
@@ -11,7 +11,7 @@
 @protocol STPPaymentCardTextFieldDelegate;
 @protocol STPCardFormViewDelegate;
 
-typedef NS_ENUM(NSUInteger, STPPaymentStatus);
+typedef NS_ENUM(NSInteger, STPPaymentStatus);
 
 // stripe_react_native-Swift.h also depends on these headers.
 #import <React/RCTBridgeModule.h>


### PR DESCRIPTION
## Summary
Align the forward declaration of `STPPaymentStatus` in `ios/StripeSwiftInterop.h` with the generated Swift header and the underlying Stripe iOS SDK type.

## Motivation
This is currently blocking iOS archive builds for our React Native mobile app.

The reason we hit it there is that our archive path does a clean native rebuild and reruns CocoaPods, which resolves Stripe iOS `25.7.x` through `stripe-react-native` `0.60.0`. In that configuration, `StripeSwiftInterop.h` declares `STPPaymentStatus` as `NSUInteger`, while the generated `stripe_react_native-Swift.h` emits it as `NSInteger` and the native Stripe iOS SDK defines it as `@objc public enum STPPaymentStatus: Int`.

That causes Xcode to fail while compiling the `stripe-react-native` pod with:

```
error: enumeration redeclared with different underlying type 'NSInteger' (was 'NSUInteger')
```

This change makes the handwritten forward declaration match the generated Swift header and the underlying native enum.

## Testing
- [ ] I tested this manually
- [ ] I added automated tests
- Not run locally; this is a header-only interop fix.

## Documentation
- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
