### PR TITLE
ios: fix 'occured' -> 'occurred' typo in Unhandled error message

### DIFF
--- a/ios/StripeSdkImpl.swift
+++ b/ios/StripeSdkImpl.swift
@@ -629,7 +629,7 @@ public class StripeSdkImpl: NSObject, UIAdaptivePresentationControllerDelegate {
                 }
             }
         } else {
-            resolve(Errors.createError(ErrorType.Unknown, "Unhandled error occured"))
+            resolve(Errors.createError(ErrorType.Unknown, "Unhandled error occurred"))
         }
     }
 


### PR DESCRIPTION
`Errors.createError` fallback in `ios/StripeSdkImpl.swift:632` read `Unhandled error occured`. String-literal-only change.