### PR TITLE
fix(android): guard PaymentSheetManager reuse across init modes

### DIFF
--- a/android/src/main/java/com/reactnativestripesdk/PaymentSheetManager.kt
+++ b/android/src/main/java/com/reactnativestripesdk/PaymentSheetManager.kt
@@ -75,6 +75,8 @@ class PaymentSheetManager(
   private val initPromise: Promise,
 ) : StripeUIManager(context),
   ConfirmCustomPaymentMethodCallback {
+  private val initializationShape =
+    determinePaymentSheetInitializationShape(arguments)
   private var paymentSheet: PaymentSheet? = null
   private var flowController: PaymentSheet.FlowController? = null
   private var paymentIntentClientSecret: String? = null
@@ -289,9 +291,18 @@ class PaymentSheetManager(
   }
 
   override fun onDestroy() {
+    super.onDestroy()
     flowController = null
     paymentSheet = null
   }
+
+  fun canReuse(params: ReadableMap): Boolean =
+    canReusePaymentSheetManager(
+      currentShape = initializationShape,
+      nextParams = params,
+      hasFlowController = flowController != null,
+      hasPaymentSheet = paymentSheet != null,
+    )
 
   fun configure(
     args: ReadableMap,
@@ -731,6 +742,53 @@ internal fun mapToPaymentMethodOptions(options: ReadableMap?): PaymentSheet.Inte
   } else {
     null
   }
+}
+
+internal enum class PaymentSheetIntentCallbackMode {
+  NONE,
+  PAYMENT_METHOD,
+  CONFIRMATION_TOKEN,
+}
+
+internal data class PaymentSheetInitializationShape(
+  val customFlow: Boolean,
+  val intentCallbackMode: PaymentSheetIntentCallbackMode,
+)
+
+internal fun canReusePaymentSheetManager(
+  currentShape: PaymentSheetInitializationShape,
+  nextParams: ReadableMap,
+  hasFlowController: Boolean,
+  hasPaymentSheet: Boolean,
+): Boolean {
+  val nextShape = determinePaymentSheetInitializationShape(nextParams)
+  if (currentShape != nextShape) {
+    return false
+  }
+
+  return if (currentShape.customFlow) {
+    hasFlowController
+  } else {
+    hasPaymentSheet
+  }
+}
+
+internal fun determinePaymentSheetInitializationShape(
+  params: ReadableMap,
+): PaymentSheetInitializationShape {
+  val intentConfiguration = params.getMap("intentConfiguration")
+  val intentCallbackMode =
+    when {
+      intentConfiguration == null -> PaymentSheetIntentCallbackMode.NONE
+      intentConfiguration.hasKey("confirmationTokenConfirmHandler") ->
+        PaymentSheetIntentCallbackMode.CONFIRMATION_TOKEN
+      else -> PaymentSheetIntentCallbackMode.PAYMENT_METHOD
+    }
+
+  return PaymentSheetInitializationShape(
+    customFlow = params.getBooleanOr("customFlow", false),
+    intentCallbackMode = intentCallbackMode,
+  )
 }
 
 internal fun handleFlowControllerConfigured(

--- a/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
+++ b/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
@@ -257,9 +257,10 @@ class StripeSdkModule(
     params: ReadableMap,
     promise: Promise,
   ) {
-    if (paymentSheetManager != null) {
+    if (paymentSheetManager?.canReuse(params) == true) {
       paymentSheetManager?.configure(params, promise)
     } else {
+      unregisterStripeUIManager(paymentSheetManager)
       paymentSheetManager =
         PaymentSheetManager(reactApplicationContext, params, promise).also {
           registerStripeUIManager(it)

--- a/android/src/test/java/com/reactnativestripesdk/PaymentSheetManagerTest.kt
+++ b/android/src/test/java/com/reactnativestripesdk/PaymentSheetManagerTest.kt
@@ -590,4 +590,150 @@ class PaymentSheetManagerTest {
     assertNotNull(resolved)
     assertTrue(!resolved.hasKey("error"))
   }
+
+  @Test
+  fun determinePaymentSheetInitializationShape_UsesPaymentMethodCallbackModeForDeferredIntent() {
+    val params =
+      readableMapOf(
+        "customFlow" to true,
+        "intentConfiguration" to readableMapOf(),
+      )
+
+    val shape = determinePaymentSheetInitializationShape(params)
+
+    assertEquals(
+      PaymentSheetInitializationShape(
+        customFlow = true,
+        intentCallbackMode = PaymentSheetIntentCallbackMode.PAYMENT_METHOD,
+      ),
+      shape,
+    )
+  }
+
+  @Test
+  fun determinePaymentSheetInitializationShape_UsesConfirmationTokenCallbackMode() {
+    val params =
+      readableMapOf(
+        "intentConfiguration" to
+          readableMapOf(
+            "confirmationTokenConfirmHandler" to true,
+          ),
+      )
+
+    val shape = determinePaymentSheetInitializationShape(params)
+
+    assertEquals(
+      PaymentSheetInitializationShape(
+        customFlow = false,
+        intentCallbackMode = PaymentSheetIntentCallbackMode.CONFIRMATION_TOKEN,
+      ),
+      shape,
+    )
+  }
+
+  @Test
+  fun determinePaymentSheetInitializationShape_DiffersWhenSwitchingFromCustomFlowToStandardFlow() {
+    val manualChargeParams =
+      readableMapOf(
+        "customFlow" to true,
+        "intentConfiguration" to readableMapOf(),
+      )
+    val addCardParams =
+      readableMapOf(
+        "customFlow" to false,
+        "intentConfiguration" to readableMapOf(),
+      )
+
+    val manualChargeShape = determinePaymentSheetInitializationShape(manualChargeParams)
+    val addCardShape = determinePaymentSheetInitializationShape(addCardParams)
+
+    assertTrue(manualChargeShape != addCardShape)
+  }
+
+  @Test
+  fun determinePaymentSheetInitializationShape_DiffersWhenSwitchingFromDeferredToImmediateIntent() {
+    val deferredIntentParams =
+      readableMapOf(
+        "intentConfiguration" to readableMapOf(),
+      )
+    val immediateIntentParams =
+      readableMapOf(
+        "paymentIntentClientSecret" to "pi_123_secret_456",
+      )
+
+    val deferredIntentShape = determinePaymentSheetInitializationShape(deferredIntentParams)
+    val immediateIntentShape = determinePaymentSheetInitializationShape(immediateIntentParams)
+
+    assertTrue(deferredIntentShape != immediateIntentShape)
+  }
+
+  @Test
+  fun canReusePaymentSheetManager_ReturnsFalse_WhenStandardFlowManagerHasNoPaymentSheet() {
+    val currentShape =
+      PaymentSheetInitializationShape(
+        customFlow = false,
+        intentCallbackMode = PaymentSheetIntentCallbackMode.PAYMENT_METHOD,
+      )
+    val nextParams =
+      readableMapOf(
+        "intentConfiguration" to readableMapOf(),
+      )
+
+    val canReuse =
+      canReusePaymentSheetManager(
+        currentShape = currentShape,
+        nextParams = nextParams,
+        hasFlowController = false,
+        hasPaymentSheet = false,
+      )
+
+    assertTrue(!canReuse)
+  }
+
+  @Test
+  fun canReusePaymentSheetManager_ReturnsFalse_WhenCustomFlowManagerHasNoFlowController() {
+    val currentShape =
+      PaymentSheetInitializationShape(
+        customFlow = true,
+        intentCallbackMode = PaymentSheetIntentCallbackMode.PAYMENT_METHOD,
+      )
+    val nextParams =
+      readableMapOf(
+        "customFlow" to true,
+        "intentConfiguration" to readableMapOf(),
+      )
+
+    val canReuse =
+      canReusePaymentSheetManager(
+        currentShape = currentShape,
+        nextParams = nextParams,
+        hasFlowController = false,
+        hasPaymentSheet = false,
+      )
+
+    assertTrue(!canReuse)
+  }
+
+  @Test
+  fun canReusePaymentSheetManager_ReturnsTrue_WhenShapeMatchesAndRequiredStateExists() {
+    val currentShape =
+      PaymentSheetInitializationShape(
+        customFlow = false,
+        intentCallbackMode = PaymentSheetIntentCallbackMode.NONE,
+      )
+    val nextParams =
+      readableMapOf(
+        "paymentIntentClientSecret" to "pi_123_secret_456",
+      )
+
+    val canReuse =
+      canReusePaymentSheetManager(
+        currentShape = currentShape,
+        nextParams = nextParams,
+        hasFlowController = false,
+        hasPaymentSheet = true,
+      )
+
+    assertTrue(canReuse)
+  }
 }


### PR DESCRIPTION
## Summary
- only reuse the existing Android `PaymentSheetManager` when the next `initPaymentSheet` call matches the same native initialization shape and the required native object already exists
- recreate the manager when switching between `customFlow` and standard flow, or between deferred callback modes that require different native wiring
- restore `StripeUIManager` cleanup on `PaymentSheetManager` destroy and add regression tests for the reuse guard

## Motivation
The March 23 refactor in `e4aca8f` changed Android `initPaymentSheet` from always recreating `PaymentSheetManager` to always reusing it. That helped some repeated-init cases, but it also introduced a few regressions:

1. Switching from a deferred `customFlow` payment sheet to a deferred standard payment sheet reuses a manager that was built around a `FlowController`, so later standard-flow calls can end up presenting the wrong native object. This is the bug we hit in Dashboard mobile when a manual charge is created first and the user then tries to add a card on file from customer details.
2. If a previous `initPaymentSheet` call failed before creating `paymentSheet` / `flowController`, a same-shape retry reuses the half-initialized manager instead of rebuilding it. The retry can then fail later with missing-init behavior even though JS called `initPaymentSheet` again.
3. `PaymentSheetManager.onDestroy()` no longer called `super.onDestroy()`, so the `UnregisterSignal` cleanup from `StripeUIManager` stopped running when the manager was replaced.

This change keeps the refactor's reuse behavior for safe same-shape reconfiguration, but falls back to recreation when reuse would be invalid or the cached manager never finished initialization.

## Testing
- [ ] I tested this manually
- [x] I added automated tests

Automated:
- `ANDROID_HOME=/Users/asendra/Library/Android/sdk ANDROID_SDK_ROOT=/Users/asendra/Library/Android/sdk ./gradlew :stripe_stripe-react-native:testDebugUnitTest --tests com.reactnativestripesdk.PaymentSheetManagerTest`

## Documentation

Select one:
- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
