### PR TITLE
propose 0.61.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 - Updated Stripe iOS SDK from 25.7.+ to 25.9.+.
 - Updated Stripe Android SDK from 23.0.+ to 23.1.+.
 
+**Fixes**
+* [Fixed] Enum type mismatch that caused iOS build failures on Xcode 26+. ([#2357](https://github.com/stripe/stripe-react-native/issues/2357))
+
 ## 0.60.0 - 2026-03-23
 **Changes**
 - Updated Stripe Android SDK from 22.8.+ to 23.0.+. See our [migration guide](https://github.com/stripe/stripe-android/blob/master/MIGRATING.md#migrating-from-versions--2300) for more information.


### PR DESCRIPTION
- [x] Ensure the CHANGELOG is up to date with all relevant commits since the last release
- [x] Add the version number for this release & the date to the CHANGELOG, underneath "## Unreleased" 
  - e.g. "## 1.2.3 - 2022-02-14"
- [x] Update the README if necessary (this is only required when there are breaking changes in the release, such as dropping support for an iOS || Android version)