### PR TITLE
docs: Update Android SDK requirements to match stripe-android 23.x

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -1,5 +1,30 @@
 # Migration Guide
 
+## Android SDK 36 requirement (stripe-android 23.x)
+
+Recent versions of `@stripe/stripe-react-native` depend on `stripe-android 23.x`, which requires:
+
+- `compileSdkVersion` 36
+- `targetSdkVersion` 36
+- `minSdkVersion` 23
+
+Update your app's `android/build.gradle`:
+
+```groovy
+android {
+    compileSdkVersion 36
+
+    defaultConfig {
+        minSdkVersion 23
+        targetSdkVersion 36
+    }
+}
+```
+
+If you cannot upgrade to Android SDK 36, pin to an older `@stripe/stripe-react-native` version that uses `stripe-android` 22.x or earlier.
+
+This is an Android-specific build requirement and does not affect iOS.
+
 ## Migrating from versions < 0.29.0
 
 The legacy Apple Pay and Google Pay APIs (`useApplePay`, `useGooglePay`, `presentApplePay`, `confirmApplePayPayment`, `initGooglePay`, `presentGooglePay`, `createGooglePayPaymentMethod`, `<ApplePayButton />`, `<GooglePayButton />`) were removed in v0.29.0.

--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ to your `app.json` file, where `merchantIdentifier` is the Apple merchant ID obt
 
 #### Android
 
-- Android 5.0 (API level 21) and above
-  - Your `compileSdkVersion` must be `34`. See [this issue](https://github.com/stripe/stripe-react-native/issues/812) for potential workarounds.
+- Android 6.0 (API level 23) and above
+  - Your `compileSdkVersion` must be `36` or higher.
 - Android gradle plugin 4.x and above
 - Kotlin 2.x and above. See [this issue](https://github.com/stripe/stripe-react-native/issues/1924#issuecomment-2867227374) for how to update the Kotlin version when using react-native 0.77 and below or Expo SDK 52.
 

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,6 +1,6 @@
 StripeSdk_kotlinVersion=2.2.21
-StripeSdk_compileSdkVersion=30
-StripeSdk_targetSdkVersion=28
-StripeSdk_minSdkVersion=21
+StripeSdk_compileSdkVersion=36
+StripeSdk_targetSdkVersion=36
+StripeSdk_minSdkVersion=23
 # Keep StripeSdk_stripeVersion in sync with https://github.com/stripe/stripe-identity-react-native/blob/main/android/gradle.properties
 StripeSdk_stripeVersion=23.6.+


### PR DESCRIPTION
## Summary
- Updates `android/gradle.properties` defaults to `compileSdkVersion=36`, `targetSdkVersion=36`, `minSdkVersion=23` to match what stripe-android 23.x actually requires.
- Updates README Android requirements section to reflect API level 23+ and compileSdkVersion 36.
- Adds a migration note in MIGRATING.md explaining the Android SDK 36 requirement and the fallback option.

## Context
Recent `@stripe/stripe-react-native` versions depend on `stripe-android 23.x`, which bumped compile/target SDK to 36 and minSdk to 23. The previous defaults and docs were stale, causing user confusion.

Fixes: https://github.com/stripe/stripe-react-native/issues/2398
Jira: [RUN_MOBILESDK-5350](https://jira.corp.stripe.com/browse/RUN_MOBILESDK-5350)

## Test plan
- [ ] Verify Android example app builds with the updated defaults
- [ ] Confirm no iOS impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)