### PR TITLE
fix: prevent crash when Google Pay is presented after activity is backgrounded

### DIFF
--- a/android/src/main/java/com/reactnativestripesdk/GooglePayLauncherManager.kt
+++ b/android/src/main/java/com/reactnativestripesdk/GooglePayLauncherManager.kt
@@ -1,6 +1,7 @@
 package com.reactnativestripesdk
 
 import android.annotation.SuppressLint
+import androidx.lifecycle.Lifecycle
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.WritableMap
@@ -63,6 +64,11 @@ class GooglePayLauncherManager(
 
   private fun onGooglePayReady(isReady: Boolean) {
     if (isReady) {
+      val activity = getCurrentActivityOrResolveWithError(promise) ?: return
+      if (!activity.lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)) {
+        callback(null, createError(GooglePayErrorType.Canceled.toString(), "Google Pay has been canceled"))
+        return
+      }
       when (mode) {
         Mode.ForSetup -> {
           launcher?.presentForSetupIntent(clientSecret, currencyCode, amount?.toLong(), label)


### PR DESCRIPTION
## Summary
This PR adds a lifecycle check to `GooglePayLauncherManager.onGooglePayReady` which surfaces an error if the lifecycle is not at least `STARTED`.

I have read through the contribution guidelines and done my best to adhere to them. Please let me know if there are any changes to this PR that you would like to see with respect to the guidelines. Thank you for your time.

## Motivation
I have been encountering a crash via the [flutter-stripe](https://github.com/flutter-stripe/flutter_stripe) package which occurs when a google pay transaction is initiated and then the app is briefly (~1 second) backgrounded. I have manually confirmed that this change prevents the crash in the described situation.

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [ ] I added automated tests
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
