### PR TITLE
StripeCryptoOnramp: ContentOnPrimary Fix

### DIFF
--- a/ios/Mappers.swift
+++ b/ios/Mappers.swift
@@ -1214,7 +1214,7 @@ class Mappers {
             darkContentOnPrimary ?? lightContentOnPrimary
         }
 
-        let colors: LinkAppearance.Colors? = if primary != nil || selectedBorder != nil {
+        let colors: LinkAppearance.Colors? = if primary != nil || selectedBorder != nil || contentOnPrimary != nil {
             .init(primary: primary, contentOnPrimary: contentOnPrimary, selectedBorder: selectedBorder)
         } else {
             nil


### PR DESCRIPTION
## Summary
Fixes an issue where `contentOnPrimary` was not a valid appearance customization for iOS on CryptoOnramp. This makes use of the already existing `contentOnPrimary` flag in RN that can be set, but has no function on iOS.

## Motivation
Matching customization options from Android.

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [ ] I added automated tests
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

1. Launch the app.
2. Login.
3. Collect Payment. Make sure the text on the button matches the `contentOnPrimary` setting.
4. Change the `contentOnPrimary` color, make sure it's reflected in the app.
5. Test on light and dark mode.

<img width="400" height="2868" alt="Simulator Screenshot - iPhone 16 Pro Max - 2026-03-30 at 11 27 45" src="https://github.com/user-attachments/assets/66c771f0-3db1-42cc-ac00-4e67cda036f7" />


## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
