### PR TITLE
Reduce CI flakiness with build retries and E2E test wait

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -474,7 +474,9 @@ workflows:
             - content: |
                 cd example/android
                 yarn build:android
-                ./gradlew assembleRelease -PnewArchEnabled=$NEW_ARCH_ENABLED -PreactNativeArchitectures=x86_64 --no-daemon --build-cache --no-scan
+                ./gradlew assembleRelease -PnewArchEnabled=$NEW_ARCH_ENABLED -PreactNativeArchitectures=x86_64 --no-daemon --build-cache --no-scan || \
+                  (echo "Gradle build failed, retrying in 30s..." && sleep 30 && \
+                   ./gradlew assembleRelease -PnewArchEnabled=$NEW_ARCH_ENABLED -PreactNativeArchitectures=x86_64 --no-daemon --build-cache --no-scan)
       - save-gradle-cache@1:
           is_always_run: true
       - deploy-to-bitrise-io@2:
@@ -540,12 +542,15 @@ workflows:
                 mkdir -p "$OUT_DIR"
 
                 DERIVED_DATA_PATH="$BITRISE_SOURCE_DIR/DerivedData"
-                xcodebuild -workspace example.xcworkspace \
-                  -scheme example \
-                  -configuration Release \
-                  -sdk iphonesimulator \
-                  -derivedDataPath "$DERIVED_DATA_PATH" \
-                  build | xcbeautify
+                build_ios() {
+                  xcodebuild -workspace example.xcworkspace \
+                    -scheme example \
+                    -configuration Release \
+                    -sdk iphonesimulator \
+                    -derivedDataPath "$DERIVED_DATA_PATH" \
+                    build | xcbeautify
+                }
+                build_ios || (echo "iOS build failed, retrying in 30s..." && sleep 30 && build_ios)
 
                 APP_ROOT="$DERIVED_DATA_PATH/Build/Products/Release-iphonesimulator"
                 APP_DIR="$APP_ROOT/ReactTestApp.app"

--- a/e2e-tests/paymentsheet-cpm.yml
+++ b/e2e-tests/paymentsheet-cpm.yml
@@ -5,6 +5,9 @@ appId: ${APP_ID}
 - tapOn: "Accept a payment"
 - tapOn: "Prebuilt UI (single-step)"
 - tapOn: "Checkout"
+- extendedWaitUntil:
+    visible: "Card"
+    timeout: 30000
 - scrollUntilVisible:
     element:
       text: "BufoPay (test)"


### PR DESCRIPTION
## Summary
- Add `extendedWaitUntil` for "Card" in `paymentsheet-cpm.yml` before scrolling to "BufoPay (test)" — ensures payment methods are loaded before scroll
- Add retry with 30s delay for `gradlew assembleRelease` in Android E2E build — handles transient Maven repo failures
- Add retry with 30s delay for `xcodebuild` in iOS E2E build — handles transient `RegisterExecutionPolicyException` on Bitrise VMs

## Motivation
PR #2417 (and master) have recurring CI failures from three flaky patterns:
1. Maestro `scrollUntilVisible` times out when payment method list hasn't loaded yet
2. Gradle build fails with "MavenRepo is disabled due to earlier error" (transient network)
3. iOS build fails with `RegisterExecutionPolicyException` / exit code 65 (Bitrise VM issue)

All retries log clearly before retrying, and real failures still fail after one extra attempt.

## Test plan
- [ ] Maestro test change: verify `paymentsheet-cpm.yml` passes locally
- [ ] Bitrise retry changes: validated on next CI run
- [ ] Verify retry output is logged (grep for "retrying in 30s" in failure logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)