### PR TITLE
fix: wire up ref correctly for PMME

### DIFF
--- a/src/components/PaymentMethodMessagingElement.tsx
+++ b/src/components/PaymentMethodMessagingElement.tsx
@@ -1,17 +1,11 @@
-import React, { forwardRef, useEffect, useRef, useState } from 'react';
-import {
-  AccessibilityProps,
-  HostComponent,
-  LayoutAnimation,
-} from 'react-native';
+import React, { forwardRef, useEffect, useState } from 'react';
+import { AccessibilityProps, LayoutAnimation } from 'react-native';
 import {
   PaymentMethodMessagingElementAppearance,
   PaymentMethodMessagingElementState,
 } from '../types/components/PaymentMethodMessagingElementComponent';
 import { PaymentMethodMessagingElementConfiguration } from '../types/components/PaymentMethodMessagingElementComponent';
-import NativePaymentMethodMessagingElement, {
-  NativeProps,
-} from '../specs/NativePaymentMethodMessagingElement';
+import NativePaymentMethodMessagingElement from '../specs/NativePaymentMethodMessagingElement';
 import { addListener } from '../events';
 
 export interface Props extends AccessibilityProps {
@@ -51,10 +45,7 @@ export interface Props extends AccessibilityProps {
  * @category ReactComponents
  */
 export const PaymentMethodMessagingElement = forwardRef<any, Props>(
-  ({ appearance, configuration, onStateChange, ...props }) => {
-    const viewRef =
-      useRef<React.ComponentRef<HostComponent<NativeProps>>>(null);
-
+  ({ appearance, configuration, onStateChange, ...props }, ref) => {
     const [height, setHeight] = useState<number | undefined>();
 
     useEffect(() => {
@@ -102,7 +93,7 @@ export const PaymentMethodMessagingElement = forwardRef<any, Props>(
         style={[{ width: '100%', height: height }]}
         configuration={configuration}
         {...props}
-        ref={viewRef}
+        ref={ref}
       />
     );
   }


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
Accept ref from forwardRef callback and pass to native element

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a link to the relevant issue, a code snippet, or an example project that demonstrates the bug. -->
The component used forwardRef but ignored the forwarded ref parameter. Instead, it created its own internal useRef (viewRef) and passed that to the native element. This meant any consumer passing a ref to <PaymentMethodMessagingElement ref={myRef} /> would get nothing — the ref was silently dropped

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [X] I tested this manually
- [ ] I added automated tests
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
