### PR TITLE
Add JS layer for Checkout SDK

### DIFF
--- a/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
+++ b/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
@@ -1717,7 +1717,12 @@ class StripeSdkModule(
     promise.reject("NotImplemented", "Checkout is not yet implemented on Android")
   }
 
-  override fun checkoutUpdateLineItemQuantity(sessionKey: String, lineItemId: String, quantity: Double, promise: Promise) {
+  override fun checkoutUpdateLineItemQuantity(
+    sessionKey: String,
+    lineItemId: String,
+    quantity: Double,
+    promise: Promise,
+  ) {
     promise.reject("NotImplemented", "Checkout is not yet implemented on Android")
   }
 

--- a/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
+++ b/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
@@ -1717,7 +1717,7 @@ class StripeSdkModule(
     promise.reject("NotImplemented", "Checkout is not yet implemented on Android")
   }
 
-  override fun checkoutUpdateLineItemQuantity(sessionKey: String, params: ReadableMap, promise: Promise) {
+  override fun checkoutUpdateLineItemQuantity(sessionKey: String, lineItemId: String, quantity: Double, promise: Promise) {
     promise.reject("NotImplemented", "Checkout is not yet implemented on Android")
   }
 
@@ -1725,7 +1725,7 @@ class StripeSdkModule(
     promise.reject("NotImplemented", "Checkout is not yet implemented on Android")
   }
 
-  override fun checkoutUpdateTaxId(sessionKey: String, params: ReadableMap, promise: Promise) {
+  override fun checkoutUpdateTaxId(sessionKey: String, type: String, value: String, promise: Promise) {
     promise.reject("NotImplemented", "Checkout is not yet implemented on Android")
   }
 

--- a/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
+++ b/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
@@ -1701,11 +1701,23 @@ class StripeSdkModule(
     promise.reject("NotImplemented", "Checkout is not yet implemented on Android")
   }
 
-  override fun checkoutUpdateShippingAddress(sessionKey: String, params: ReadableMap, promise: Promise) {
+  override fun checkoutUpdateShippingAddress(
+    sessionKey: String,
+    address: ReadableMap,
+    name: String?,
+    phone: String?,
+    promise: Promise,
+  ) {
     promise.reject("NotImplemented", "Checkout is not yet implemented on Android")
   }
 
-  override fun checkoutUpdateBillingAddress(sessionKey: String, params: ReadableMap, promise: Promise) {
+  override fun checkoutUpdateBillingAddress(
+    sessionKey: String,
+    address: ReadableMap,
+    name: String?,
+    phone: String?,
+    promise: Promise,
+  ) {
     promise.reject("NotImplemented", "Checkout is not yet implemented on Android")
   }
 

--- a/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
+++ b/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
@@ -1695,6 +1695,44 @@ class StripeSdkModule(
     // noop, iOS only.
   }
 
+  // Checkout Session stubs — real implementations in a future PR.
+
+  override fun initCheckoutSession(clientSecret: String, configuration: ReadableMap, promise: Promise) {
+    promise.reject("NotImplemented", "Checkout is not yet implemented on Android")
+  }
+
+  override fun checkoutUpdateShippingAddress(sessionKey: String, params: ReadableMap, promise: Promise) {
+    promise.reject("NotImplemented", "Checkout is not yet implemented on Android")
+  }
+
+  override fun checkoutUpdateBillingAddress(sessionKey: String, params: ReadableMap, promise: Promise) {
+    promise.reject("NotImplemented", "Checkout is not yet implemented on Android")
+  }
+
+  override fun checkoutApplyPromotionCode(sessionKey: String, code: String, promise: Promise) {
+    promise.reject("NotImplemented", "Checkout is not yet implemented on Android")
+  }
+
+  override fun checkoutRemovePromotionCode(sessionKey: String, promise: Promise) {
+    promise.reject("NotImplemented", "Checkout is not yet implemented on Android")
+  }
+
+  override fun checkoutUpdateLineItemQuantity(sessionKey: String, params: ReadableMap, promise: Promise) {
+    promise.reject("NotImplemented", "Checkout is not yet implemented on Android")
+  }
+
+  override fun checkoutSelectShippingOption(sessionKey: String, id: String, promise: Promise) {
+    promise.reject("NotImplemented", "Checkout is not yet implemented on Android")
+  }
+
+  override fun checkoutUpdateTaxId(sessionKey: String, params: ReadableMap, promise: Promise) {
+    promise.reject("NotImplemented", "Checkout is not yet implemented on Android")
+  }
+
+  override fun checkoutRefresh(sessionKey: String, promise: Promise) {
+    promise.reject("NotImplemented", "Checkout is not yet implemented on Android")
+  }
+
   /**
    * Safely get and cast the current activity as an AppCompatActivity. If that fails, the promise
    * provided will be resolved with an error message instructing the user to retry the method.

--- a/android/src/oldarch/java/com/reactnativestripesdk/NativeStripeSdkModuleSpec.java
+++ b/android/src/oldarch/java/com/reactnativestripesdk/NativeStripeSdkModuleSpec.java
@@ -295,6 +295,42 @@ public abstract class NativeStripeSdkModuleSpec extends ReactContextBaseJavaModu
 
   @ReactMethod
   @DoNotStrip
+  public abstract void initCheckoutSession(String clientSecret, ReadableMap configuration, Promise promise);
+
+  @ReactMethod
+  @DoNotStrip
+  public abstract void checkoutUpdateShippingAddress(String sessionKey, ReadableMap params, Promise promise);
+
+  @ReactMethod
+  @DoNotStrip
+  public abstract void checkoutUpdateBillingAddress(String sessionKey, ReadableMap params, Promise promise);
+
+  @ReactMethod
+  @DoNotStrip
+  public abstract void checkoutApplyPromotionCode(String sessionKey, String code, Promise promise);
+
+  @ReactMethod
+  @DoNotStrip
+  public abstract void checkoutRemovePromotionCode(String sessionKey, Promise promise);
+
+  @ReactMethod
+  @DoNotStrip
+  public abstract void checkoutUpdateLineItemQuantity(String sessionKey, ReadableMap params, Promise promise);
+
+  @ReactMethod
+  @DoNotStrip
+  public abstract void checkoutSelectShippingOption(String sessionKey, String id, Promise promise);
+
+  @ReactMethod
+  @DoNotStrip
+  public abstract void checkoutUpdateTaxId(String sessionKey, ReadableMap params, Promise promise);
+
+  @ReactMethod
+  @DoNotStrip
+  public abstract void checkoutRefresh(String sessionKey, Promise promise);
+
+  @ReactMethod
+  @DoNotStrip
   public abstract void addListener(String eventType);
 
   @ReactMethod

--- a/android/src/oldarch/java/com/reactnativestripesdk/NativeStripeSdkModuleSpec.java
+++ b/android/src/oldarch/java/com/reactnativestripesdk/NativeStripeSdkModuleSpec.java
@@ -315,7 +315,7 @@ public abstract class NativeStripeSdkModuleSpec extends ReactContextBaseJavaModu
 
   @ReactMethod
   @DoNotStrip
-  public abstract void checkoutUpdateLineItemQuantity(String sessionKey, ReadableMap params, Promise promise);
+  public abstract void checkoutUpdateLineItemQuantity(String sessionKey, String lineItemId, double quantity, Promise promise);
 
   @ReactMethod
   @DoNotStrip
@@ -323,7 +323,7 @@ public abstract class NativeStripeSdkModuleSpec extends ReactContextBaseJavaModu
 
   @ReactMethod
   @DoNotStrip
-  public abstract void checkoutUpdateTaxId(String sessionKey, ReadableMap params, Promise promise);
+  public abstract void checkoutUpdateTaxId(String sessionKey, String type, String value, Promise promise);
 
   @ReactMethod
   @DoNotStrip

--- a/android/src/oldarch/java/com/reactnativestripesdk/NativeStripeSdkModuleSpec.java
+++ b/android/src/oldarch/java/com/reactnativestripesdk/NativeStripeSdkModuleSpec.java
@@ -299,11 +299,11 @@ public abstract class NativeStripeSdkModuleSpec extends ReactContextBaseJavaModu
 
   @ReactMethod
   @DoNotStrip
-  public abstract void checkoutUpdateShippingAddress(String sessionKey, ReadableMap params, Promise promise);
+  public abstract void checkoutUpdateShippingAddress(String sessionKey, ReadableMap address, @Nullable String name, @Nullable String phone, Promise promise);
 
   @ReactMethod
   @DoNotStrip
-  public abstract void checkoutUpdateBillingAddress(String sessionKey, ReadableMap params, Promise promise);
+  public abstract void checkoutUpdateBillingAddress(String sessionKey, ReadableMap address, @Nullable String name, @Nullable String phone, Promise promise);
 
   @ReactMethod
   @DoNotStrip

--- a/src/hooks/useCheckout.tsx
+++ b/src/hooks/useCheckout.tsx
@@ -1,0 +1,152 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import NativeStripeSdk from '../specs/NativeStripeSdkModule';
+import type { Checkout } from '../types/Checkout';
+
+/**
+ * Initializes a Stripe Checkout Session and returns a reactive handle.
+ *
+ * The session is fetched from Stripe when the hook mounts. `state` is `null`
+ * until the initial load completes, then transitions between `loaded` and
+ * `loading` as mutations are performed.
+ *
+ * Pass the returned `checkout` to `initPaymentSheet` to complete the purchase.
+ *
+ * @checkoutSessionsPreview
+ */
+export function useCheckout(
+  clientSecret: string,
+  configuration?: Checkout.Configuration
+): {
+  /** The current loading state of the checkout session. `null` until the initial load completes. */
+  state: Checkout.State | null;
+  /** A handle to the session with methods for mutations. */
+  checkout: Checkout;
+  /** Set if the initial session load fails. Undefined otherwise. */
+  error?: Checkout.Error;
+} {
+  const [state, setState] = useState<Checkout.State | null>(null);
+  const [error, setError] = useState<Checkout.Error | undefined>(undefined);
+
+  // Ref so mutation callbacks don't need it as a dependency.
+  const sessionKeyRef = useRef<string | null>(null);
+
+  // Load session on mount / clientSecret change.
+  useEffect(() => {
+    let cancelled = false;
+    sessionKeyRef.current = null;
+    setState(null);
+    setError(undefined);
+
+    (async () => {
+      try {
+        const result = await NativeStripeSdk.initCheckoutSession(
+          clientSecret,
+          configuration ?? {}
+        );
+        if (cancelled) return;
+        sessionKeyRef.current = result.sessionKey;
+        setState(result.state);
+      } catch (e: any) {
+        if (cancelled) return;
+        setError({
+          code: e.code ?? 'Failed',
+          message: e.message ?? 'Failed to initialize checkout session',
+        });
+      }
+    })();
+
+    // Ignore in-flight init if unmounted or clientSecret changed.
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [clientSecret]);
+
+  // Sets `loading`, calls native, applies returned state. Reverts on error.
+  const withLoading = useCallback(
+    async (fn: (sessionKey: string) => Promise<Checkout.State>) => {
+      const key = sessionKeyRef.current;
+      if (!key) {
+        throw { code: 'Failed', message: 'Checkout session not initialized.' };
+      }
+
+      setState((prev) =>
+        prev ? { status: 'loading', session: prev.session } : prev
+      );
+
+      try {
+        const newState = await fn(key);
+        setState(newState);
+      } catch (e: any) {
+        setState((prev) =>
+          prev?.status === 'loading'
+            ? { status: 'loaded', session: prev.session }
+            : prev
+        );
+        throw e;
+      }
+    },
+    []
+  );
+
+  // Mutation methods — each delegates to withLoading.
+  const checkout: Checkout = {
+    get sessionKey(): string {
+      if (!sessionKeyRef.current) {
+        throw new Error('Checkout session not initialized.');
+      }
+      return sessionKeyRef.current;
+    },
+    updateShippingAddress: useCallback(
+      (params) =>
+        withLoading((key) =>
+          NativeStripeSdk.checkoutUpdateShippingAddress(key, params)
+        ),
+      [withLoading]
+    ),
+    updateBillingAddress: useCallback(
+      (params) =>
+        withLoading((key) =>
+          NativeStripeSdk.checkoutUpdateBillingAddress(key, params)
+        ),
+      [withLoading]
+    ),
+    applyPromotionCode: useCallback(
+      (code) =>
+        withLoading((key) =>
+          NativeStripeSdk.checkoutApplyPromotionCode(key, code)
+        ),
+      [withLoading]
+    ),
+    removePromotionCode: useCallback(
+      () =>
+        withLoading((key) => NativeStripeSdk.checkoutRemovePromotionCode(key)),
+      [withLoading]
+    ),
+    updateLineItemQuantity: useCallback(
+      (params) =>
+        withLoading((key) =>
+          NativeStripeSdk.checkoutUpdateLineItemQuantity(key, params)
+        ),
+      [withLoading]
+    ),
+    selectShippingOption: useCallback(
+      (id) =>
+        withLoading((key) =>
+          NativeStripeSdk.checkoutSelectShippingOption(key, id)
+        ),
+      [withLoading]
+    ),
+    updateTaxId: useCallback(
+      (params) =>
+        withLoading((key) => NativeStripeSdk.checkoutUpdateTaxId(key, params)),
+      [withLoading]
+    ),
+    refresh: useCallback(
+      () => withLoading((key) => NativeStripeSdk.checkoutRefresh(key)),
+      [withLoading]
+    ),
+  };
+
+  return { state, checkout, error };
+}

--- a/src/hooks/useCheckout.tsx
+++ b/src/hooks/useCheckout.tsx
@@ -98,16 +98,26 @@ export function useCheckout(
       return sessionKeyRef.current;
     },
     updateShippingAddress: useCallback(
-      (params) =>
+      (address, name, phone) =>
         withLoading((key) =>
-          NativeStripeSdk.checkoutUpdateShippingAddress(key, params)
+          NativeStripeSdk.checkoutUpdateShippingAddress(
+            key,
+            address,
+            name ?? null,
+            phone ?? null
+          )
         ),
       [withLoading]
     ),
     updateBillingAddress: useCallback(
-      (params) =>
+      (address, name, phone) =>
         withLoading((key) =>
-          NativeStripeSdk.checkoutUpdateBillingAddress(key, params)
+          NativeStripeSdk.checkoutUpdateBillingAddress(
+            key,
+            address,
+            name ?? null,
+            phone ?? null
+          )
         ),
       [withLoading]
     ),

--- a/src/hooks/useCheckout.tsx
+++ b/src/hooks/useCheckout.tsx
@@ -124,9 +124,13 @@ export function useCheckout(
       [withLoading]
     ),
     updateLineItemQuantity: useCallback(
-      (params) =>
+      (lineItemId, quantity) =>
         withLoading((key) =>
-          NativeStripeSdk.checkoutUpdateLineItemQuantity(key, params)
+          NativeStripeSdk.checkoutUpdateLineItemQuantity(
+            key,
+            lineItemId,
+            quantity
+          )
         ),
       [withLoading]
     ),
@@ -138,8 +142,10 @@ export function useCheckout(
       [withLoading]
     ),
     updateTaxId: useCallback(
-      (params) =>
-        withLoading((key) => NativeStripeSdk.checkoutUpdateTaxId(key, params)),
+      (type, value) =>
+        withLoading((key) =>
+          NativeStripeSdk.checkoutUpdateTaxId(key, type, value)
+        ),
       [withLoading]
     ),
     refresh: useCallback(

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,6 +6,7 @@ export { usePlatformPay } from './hooks/usePlatformPay';
 export { usePaymentSheet } from './hooks/usePaymentSheet';
 export { useFinancialConnectionsSheet } from './hooks/useFinancialConnectionsSheet';
 export { useOnramp } from './hooks/useOnramp';
+export { useCheckout } from './hooks/useCheckout';
 
 //components
 export { initStripe, StripeProvider } from './components/StripeProvider';
@@ -35,6 +36,7 @@ export type { Props as CustomerSheetProps } from './components/CustomerSheet';
 export * from './types/EmbeddedPaymentElement';
 export * from './types/PaymentSheet';
 export * from './types/ConfirmationToken';
+export * from './types/Checkout';
 
 export * from './types/components/PaymentMethodMessagingElementComponent';
 export type { Props as PaymentMethodMessagingElementProps } from './components/PaymentMethodMessagingElement';

--- a/src/specs/NativeStripeSdkModule.ts
+++ b/src/specs/NativeStripeSdkModule.ts
@@ -236,7 +236,8 @@ export interface Spec extends TurboModule {
 
   checkoutUpdateLineItemQuantity(
     sessionKey: string,
-    params: UnsafeObject<Checkout.LineItemUpdate>
+    lineItemId: string,
+    quantity: number
   ): Promise<UnsafeObject<Checkout.State>>;
 
   checkoutSelectShippingOption(
@@ -246,7 +247,8 @@ export interface Spec extends TurboModule {
 
   checkoutUpdateTaxId(
     sessionKey: string,
-    params: UnsafeObject<Checkout.TaxIdUpdate>
+    type: string,
+    value: string
   ): Promise<UnsafeObject<Checkout.State>>;
 
   checkoutRefresh(sessionKey: string): Promise<UnsafeObject<Checkout.State>>;

--- a/src/specs/NativeStripeSdkModule.ts
+++ b/src/specs/NativeStripeSdkModule.ts
@@ -36,6 +36,7 @@ import type {
   VerifyMicrodepositsParams,
   CreateRadarSessionResult,
 } from '../types';
+import type { Checkout } from '../types/Checkout';
 import type {
   EmbeddedPaymentElementConfiguration,
   EmbeddedPaymentElementResult,
@@ -206,6 +207,49 @@ export interface Spec extends TurboModule {
   ): Promise<void>;
   clearEmbeddedPaymentOption(viewTag: Int32): Promise<void>;
   createRadarSession(): Promise<CreateRadarSessionResult>;
+
+  // Checkout Session
+
+  initCheckoutSession(
+    clientSecret: string,
+    configuration: UnsafeObject<Checkout.Configuration>
+  ): Promise<UnsafeObject<{ sessionKey: string; state: Checkout.State }>>;
+
+  checkoutUpdateShippingAddress(
+    sessionKey: string,
+    params: UnsafeObject<Checkout.AddressUpdate>
+  ): Promise<UnsafeObject<Checkout.State>>;
+
+  checkoutUpdateBillingAddress(
+    sessionKey: string,
+    params: UnsafeObject<Checkout.AddressUpdate>
+  ): Promise<UnsafeObject<Checkout.State>>;
+
+  checkoutApplyPromotionCode(
+    sessionKey: string,
+    code: string
+  ): Promise<UnsafeObject<Checkout.State>>;
+
+  checkoutRemovePromotionCode(
+    sessionKey: string
+  ): Promise<UnsafeObject<Checkout.State>>;
+
+  checkoutUpdateLineItemQuantity(
+    sessionKey: string,
+    params: UnsafeObject<Checkout.LineItemUpdate>
+  ): Promise<UnsafeObject<Checkout.State>>;
+
+  checkoutSelectShippingOption(
+    sessionKey: string,
+    id: string
+  ): Promise<UnsafeObject<Checkout.State>>;
+
+  checkoutUpdateTaxId(
+    sessionKey: string,
+    params: UnsafeObject<Checkout.TaxIdUpdate>
+  ): Promise<UnsafeObject<Checkout.State>>;
+
+  checkoutRefresh(sessionKey: string): Promise<UnsafeObject<Checkout.State>>;
 
   setFinancialConnectionsForceNativeFlow(enabled: boolean): Promise<void>;
 

--- a/src/specs/NativeStripeSdkModule.ts
+++ b/src/specs/NativeStripeSdkModule.ts
@@ -217,12 +217,16 @@ export interface Spec extends TurboModule {
 
   checkoutUpdateShippingAddress(
     sessionKey: string,
-    params: UnsafeObject<Checkout.AddressUpdate>
+    address: UnsafeObject<Checkout.Address>,
+    name: string | null,
+    phone: string | null
   ): Promise<UnsafeObject<Checkout.State>>;
 
   checkoutUpdateBillingAddress(
     sessionKey: string,
-    params: UnsafeObject<Checkout.AddressUpdate>
+    address: UnsafeObject<Checkout.Address>,
+    name: string | null,
+    phone: string | null
   ): Promise<UnsafeObject<Checkout.State>>;
 
   checkoutApplyPromotionCode(

--- a/src/types/Checkout.ts
+++ b/src/types/Checkout.ts
@@ -149,13 +149,15 @@ export interface Checkout {
    * address source is "shipping", the address is also sent to the server to
    * compute updated tax amounts.
    *
-   * - Parameter params: The shipping address to set. To reset tax computation
-   *   to a country-only region, pass an `AddressUpdate` with just the country.
-   * - Throws: `CheckoutError` if the session is not open, or if
-   *   the server request fails.
-   * @checkoutSessionsPreview
+   * @param address - The shipping address to set.
+   * @param name - The recipient's name.
+   * @param phone - The recipient's phone number.
    */
-  updateShippingAddress(params: Checkout.AddressUpdate): Promise<void>;
+  updateShippingAddress(
+    address: Checkout.Address,
+    name?: string,
+    phone?: string
+  ): Promise<void>;
 
   /**
    * Sets the billing address for this checkout.
@@ -165,14 +167,15 @@ export interface Checkout {
    * address source is "billing", the address is also sent to the server to
    * compute updated tax amounts.
    *
-   * - Parameter params: The billing address to set. To reset tax computation
-   *   to a country-only region, pass an `AddressUpdate` with just the country.
-   * - Throws: `CheckoutError` if the session is not open, or if
-   *   the server request fails.
-   * @checkoutSessionsPreview
+   * @param address - The billing address to set.
+   * @param name - The customer's name.
+   * @param phone - The customer's phone number.
    */
-
-  updateBillingAddress(params: Checkout.AddressUpdate): Promise<void>;
+  updateBillingAddress(
+    address: Checkout.Address,
+    name?: string,
+    phone?: string
+  ): Promise<void>;
 
   /**
    * Applies a promotion code to the session.

--- a/src/types/Checkout.ts
+++ b/src/types/Checkout.ts
@@ -117,16 +117,6 @@ export namespace Checkout {
     postalCode?: string;
   }
 
-  export interface LineItemUpdate {
-    lineItemId: string;
-    quantity: number;
-  }
-
-  export interface TaxIdUpdate {
-    type: string;
-    value: string;
-  }
-
   export interface Error {
     code: ErrorCode;
     message: string;
@@ -172,13 +162,13 @@ export interface Checkout {
   removePromotionCode(): Promise<void>;
 
   /** Updates the quantity of a line item. */
-  updateLineItemQuantity(params: Checkout.LineItemUpdate): Promise<void>;
+  updateLineItemQuantity(lineItemId: string, quantity: number): Promise<void>;
 
   /** Selects a shipping option for the session. */
   selectShippingOption(id: string): Promise<void>;
 
   /** Sets the customer's tax ID on the session. */
-  updateTaxId(params: Checkout.TaxIdUpdate): Promise<void>;
+  updateTaxId(type: string, value: string): Promise<void>;
 
   /** Refreshes the session from Stripe. */
   refresh(): Promise<void>;

--- a/src/types/Checkout.ts
+++ b/src/types/Checkout.ts
@@ -1,20 +1,35 @@
 /**
- * @checkoutSessionsPreview
  * All types for the Checkout Session API.
+ * @checkoutSessionsPreview
  */
 export namespace Checkout {
+  /**
+   * Configuration options for a `useCheckout` instance.
+   * @checkoutSessionsPreview
+   */
   export interface Configuration {
     /**
      * Controls whether adaptive pricing is requested for this session.
+     *
+     * When allowed, Stripe may present prices in the customer's local
+     * currency alongside the merchant's settlement currency.
+     *
      * Default: `{ allowed: true }`.
      */
     adaptivePricing?: AdaptivePricing;
   }
 
+  /**
+   * Options for adaptive pricing behavior.
+   * @checkoutSessionsPreview
+   */
   export interface AdaptivePricing {
     /**
-     * Set to `false` to prevent Stripe from activating adaptive pricing
-     * even if the Checkout Session is configured for it on the server.
+     * Whether the integration allows adaptive pricing for this session.
+     *
+     * Set to `false` to prevent Stripe from activating adaptive pricing even
+     * if the Checkout Session is configured for it on the server.
+     *
      * Default: `true`.
      */
     allowed: boolean;
@@ -34,94 +49,226 @@ export namespace Checkout {
    * @checkoutSessionsPreview
    */
   export type State =
-    | { status: 'loading'; session: Session }
-    | { status: 'loaded'; session: Session };
+    | {
+        /**
+         * `loading` while a mutation or refresh is in flight.
+         *
+         * The associated `session` value is the most recently loaded copy and
+         * may be stale.
+         */
+        status: 'loading';
+        /** The most recently loaded session value. */
+        session: Session;
+      }
+    | {
+        /** `loaded` when the session is current and ready to use. */
+        status: 'loaded';
+        /** The latest checkout session value from Stripe. */
+        session: Session;
+      };
 
+  /**
+   * The status of a checkout session.
+   *
+   * - `unknown` - A status not recognized by this version of the SDK.
+   * - `open` - The checkout session is still in progress.
+   * - `complete` - The checkout session is complete.
+   * - `expired` - The checkout session has expired.
+   * @checkoutSessionsPreview
+   */
   export type Status = 'unknown' | 'open' | 'complete' | 'expired';
 
+  /**
+   * The payment status of a checkout session.
+   *
+   * - `unknown` - A payment status not recognized by this version of the SDK.
+   * - `paid` - The payment funds are available in your account.
+   * - `unpaid` - The payment funds are not yet available in your account.
+   * - `noPaymentRequired` - No payment is currently required for the session.
+   * @checkoutSessionsPreview
+   */
   export type PaymentStatus =
     | 'unknown'
     | 'paid'
     | 'unpaid'
     | 'noPaymentRequired';
 
+  /**
+   * A read-only snapshot of a Stripe Checkout Session.
+   * @checkoutSessionsPreview
+   */
   export interface Session {
+    /** Unique identifier for this checkout session. */
     id: string;
+    /** The current session state, if available. */
     status?: Status;
+    /** The payment status for this checkout session. */
     paymentStatus: PaymentStatus;
     /** Three-letter ISO 4217 currency code in lowercase (e.g. `"usd"`). */
     currency?: string;
+    /** Indicates whether this session was created in live mode. */
     livemode: boolean;
-    /** All amounts in smallest currency unit (e.g. cents for USD). */
+    /** A summary of monetary totals for this session, if available. */
     totals?: Totals;
+    /** The line items purchased by the customer. */
     lineItems: LineItem[];
+    /** The shipping rate options available for this session. */
     shippingOptions: ShippingOption[];
+    /** The discounts applied to this session. */
     discounts: Discount[];
+    /** The Stripe customer ID attached to this session, if any. */
     customerId?: string;
+    /** The customer's email address, if available. */
     customerEmail?: string;
+    /** The billing address set via `updateBillingAddress`, if any. */
     billingAddress?: AddressUpdate;
+    /** The shipping address set via `updateShippingAddress`, if any. */
     shippingAddress?: AddressUpdate;
   }
 
-  /** All amounts are in the smallest currency unit (e.g. cents for USD). */
+  /**
+   * Monetary totals for a checkout session.
+   *
+   * All amounts are in the smallest currency unit (e.g. cents for USD).
+   * @checkoutSessionsPreview
+   */
   export interface Totals {
+    /** The subtotal amount before discounts, shipping, and tax. */
     subtotal: number;
+    /** The final total after discounts, shipping, and tax. */
     total: number;
+    /** The amount currently due from the customer. */
     due: number;
+    /** The total discount amount applied to the session. */
     discount: number;
+    /** The total shipping amount. */
     shipping: number;
+    /** The total tax amount applied to the session. */
     tax: number;
   }
 
+  /**
+   * A line item in a checkout session.
+   * @checkoutSessionsPreview
+   */
   export interface LineItem {
+    /** Unique identifier for this line item. */
     id: string;
+    /** The display name shown for this line item. */
     name: string;
+    /** The quantity for this line item. */
     quantity: number;
+    /** The per-unit price in the smallest currency unit. */
     unitAmount: number;
+    /** Three-letter ISO 4217 currency code in lowercase. */
     currency: string;
   }
 
+  /**
+   * A shipping option available in a checkout session.
+   * @checkoutSessionsPreview
+   */
   export interface ShippingOption {
+    /** The shipping rate identifier. */
     id: string;
+    /** The display name shown to the customer. */
     displayName: string;
+    /** The shipping amount in the smallest currency unit. */
     amount: number;
+    /** Three-letter ISO 4217 currency code in lowercase. */
     currency: string;
+    /** The estimated delivery window shown to the customer, if available. */
     deliveryEstimate?: string;
   }
 
+  /**
+   * A discount applied to a checkout session.
+   * @checkoutSessionsPreview
+   */
   export interface Discount {
+    /** The coupon associated with this discount. */
     coupon: Coupon;
+    /** The promotion code used to apply this discount, if any. */
     promotionCode?: string;
+    /** The discount amount in the smallest currency unit. */
     amount: number;
   }
 
+  /**
+   * A coupon associated with a checkout discount.
+   * @checkoutSessionsPreview
+   */
   export interface Coupon {
+    /** The coupon identifier. */
     id: string;
+    /** The display name of the coupon, if one exists. */
     name?: string;
+    /** The percentage off, if this is a percentage-based coupon. */
     percentOff?: number;
+    /** The fixed amount off, in the smallest currency unit, if applicable. */
     amountOff?: number;
   }
 
+  /**
+   * A locally stored address override for checkout.
+   *
+   * Address updates are merged into PaymentSheet configuration and may also be
+   * sent to Stripe when tax calculation depends on the billing or shipping
+   * address.
+   * @checkoutSessionsPreview
+   */
   export interface AddressUpdate {
+    /** The customer's or recipient's name, if provided. */
     name?: string;
+    /** The customer's or recipient's phone number, if provided. */
     phone?: string;
+    /** The postal address to use for the update. */
     address: Address;
   }
 
+  /**
+   * A postal address used for billing, shipping, or tax updates.
+   * @checkoutSessionsPreview
+   */
   export interface Address {
+    /** The country for this address, such as `"US"`. */
     country: string;
+    /** The first address line. */
     line1?: string;
+    /** The second address line. */
     line2?: string;
+    /** The city, district, suburb, town, or village. */
     city?: string;
+    /** The state, county, province, or region. */
     state?: string;
+    /** The postal or ZIP code. */
     postalCode?: string;
   }
 
+  /**
+   * A Checkout-specific error returned from `useCheckout` or a Checkout
+   * mutation method.
+   * @checkoutSessionsPreview
+   */
   export interface Error {
+    /** A machine-readable error code describing the failure. */
     code: ErrorCode;
+    /** A human-readable message describing the failure. */
     message: string;
   }
 
+  /**
+   * The set of Checkout-specific error codes.
+   *
+   * - `Failed` - The operation could not be completed.
+   * - `InvalidClientSecret` - The provided Checkout Session client secret is
+   *   invalid.
+   * - `SessionNotOpen` - The Checkout Session is no longer open for updates.
+   * - `SheetCurrentlyPresented` - The operation is unavailable while
+   *   PaymentSheet is being presented.
+   * - `Canceled` - The operation was canceled before completion.
+   * @checkoutSessionsPreview
+   */
   export type ErrorCode =
     | 'Failed'
     | 'InvalidClientSecret'

--- a/src/types/Checkout.ts
+++ b/src/types/Checkout.ts
@@ -143,33 +143,85 @@ export interface Checkout {
 
   /**
    * Sets the shipping address for this checkout.
-   * If automatic tax is enabled with shipping as the tax address source,
-   * also updates the tax region on the server.
+   *
+   * The address is stored locally and merged into PaymentSheet configuration
+   * when presenting payment UI. If automatic tax is enabled and the tax
+   * address source is "shipping", the address is also sent to the server to
+   * compute updated tax amounts.
+   *
+   * - Parameter params: The shipping address to set. To reset tax computation
+   *   to a country-only region, pass an `AddressUpdate` with just the country.
+   * - Throws: `CheckoutError` if the session is not open, or if
+   *   the server request fails.
+   * @checkoutSessionsPreview
    */
   updateShippingAddress(params: Checkout.AddressUpdate): Promise<void>;
 
   /**
    * Sets the billing address for this checkout.
-   * If automatic tax is enabled with billing as the tax address source,
-   * also updates the tax region on the server.
+   *
+   * The address is stored locally and merged into PaymentSheet configuration
+   * when presenting payment UI. If automatic tax is enabled and the tax
+   * address source is "billing", the address is also sent to the server to
+   * compute updated tax amounts.
+   *
+   * - Parameter params: The billing address to set. To reset tax computation
+   *   to a country-only region, pass an `AddressUpdate` with just the country.
+   * - Throws: `CheckoutError` if the session is not open, or if
+   *   the server request fails.
+   * @checkoutSessionsPreview
    */
+
   updateBillingAddress(params: Checkout.AddressUpdate): Promise<void>;
 
-  /** Applies a promotion code to the session. */
+  /**
+   * Applies a promotion code to the session.
+   * - Parameter code: The promotion code to apply (e.g. `"SUMMER2026"`).
+   * - Throws: `CheckoutError` if applying the promotion code fails.
+   * @checkoutSessionsPreview
+   */
   applyPromotionCode(code: string): Promise<void>;
 
-  /** Removes the currently applied promotion code. */
+  /**
+   * Removes the currently applied promotion code.
+   * - Throws: `CheckoutError` if removing the promotion code fails.
+   * @checkoutSessionsPreview
+   */
   removePromotionCode(): Promise<void>;
 
-  /** Updates the quantity of a line item. */
+  /**
+   * Updates the quantity of a line item.
+   * @param lineItemId - The ID of the line item to update.
+   * @param quantity - The new quantity to set.
+   * - Throws: `CheckoutError` if updating the line item quantity fails.
+   * @checkoutSessionsPreview
+   */
   updateLineItemQuantity(lineItemId: string, quantity: number): Promise<void>;
 
-  /** Selects a shipping option for the session. */
+  /**
+   * Selects a shipping option for the session.
+   * @param id - The ID of the shipping rate to select.
+   * - Throws: `CheckoutError` if selecting the shipping option fails.
+   * @checkoutSessionsPreview
+   */
   selectShippingOption(id: string): Promise<void>;
 
-  /** Sets the customer's tax ID on the session. */
+  /**
+   * Sets the customer's tax ID on the session.
+   * @param type - The tax ID type (e.g. `"eu_vat"`).
+   * @param value - The tax ID value (e.g. `"DE123456789"`).
+   * - Throws: `CheckoutError` if updating the tax ID fails.
+   * @checkoutSessionsPreview
+   */
   updateTaxId(type: string, value: string): Promise<void>;
 
-  /** Refreshes the session from Stripe. */
+  /**
+   * Refreshes the session by fetching the latest copy from Stripe.
+   *
+   * Call this after making server-side changes to the Checkout Session
+   * so the local state stays in sync.
+   * - Throws: `CheckoutError` if refreshing the session fails.
+   * @checkoutSessionsPreview
+   */
   refresh(): Promise<void>;
 }

--- a/src/types/Checkout.ts
+++ b/src/types/Checkout.ts
@@ -1,0 +1,190 @@
+/**
+ * @checkoutSessionsPreview
+ * All types for the Checkout Session API.
+ */
+export namespace Checkout {
+  export interface Configuration {
+    /**
+     * Controls whether adaptive pricing is requested for this session.
+     * Default: `{ allowed: true }`.
+     */
+    adaptivePricing?: AdaptivePricing;
+  }
+
+  export interface AdaptivePricing {
+    /**
+     * Set to `false` to prevent Stripe from activating adaptive pricing
+     * even if the Checkout Session is configured for it on the server.
+     * Default: `true`.
+     */
+    allowed: boolean;
+  }
+
+  /**
+   * The loading state of the checkout session.
+   *
+   * Returned as `state` from `useCheckout`. React re-renders automatically
+   * whenever the session changes.
+   *
+   * - `loading` – a mutation or refresh is in flight; `session` is the most
+   *   recently loaded value and may be stale.
+   * - `loaded`  – session is current and ready.
+   *
+   * Before the initial session load completes, `state` is `null`.
+   * @checkoutSessionsPreview
+   */
+  export type State =
+    | { status: 'loading'; session: Session }
+    | { status: 'loaded'; session: Session };
+
+  export type Mode = 'unknown' | 'payment' | 'setup' | 'subscription';
+
+  export type Status = 'unknown' | 'open' | 'complete' | 'expired';
+
+  export type PaymentStatus =
+    | 'unknown'
+    | 'paid'
+    | 'unpaid'
+    | 'noPaymentRequired';
+
+  export interface Session {
+    id: string;
+    mode: Mode;
+    status?: Status;
+    paymentStatus: PaymentStatus;
+    /** Three-letter ISO 4217 currency code in lowercase (e.g. `"usd"`). */
+    currency?: string;
+    livemode: boolean;
+    /** All amounts in smallest currency unit (e.g. cents for USD). */
+    totals?: Totals;
+    lineItems: LineItem[];
+    shippingOptions: ShippingOption[];
+    selectedShippingOption?: ShippingOption;
+    discounts: Discount[];
+    appliedPromotionCode?: string;
+    customerId?: string;
+    customerEmail?: string;
+    billingAddress?: AddressUpdate;
+    shippingAddress?: AddressUpdate;
+  }
+
+  /** All amounts are in the smallest currency unit (e.g. cents for USD). */
+  export interface Totals {
+    subtotal: number;
+    total: number;
+    due: number;
+    discount: number;
+    shipping: number;
+    tax: number;
+  }
+
+  export interface LineItem {
+    id: string;
+    name: string;
+    quantity: number;
+    unitAmount: number;
+    currency: string;
+  }
+
+  export interface ShippingOption {
+    id: string;
+    displayName: string;
+    amount: number;
+    currency: string;
+    deliveryEstimate?: string;
+  }
+
+  export interface Discount {
+    coupon: Coupon;
+    promotionCode?: string;
+    amount: number;
+  }
+
+  export interface Coupon {
+    id: string;
+    name?: string;
+    percentOff?: number;
+    amountOff?: number;
+  }
+
+  export interface AddressUpdate {
+    name?: string;
+    phone?: string;
+    address: Address;
+  }
+
+  export interface Address {
+    country: string;
+    line1?: string;
+    line2?: string;
+    city?: string;
+    state?: string;
+    postalCode?: string;
+  }
+
+  export interface LineItemUpdate {
+    lineItemId: string;
+    quantity: number;
+  }
+
+  export interface TaxIdUpdate {
+    type: string;
+    value: string;
+  }
+
+  export interface Error {
+    code: ErrorCode;
+    message: string;
+  }
+
+  export type ErrorCode =
+    | 'Failed'
+    | 'InvalidClientSecret'
+    | 'SessionNotOpen'
+    | 'SheetCurrentlyPresented'
+    | 'Canceled';
+}
+
+/**
+ * A handle to a live Checkout Session.
+ *
+ * Returned by `useCheckout`. Call mutation methods to update the session;
+ * the hook's `state` updates automatically after each mutation.
+ * @checkoutSessionsPreview
+ */
+export interface Checkout {
+  /** @internal Opaque key for the native Checkout instance. Used by `initPaymentSheet`. */
+  readonly sessionKey: string;
+
+  /**
+   * Sets the shipping address for this checkout.
+   * If automatic tax is enabled with shipping as the tax address source,
+   * also updates the tax region on the server.
+   */
+  updateShippingAddress(params: Checkout.AddressUpdate): Promise<void>;
+
+  /**
+   * Sets the billing address for this checkout.
+   * If automatic tax is enabled with billing as the tax address source,
+   * also updates the tax region on the server.
+   */
+  updateBillingAddress(params: Checkout.AddressUpdate): Promise<void>;
+
+  /** Applies a promotion code to the session. */
+  applyPromotionCode(code: string): Promise<void>;
+
+  /** Removes the currently applied promotion code. */
+  removePromotionCode(): Promise<void>;
+
+  /** Updates the quantity of a line item. */
+  updateLineItemQuantity(params: Checkout.LineItemUpdate): Promise<void>;
+
+  /** Selects a shipping option for the session. */
+  selectShippingOption(id: string): Promise<void>;
+
+  /** Sets the customer's tax ID on the session. */
+  updateTaxId(params: Checkout.TaxIdUpdate): Promise<void>;
+
+  /** Refreshes the session from Stripe. */
+  refresh(): Promise<void>;
+}

--- a/src/types/Checkout.ts
+++ b/src/types/Checkout.ts
@@ -37,8 +37,6 @@ export namespace Checkout {
     | { status: 'loading'; session: Session }
     | { status: 'loaded'; session: Session };
 
-  export type Mode = 'unknown' | 'payment' | 'setup' | 'subscription';
-
   export type Status = 'unknown' | 'open' | 'complete' | 'expired';
 
   export type PaymentStatus =
@@ -49,7 +47,6 @@ export namespace Checkout {
 
   export interface Session {
     id: string;
-    mode: Mode;
     status?: Status;
     paymentStatus: PaymentStatus;
     /** Three-letter ISO 4217 currency code in lowercase (e.g. `"usd"`). */
@@ -59,9 +56,7 @@ export namespace Checkout {
     totals?: Totals;
     lineItems: LineItem[];
     shippingOptions: ShippingOption[];
-    selectedShippingOption?: ShippingOption;
     discounts: Discount[];
-    appliedPromotionCode?: string;
     customerId?: string;
     customerEmail?: string;
     billingAddress?: AddressUpdate;

--- a/src/types/PaymentSheet.ts
+++ b/src/types/PaymentSheet.ts
@@ -15,6 +15,7 @@ import type { FutureUsage } from './PaymentIntent';
 import type { Result } from './PaymentMethod';
 import type { StripeError } from './Errors';
 import type { Result as ConfirmationTokenResult } from './ConfirmationToken';
+import type { Checkout } from './Checkout';
 
 export type SetupParamsBase = IntentParams & {
   /** Your customer-facing business name. On Android, this is required and cannot be an empty string. */
@@ -46,7 +47,7 @@ export type SetupParamsBase = IntentParams & {
   defaultShippingDetails?: AddressDetails;
   /** If true, allows payment methods that do not move money at the end of the checkout. Defaults to false.
    *
-   * Some payment methods can’t guarantee you will receive funds from your customer at the end of the checkout
+   * Some payment methods can't guarantee you will receive funds from your customer at the end of the checkout
    * because they take time to settle (eg. most bank debits, like SEPA or ACH) or require customer action to
    * complete (e.g. OXXO, Konbini, Boleto). If this is set to true, make sure your integration listens to webhooks
    * for notifications on whether a payment has succeeded or not.
@@ -65,7 +66,7 @@ export type SetupParamsBase = IntentParams & {
    *  You can override the default order in which payment methods are displayed in PaymentSheet with a list of payment method types.
    *  See https://stripe.com/docs/api/payment_methods/object#payment_method_object-type for the list of valid types.  You may also pass external payment methods.
    *  - Example: ["card", "external_paypal", "klarna"]
-   *  - Note: If you omit payment methods from this list, they’ll be automatically ordered by Stripe after the ones you provide. Invalid payment methods are ignored.
+   *  - Note: If you omit payment methods from this list, they'll be automatically ordered by Stripe after the ones you provide. Invalid payment methods are ignored.
    */
   paymentMethodOrder?: Array<String>;
   /** This is an experimental feature that may be removed at any time.
@@ -112,9 +113,29 @@ export type SetupParamsBase = IntentParams & {
   };
 };
 
+/**
+ * Parameters for initializing PaymentSheet from a Checkout Session.
+ * Use when you have called `useCheckout` and the state is `loaded`.
+ * @checkoutSessionsPreview
+ */
+export type CheckoutSetupParams = {
+  /** A fully loaded Checkout instance whose `state.status` is `'loaded'`. */
+  checkout: Checkout;
+  paymentIntentClientSecret?: never;
+  setupIntentClientSecret?: never;
+  intentConfiguration?: never;
+  customerEphemeralKeySecret?: never;
+  customerSessionClientSecret?: never;
+} & Omit<
+  SetupParamsBase,
+  | 'paymentIntentClientSecret'
+  | 'setupIntentClientSecret'
+  | 'intentConfiguration'
+>;
+
 export type SetupParams =
   | (SetupParamsBase & {
-      /** A short-lived token that allows the SDK to access a Customer’s payment methods. */
+      /** A short-lived token that allows the SDK to access a Customer's payment methods. */
       customerEphemeralKeySecret: string;
       customerSessionClientSecret?: never;
     })
@@ -123,7 +144,8 @@ export type SetupParams =
       /** The client secret of this Customer Session. Used on the client to set up secure access to the given customer. */
       customerSessionClientSecret: string;
     })
-  | SetupParamsBase;
+  | SetupParamsBase
+  | CheckoutSetupParams;
 
 export type IntentParams =
   | {
@@ -406,7 +428,7 @@ export type PrimaryButtonColorConfig = {
   successTextColor?: ThemedColor;
 };
 
-/** A color that’s either a single hex or a light/dark pair */
+/** A color that's either a single hex or a light/dark pair */
 export type ThemedColor = string | { light: string; dark: string };
 
 /** Represents edge insets */
@@ -649,7 +671,7 @@ export type Mode = PaymentMode | SetupMode;
 export enum CaptureMethod {
   /** (Default) Stripe automatically captures funds when the customer authorizes the payment. */
   Automatic = 'Automatic',
-  /** Place a hold on the funds when the customer authorizes the payment, but don’t capture the funds until later. (Not all payment methods support this.) */
+  /** Place a hold on the funds when the customer authorizes the payment, but don't capture the funds until later. (Not all payment methods support this.) */
   Manual = 'Manual',
   /** Asynchronously capture funds when the customer authorizes the payment.
   - Note: Recommended over `CaptureMethod.Automatic` due to improved latency, but may require additional integration changes.


### PR DESCRIPTION
## Summary
- Adds the JS layer for the Checkout SDK
- 3 more PRs to come (iOS, Android, and example app)

## Motivation
- https://docs.google.com/document/d/1CWglcOHR6I8cOWKjztPfnhnVG8axucpv-j5cWIoey7E/edit?tab=t.88ysmrst8j3w

