### PR TITLE
chore: Update swiftlint to match stripe-ios

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,5 +1,8 @@
 # .swiftlint.yml
 #
+# Keep in sync with stripe-ios/.swiftlint.yml
+# (excluded paths and custom_rules may differ)
+#
 # Goals:
 #   - Decrease number of `disabled_rules` that we agree with as a team
 #   - Increase number of `opt_in_rules` that we agree with as a team
@@ -13,7 +16,7 @@ disabled_rules:
   - file_length
   - force_cast
   - function_body_length # Interesting overlap between these violations and cyclomatic_complexity
-  - function_name_whitespace
+  - operator_whitespace
   - todo
   - type_body_length
   - void_function_in_ternary
@@ -99,3 +102,12 @@ trailing_comma:
 
 generic_type_name:
   max_length: 30 # Maybe remove after initial cleanup.
+
+custom_rules:
+  no_async_let:
+    name: "async let is banned"
+    message: "async let crashes in Xcode 26.4. Do not use async let until Xcode 27 is required (May 2027)."
+    regex: '(?<=async )let\b'
+    match_kinds:
+      - keyword
+    severity: error


### PR DESCRIPTION
## Summary
.

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [ ] I added automated tests
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->
```
[I] yuki@st-yuki5 ~/s/stripe-react-native (yuki/match-swiftlint)> diff .swiftlint.yml ~/stripe/stripe-ios/.swiftlint.yml
3,5d2
< # Keep in sync with stripe-ios/.swiftlint.yml
< # (excluded paths and custom_rules may differ)
< #
15c12
<   - cyclomatic_complexity # This finds some hairy methods
---
>   - cyclomatic_complexity       # This finds some hairy methods
18c15
<   - function_body_length # Interesting overlap between these violations and cyclomatic_complexity
---
>   - function_body_length        # Interesting overlap between these violations and cyclomatic_complexity
35c32
<   - for_where
---
>   - for_where
73,74c70,75
<   - ios/Pods
<   - ios/build*
---
>   - Package.swift
>   - Pods
>   - Tests/installation_tests
>   - vendor
>   - build*
>   - .build
83c84
<   warning: 4 # It would be nice to lower this number
---
>   warning: 4                # It would be nice to lower this number
104c105
<   max_length: 30 # Maybe remove after initial cleanup.
---
>   max_length: 30          # Maybe remove after initial cleanup.
106a108,122
>   enum_safe_decodable:
>     name: "Use SafeEnumDecodable for enums"
>     message: "Enums in API Bindings should conform to SafeEnumDecodable or SafeEnumCodable instead of Decodable or Codable to handle unknown values gracefully."
>     regex: 'enum\s+(?!CodingKeys)\w+\s*(<[^>]*>)?\s*:\s*[^{]*(?<!SafeEnum)(Decodable|Codable)\b(?!Key)'
>     severity: error
>     included:
>       - "StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/"
>   no_shared_api_client_mutation_in_tests:
>     name: "Don't use STPAPIClient.shared in tests"
>     message: "Avoid setting STPAPIClient.shared.publishableKey in tests. Create a dedicated STPAPIClient instance instead to prevent test pollution. Note also that it's valid for merchants to pass their own instance of STPAPIClient and *not* use STPAPIClient.shared."
>     regex: 'STPAPIClient\.shared\.publishableKey\s*='
>     severity: warning
>     included:
>       - ".*Tests\\.swift$"
>       - ".*Tests/"
```

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
