### PR TITLE
fix: handle network errors in retrievePaymentIntent and retrieveSetupIntent on Android

### DIFF
--- a/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
+++ b/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
@@ -32,6 +32,8 @@ import com.reactnativestripesdk.pushprovisioning.PushProvisioningProxy
 import com.reactnativestripesdk.utils.ConfirmPaymentErrorType
 import com.reactnativestripesdk.utils.CreateTokenErrorType
 import com.reactnativestripesdk.utils.ErrorType
+import com.reactnativestripesdk.utils.RetrievePaymentIntentErrorType
+import com.reactnativestripesdk.utils.RetrieveSetupIntentErrorType
 import com.reactnativestripesdk.utils.GooglePayErrorType
 import com.reactnativestripesdk.utils.StripeUIManager
 import com.reactnativestripesdk.utils.createCanAddCardResult
@@ -696,8 +698,12 @@ class StripeSdkModule(
     promise: Promise,
   ) {
     CoroutineScope(Dispatchers.IO).launch {
-      val paymentIntent = stripe.retrievePaymentIntentSynchronous(clientSecret)
-      promise.resolve(createResult("paymentIntent", mapFromPaymentIntentResult(paymentIntent)))
+      try {
+        val paymentIntent = stripe.retrievePaymentIntentSynchronous(clientSecret)
+        promise.resolve(createResult("paymentIntent", mapFromPaymentIntentResult(paymentIntent)))
+      } catch (e: Exception) {
+        promise.resolve(createError(RetrievePaymentIntentErrorType.Unknown.toString(), e))
+      }
     }
   }
 
@@ -707,8 +713,12 @@ class StripeSdkModule(
     promise: Promise,
   ) {
     CoroutineScope(Dispatchers.IO).launch {
-      val setupIntent = stripe.retrieveSetupIntentSynchronous(clientSecret)
-      promise.resolve(createResult("setupIntent", mapFromSetupIntentResult(setupIntent)))
+      try {
+        val setupIntent = stripe.retrieveSetupIntentSynchronous(clientSecret)
+        promise.resolve(createResult("setupIntent", mapFromSetupIntentResult(setupIntent)))
+      } catch (e: Exception) {
+        promise.resolve(createError(RetrieveSetupIntentErrorType.Unknown.toString(), e))
+      }
     }
   }
 

--- a/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
+++ b/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
@@ -32,9 +32,9 @@ import com.reactnativestripesdk.pushprovisioning.PushProvisioningProxy
 import com.reactnativestripesdk.utils.ConfirmPaymentErrorType
 import com.reactnativestripesdk.utils.CreateTokenErrorType
 import com.reactnativestripesdk.utils.ErrorType
+import com.reactnativestripesdk.utils.GooglePayErrorType
 import com.reactnativestripesdk.utils.RetrievePaymentIntentErrorType
 import com.reactnativestripesdk.utils.RetrieveSetupIntentErrorType
-import com.reactnativestripesdk.utils.GooglePayErrorType
 import com.reactnativestripesdk.utils.StripeUIManager
 import com.reactnativestripesdk.utils.createCanAddCardResult
 import com.reactnativestripesdk.utils.createError


### PR DESCRIPTION
## Summary
- Fixes a crash when `retrievePaymentIntent` or `retrieveSetupIntent` is called with no network connectivity on Android
- Wraps the synchronous Stripe SDK calls in try-catch blocks so `APIConnectionException` (and other network errors) are returned as error results to JS instead of crashing the app

## Motivation
Fixes #2332.

The `confirmPayment` flow involves two network calls:

```
JS: confirmPayment(clientSecret, params)
 │
 ├─ 1. Confirm (POST /v1/payment_intents/:id/confirm)
 │     Handled by PaymentLauncher (native SDK)
 │     ✅ Errors map to PaymentResult.Failed → returned to JS
 │
 └─ 2. Retrieve (GET /v1/payment_intents/:id)
       Called after confirm succeeds, to get the final intent state
       PaymentLauncherManager.retrievePaymentIntent() uses async callback API
       ✅ Errors handled via ApiResultCallback.onError
```

Both paths in `confirmPayment` are safe. However, the SDK also exposes `retrievePaymentIntent` and `retrieveSetupIntent` as standalone JS functions. These go through `StripeSdkModule`, which calls the **synchronous** Stripe SDK variants inside an unprotected coroutine:

```
JS: retrievePaymentIntent(clientSecret)
 │
 └─▶ StripeSdkModule.retrievePaymentIntent()
       └─▶ CoroutineScope(Dispatchers.IO).launch {          ← no try-catch ❌
             stripe.retrievePaymentIntentSynchronous()
               └─▶ throws APIConnectionException on network failure
                     └─▶ UncaughtExceptionHandler → 💥 crash
       }
```

This matches the reported stacktrace. The fix adds try-catch to these two methods, consistent with how other synchronous calls in the same file are handled (e.g. `createCardTokenSynchronous`, `createPiiTokenSynchronous`). The iOS side already handles this correctly via callback-based error handling.

## Test plan
- [ ] Enable airplane mode on Android device/emulator
- [ ] Call `retrievePaymentIntent` with a valid client secret — should return an error object instead of crashing
- [ ] Call `retrieveSetupIntent` with a valid client secret — should return an error object instead of crashing
- [ ] Verify normal (online) payment flows still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)