### PR TITLE
Deflake CPM test on Android

### DIFF
--- a/example/src/screens/PaymentsUICompleteScreen.tsx
+++ b/example/src/screens/PaymentsUICompleteScreen.tsx
@@ -170,7 +170,7 @@ export default function PaymentsUICompleteScreen() {
         allowsDelayedPaymentMethods: true,
         appearance: getAppearanceForSetting(appearanceSettings),
         primaryButtonLabel: 'purchase!',
-        paymentMethodLayout: PaymentMethodLayout.Automatic,
+        paymentMethodLayout: PaymentMethodLayout.Vertical,
         removeSavedPaymentMethodMessage: 'remove this payment method?',
         preferredNetworks: [CardBrand.Amex, CardBrand.Visa],
         opensCardScannerAutomatically,


### PR DESCRIPTION
Always use vertical mode so the scrolling is deterministic. 