### PR TITLE
Add React Native analytics (react_native_version and react_native_is_…

### DIFF
--- a/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
+++ b/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
@@ -60,6 +60,7 @@ import com.stripe.android.PaymentConfiguration
 import com.stripe.android.Stripe
 import com.stripe.android.core.ApiVersion
 import com.stripe.android.core.AppInfo
+import com.stripe.android.core.reactnative.ReactNativeAnalytics
 import com.stripe.android.core.reactnative.ReactNativeSdkInternal
 import com.stripe.android.customersheet.CustomerSheet
 import com.stripe.android.googlepaylauncher.GooglePayLauncher
@@ -251,6 +252,12 @@ class StripeSdkModule(
     stripe = Stripe(reactApplicationContext, publishableKey, stripeAccountId)
 
     PaymentConfiguration.init(reactApplicationContext, publishableKey, stripeAccountId)
+
+    ReactNativeAnalytics.isNewArchitecture = BuildConfig.IS_NEW_ARCHITECTURE_ENABLED
+    ReactNativeAnalytics.reactNativeVersion =
+      with(ReactNativeVersion.VERSION) {
+        "${get("major")}.${get("minor")}.${get("patch")}"
+      }
 
     preventActivityRecreation()
     setupComposeCompatView()

--- a/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
+++ b/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
@@ -224,6 +224,7 @@ class StripeSdkModule(
     )
   }
 
+  @SuppressLint("RestrictedApi")
   @ReactMethod
   override fun initialise(
     params: ReadableMap,
@@ -258,7 +259,6 @@ class StripeSdkModule(
       with(ReactNativeVersion.VERSION) {
         "${get("major")}.${get("minor")}.${get("patch")}"
       }
-
     preventActivityRecreation()
     setupComposeCompatView()
 


### PR DESCRIPTION
…new_architecture) for Android too

## Summary
Follow up to https://github.com/stripe/stripe-react-native/pull/2389

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [ ] I added automated tests
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

```
Log.d(TAG, "ReactNativeAnalytics: isNewArchitecture=${ReactNativeAnalytics.isNewArchitecture}, reactNativeVersion=${ReactNativeAnalytics.reactNativeVersion}")

...

[I] yuki@st-yuki5 ~/s/y/send-new-arch-in-analytics (yuki/send-new-arch-in-analytics-android)> adb logcat -s StripeSdkModule
--------- beginning of main
04-16 14:59:29.054  2755  2802 D StripeSdkModule: ReactNativeAnalytics: isNewArchitecture=true, reactNativeVersion=0.81.5
```



## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
