### PR TITLE
Add Embedded and PS.FC to Checkout test screen

### DIFF
--- a/android/src/main/java/com/reactnativestripesdk/EmbeddedPaymentElementView.kt
+++ b/android/src/main/java/com/reactnativestripesdk/EmbeddedPaymentElementView.kt
@@ -25,7 +25,9 @@ import com.reactnativestripesdk.utils.KeepJsAwakeTask
 import com.reactnativestripesdk.utils.mapFromConfirmationToken
 import com.reactnativestripesdk.utils.mapFromCustomPaymentMethod
 import com.reactnativestripesdk.utils.mapFromPaymentMethod
+import com.stripe.android.checkout.Checkout
 import com.stripe.android.model.PaymentMethod
+import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentelement.CustomPaymentMethodResult
 import com.stripe.android.paymentelement.CustomPaymentMethodResultHandler
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
@@ -43,6 +45,7 @@ enum class RowSelectionBehaviorType {
   ImmediateAction,
 }
 
+@OptIn(CheckoutSessionPreview::class)
 class EmbeddedPaymentElementView(
   context: Context,
 ) : StripeAbstractComposeView(context) {
@@ -50,6 +53,11 @@ class EmbeddedPaymentElementView(
     data class Configure(
       val configuration: EmbeddedPaymentElement.Configuration,
       val intentConfiguration: PaymentSheet.IntentConfiguration,
+    ) : Event
+
+    data class ConfigureWithCheckout(
+      val configuration: EmbeddedPaymentElement.Configuration,
+      val checkout: Checkout,
     ) : Event
 
     data class Update(
@@ -63,6 +71,7 @@ class EmbeddedPaymentElementView(
 
   var latestIntentConfig: PaymentSheet.IntentConfiguration? = null
   var latestElementConfig: EmbeddedPaymentElement.Configuration? = null
+  var latestCheckout: Checkout? = null
 
   val rowSelectionBehaviorType = mutableStateOf<RowSelectionBehaviorType?>(null)
   val useConfirmationTokenCallback = mutableStateOf(false)
@@ -303,27 +312,21 @@ class EmbeddedPaymentElementView(
       events.consumeAsFlow().collect { ev ->
         when (ev) {
           is Event.Configure -> {
-            // call configure and grab the result
-            val result =
+            handleConfigureResult(
               embedded.configure(
                 intentConfiguration = ev.intentConfiguration,
                 configuration = ev.configuration,
-              )
+              ),
+            )
+          }
 
-            when (result) {
-              is EmbeddedPaymentElement.ConfigureResult.Succeeded -> reportHeightChange(1f)
-              is EmbeddedPaymentElement.ConfigureResult.Failed -> {
-                // send the error back to JS
-                val err = result.error
-                val msg = err.localizedMessage ?: err.toString()
-                // build a RN map
-                val payload =
-                  Arguments.createMap().apply {
-                    putString("message", msg)
-                  }
-                requireStripeSdkModule().eventEmitter.emitEmbeddedPaymentElementLoadingFailed(payload)
-              }
-            }
+          is Event.ConfigureWithCheckout -> {
+            handleConfigureResult(
+              embedded.configure(
+                checkout = ev.checkout,
+                configuration = ev.configuration,
+              ),
+            )
           }
 
           is Event.Update -> {
@@ -449,12 +452,34 @@ class EmbeddedPaymentElementView(
     requireStripeSdkModule().eventEmitter.emitEmbeddedPaymentElementDidUpdateHeight(params)
   }
 
+  private fun handleConfigureResult(result: EmbeddedPaymentElement.ConfigureResult) {
+    when (result) {
+      is EmbeddedPaymentElement.ConfigureResult.Succeeded -> reportHeightChange(1f)
+      is EmbeddedPaymentElement.ConfigureResult.Failed -> {
+        val err = result.error
+        val msg = err.localizedMessage ?: err.toString()
+        val payload =
+          Arguments.createMap().apply {
+            putString("message", msg)
+          }
+        requireStripeSdkModule().eventEmitter.emitEmbeddedPaymentElementLoadingFailed(payload)
+      }
+    }
+  }
+
   // APIs
   fun configure(
     config: EmbeddedPaymentElement.Configuration,
     intentConfig: PaymentSheet.IntentConfiguration,
   ) {
     events.trySend(Event.Configure(config, intentConfig))
+  }
+
+  fun configureWithCheckout(
+    config: EmbeddedPaymentElement.Configuration,
+    checkout: Checkout,
+  ) {
+    events.trySend(Event.ConfigureWithCheckout(config, checkout))
   }
 
   fun update(intentConfig: PaymentSheet.IntentConfiguration) {

--- a/android/src/main/java/com/reactnativestripesdk/EmbeddedPaymentElementViewManager.kt
+++ b/android/src/main/java/com/reactnativestripesdk/EmbeddedPaymentElementViewManager.kt
@@ -23,6 +23,7 @@ import com.reactnativestripesdk.utils.getStringList
 import com.reactnativestripesdk.utils.mapToPreferredNetworks
 import com.reactnativestripesdk.utils.parseCustomPaymentMethods
 import com.stripe.android.ExperimentalAllowsRemovalOfLastSavedPaymentMethodApi
+import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentsheet.CardFundingFilteringPrivatePreview
 import com.stripe.android.paymentsheet.PaymentSheet
@@ -30,6 +31,7 @@ import org.json.JSONArray
 import org.json.JSONObject
 
 @ReactModule(name = EmbeddedPaymentElementViewManager.NAME)
+@OptIn(CheckoutSessionPreview::class)
 class EmbeddedPaymentElementViewManager :
   ViewGroupManager<EmbeddedPaymentElementView>(),
   EmbeddedPaymentElementViewManagerInterface<EmbeddedPaymentElementView> {
@@ -66,9 +68,7 @@ class EmbeddedPaymentElementViewManager :
 
     val elementConfig = parseElementConfiguration(readableMap, view.context)
     view.latestElementConfig = elementConfig
-    // if intentConfig is already set, configure immediately:
-    view.latestIntentConfig?.let { intentCfg ->
-      view.configure(elementConfig, intentCfg)
+    if (configureIfReady(view, elementConfig)) {
       view.post {
         view.requestLayout()
         view.invalidate()
@@ -82,17 +82,78 @@ class EmbeddedPaymentElementViewManager :
     cfg: Dynamic,
   ) {
     val readableMap = cfg.asMapOrNull()
-    if (readableMap == null) return
+    if (readableMap == null) {
+      // JS dropped the intent config (e.g. switched to checkout); reconfigure
+      // with whatever source is left.
+      view.latestIntentConfig = null
+      view.latestElementConfig?.let { configureIfReady(view, it) }
+      return
+    }
 
     // Detect which callback type to use based on the presence of the confirmation token handler
     val useConfirmationTokenCallback = readableMap.hasKey("confirmationTokenConfirmHandler")
     view.setUseConfirmationTokenCallback(useConfirmationTokenCallback)
 
-    val intentConfig = parseIntentConfiguration(readableMap)
-    view.latestIntentConfig = intentConfig
-    view.latestElementConfig?.let { elemCfg ->
-      view.configure(elemCfg, intentConfig)
+    view.latestIntentConfig = parseIntentConfiguration(readableMap)
+    view.latestElementConfig?.let { configureIfReady(view, it) }
+  }
+
+  @ReactProp(name = "checkout")
+  override fun setCheckout(
+    view: EmbeddedPaymentElementView,
+    cfg: Dynamic,
+  ) {
+    val sessionKey = cfg.asMapOrNull()?.getString("sessionKey")
+    if (sessionKey == null) {
+      // JS dropped the checkout (e.g. switched to intent config); reconfigure
+      // with whatever source is left.
+      view.latestCheckout = null
+      view.latestElementConfig?.let { configureIfReady(view, it) }
+      return
     }
+
+    val stripeSdkModule =
+      (view.context as ThemedReactContext).getNativeModule(StripeSdkModule::class.java)
+    val checkout = stripeSdkModule?.checkoutInstances?.get(sessionKey)
+    if (checkout == null) {
+      // Stale or unknown session key — surface it via loadingError instead
+      // of silently doing nothing.
+      view.latestCheckout = null
+      val payload =
+        Arguments.createMap().apply {
+          putString("message", "Checkout session not found.")
+        }
+      stripeSdkModule?.eventEmitter?.emitEmbeddedPaymentElementLoadingFailed(payload)
+      return
+    }
+
+    view.latestCheckout = checkout
+    view.latestElementConfig?.let { configureIfReady(view, it) }
+  }
+
+  /**
+   * Configures the embedded element once both the element config and an
+   * intent source (intent configuration or checkout) are set.
+   *
+   * Checkout wins when both are present so source selection is stable
+   * regardless of which prop arrived last. JS only ever sets one of the
+   * two at a time, so this only matters during transitional reconfigures.
+   *
+   * @return `true` when a configure was dispatched.
+   */
+  private fun configureIfReady(
+    view: EmbeddedPaymentElementView,
+    elementConfig: EmbeddedPaymentElement.Configuration,
+  ): Boolean {
+    view.latestCheckout?.let { checkout ->
+      view.configureWithCheckout(elementConfig, checkout)
+      return true
+    }
+    view.latestIntentConfig?.let { intentCfg ->
+      view.configure(elementConfig, intentCfg)
+      return true
+    }
+    return false
   }
 
   @SuppressLint("RestrictedApi")

--- a/android/src/main/java/com/reactnativestripesdk/EmbeddedPaymentElementViewManager.kt
+++ b/android/src/main/java/com/reactnativestripesdk/EmbeddedPaymentElementViewManager.kt
@@ -81,18 +81,9 @@ class EmbeddedPaymentElementViewManager :
     view: EmbeddedPaymentElementView,
     cfg: Dynamic,
   ) {
-    val readableMap = cfg.asMapOrNull()
-    if (readableMap == null) {
-      // JS dropped the intent config (e.g. switched to checkout); reconfigure
-      // with whatever source is left.
-      view.latestIntentConfig = null
-      view.latestElementConfig?.let { configureIfReady(view, it) }
-      return
-    }
+    val readableMap = cfg.asMapOrNull() ?: return
 
-    // Detect which callback type to use based on the presence of the confirmation token handler
-    val useConfirmationTokenCallback = readableMap.hasKey("confirmationTokenConfirmHandler")
-    view.setUseConfirmationTokenCallback(useConfirmationTokenCallback)
+    view.setUseConfirmationTokenCallback(readableMap.hasKey("confirmationTokenConfirmHandler"))
 
     view.latestIntentConfig = parseIntentConfiguration(readableMap)
     view.latestElementConfig?.let { configureIfReady(view, it) }
@@ -103,22 +94,12 @@ class EmbeddedPaymentElementViewManager :
     view: EmbeddedPaymentElementView,
     cfg: Dynamic,
   ) {
-    val sessionKey = cfg.asMapOrNull()?.getString("sessionKey")
-    if (sessionKey == null) {
-      // JS dropped the checkout (e.g. switched to intent config); reconfigure
-      // with whatever source is left.
-      view.latestCheckout = null
-      view.latestElementConfig?.let { configureIfReady(view, it) }
-      return
-    }
+    val sessionKey = cfg.asMapOrNull()?.getString("sessionKey") ?: return
 
     val stripeSdkModule =
       (view.context as ThemedReactContext).getNativeModule(StripeSdkModule::class.java)
     val checkout = stripeSdkModule?.checkoutInstances?.get(sessionKey)
     if (checkout == null) {
-      // Stale or unknown session key — surface it via loadingError instead
-      // of silently doing nothing.
-      view.latestCheckout = null
       val payload =
         Arguments.createMap().apply {
           putString("message", "Checkout session not found.")
@@ -133,13 +114,8 @@ class EmbeddedPaymentElementViewManager :
 
   /**
    * Configures the embedded element once both the element config and an
-   * intent source (intent configuration or checkout) are set.
-   *
-   * Checkout wins when both are present so source selection is stable
-   * regardless of which prop arrived last. JS only ever sets one of the
-   * two at a time, so this only matters during transitional reconfigures.
-   *
-   * @return `true` when a configure was dispatched.
+   * intent source (intent configuration or checkout) have arrived. Returns
+   * `true` when a configure was dispatched.
    */
   private fun configureIfReady(
     view: EmbeddedPaymentElementView,

--- a/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
+++ b/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
@@ -112,7 +112,7 @@ class StripeSdkModule(
   private var financialConnectionsSheetManager: FinancialConnectionsSheetManager? = null
   private var googlePayLauncherManager: GooglePayLauncherManager? = null
   private var googlePayPaymentMethodLauncherManager: GooglePayPaymentMethodLauncherManager? = null
-  private val checkoutInstances = mutableMapOf<String, Checkout>()
+  internal val checkoutInstances = mutableMapOf<String, Checkout>()
 
   private var customerSheetManager: CustomerSheetManager? = null
 
@@ -1390,13 +1390,26 @@ class StripeSdkModule(
     )
   }
 
+  // Android configures the embedded element through view props (see
+  // EmbeddedPaymentElementViewManager), so the bridge calls below are no-ops
+  // and only exist to keep the TurboModule contract symmetric with iOS.
+
   @ReactMethod
   override fun createEmbeddedPaymentElement(
     intentConfig: ReadableMap,
     configuration: ReadableMap,
     promise: Promise,
   ) {
-    // TODO:
+    promise.resolve(null)
+  }
+
+  @ReactMethod
+  override fun createEmbeddedPaymentElementWithCheckout(
+    sessionKey: String,
+    configuration: ReadableMap,
+    promise: Promise,
+  ) {
+    promise.resolve(null)
   }
 
   @ReactMethod

--- a/android/src/oldarch/java/com/facebook/react/viewmanagers/EmbeddedPaymentElementViewManagerDelegate.java
+++ b/android/src/oldarch/java/com/facebook/react/viewmanagers/EmbeddedPaymentElementViewManagerDelegate.java
@@ -30,6 +30,9 @@ public class EmbeddedPaymentElementViewManagerDelegate<T extends View, U extends
       case "intentConfiguration":
         mViewManager.setIntentConfiguration(view, new DynamicFromObject(value));
         break;
+      case "checkout":
+        mViewManager.setCheckout(view, new DynamicFromObject(value));
+        break;
       default:
         super.setProperty(view, propName, value);
     }

--- a/android/src/oldarch/java/com/facebook/react/viewmanagers/EmbeddedPaymentElementViewManagerInterface.java
+++ b/android/src/oldarch/java/com/facebook/react/viewmanagers/EmbeddedPaymentElementViewManagerInterface.java
@@ -16,6 +16,7 @@ import com.facebook.react.bridge.Dynamic;
 public interface EmbeddedPaymentElementViewManagerInterface<T extends View>  {
   void setConfiguration(T view, Dynamic value);
   void setIntentConfiguration(T view, Dynamic value);
+  void setCheckout(T view, Dynamic value);
   void confirm(T view);
   void clearPaymentOption(T view);
   void update(T view, @Nullable String intentConfigurationJson);

--- a/android/src/oldarch/java/com/reactnativestripesdk/NativeStripeSdkModuleSpec.java
+++ b/android/src/oldarch/java/com/reactnativestripesdk/NativeStripeSdkModuleSpec.java
@@ -255,6 +255,10 @@ public abstract class NativeStripeSdkModuleSpec extends ReactContextBaseJavaModu
 
   @ReactMethod
   @DoNotStrip
+  public abstract void createEmbeddedPaymentElementWithCheckout(String sessionKey, ReadableMap configuration, Promise promise);
+
+  @ReactMethod
+  @DoNotStrip
   public abstract void confirmEmbeddedPaymentElement(double viewTag, Promise promise);
 
   @ReactMethod

--- a/etc/stripe-react-native.api.md
+++ b/etc/stripe-react-native.api.md
@@ -3864,6 +3864,9 @@ export function useConfirmSetupIntent(): {
 // @public
 export function useEmbeddedPaymentElement(intentConfig: PaymentSheet.IntentConfiguration, configuration: EmbeddedPaymentElementConfiguration): UseEmbeddedPaymentElementResult;
 
+// @public
+export function useEmbeddedPaymentElement(checkout: Checkout, configuration: EmbeddedPaymentElementConfiguration): UseEmbeddedPaymentElementResult;
+
 // @public (undocumented)
 export interface UseEmbeddedPaymentElementResult {
     // (undocumented)

--- a/example/src/checkoutPlayground/CheckoutPlaygroundCartSections.tsx
+++ b/example/src/checkoutPlayground/CheckoutPlaygroundCartSections.tsx
@@ -7,6 +7,7 @@ import { cartStyles as styles } from './CheckoutPlaygroundCartStyles';
 import { type OrderSummaryRow } from './CheckoutPlaygroundCartUtils';
 import {
   formatCurrencyAmount,
+  getIntegrationTypeLabel,
   shouldShowAutomaticTax,
   type CheckoutPlaygroundConfig,
 } from './types';
@@ -76,6 +77,10 @@ export function SessionSection({
             label="Session ID"
             value={session.id}
             hint="Long press to copy"
+          />
+          <DetailRow
+            label="Integration"
+            value={getIntegrationTypeLabel(config.integrationType)}
           />
           <DetailRow label="Mode" value={config.mode} />
           <DetailRow label="Status" value={session.status ?? 'unknown'} />

--- a/example/src/checkoutPlayground/CheckoutPlaygroundCartUtils.ts
+++ b/example/src/checkoutPlayground/CheckoutPlaygroundCartUtils.ts
@@ -7,11 +7,23 @@ export type OrderSummaryRow = {
   emphasized?: boolean;
 };
 
+// Pre-fills the AddressSheet with Stripe HQ when the session has no address yet
+// so the playground doesn't require manually typing every field on every run.
+const DEFAULT_ADDRESS_SHEET_VALUES: AddressDetails = {
+  address: {
+    country: 'US',
+    line1: '354 Oyster Point Blvd',
+    city: 'South San Francisco',
+    state: 'CA',
+    postalCode: '94080',
+  },
+};
+
 export const toAddressSheetDefaultValues = (
   addressUpdate?: Checkout.AddressUpdate
-): AddressDetails | undefined => {
+): AddressDetails => {
   if (!addressUpdate) {
-    return undefined;
+    return DEFAULT_ADDRESS_SHEET_VALUES;
   }
 
   return {

--- a/example/src/checkoutPlayground/CheckoutPlaygroundCartView.tsx
+++ b/example/src/checkoutPlayground/CheckoutPlaygroundCartView.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo, useState } from 'react';
-import { ScrollView, View } from 'react-native';
+import { Modal, ScrollView, View } from 'react-native';
 import {
   AddressSheet,
   AddressSheetError,
@@ -16,6 +16,7 @@ import {
   SessionSection,
   ShippingOptionsSection,
 } from './CheckoutPlaygroundCartSections';
+import { CheckoutPlaygroundEmbeddedView } from './CheckoutPlaygroundEmbeddedView';
 import { cartStyles as styles } from './CheckoutPlaygroundCartStyles';
 import {
   buildOrderSummaryRows,
@@ -70,6 +71,7 @@ export function CheckoutPlaygroundCartView({
   const [promotionCode, setPromotionCode] = useState('');
   const [feedback, setFeedback] = useState<FeedbackState | null>(null);
   const [presentingPaymentSheet, setPresentingPaymentSheet] = useState(false);
+  const [embeddedModalVisible, setEmbeddedModalVisible] = useState(false);
   const [showShippingAddressSheet, setShowShippingAddressSheet] =
     useState(false);
   const [showBillingAddressSheet, setShowBillingAddressSheet] = useState(false);
@@ -510,9 +512,35 @@ export function CheckoutPlaygroundCartView({
         primaryDisabled={state?.status !== 'loaded' || presentingPaymentSheet}
         primaryLoading={presentingPaymentSheet}
         onPrimaryPress={() => {
-          handlePresentPaymentSheet();
+          if (config.integrationType === 'embedded') {
+            setFeedback(null);
+            setEmbeddedModalVisible(true);
+          } else {
+            handlePresentPaymentSheet();
+          }
         }}
       />
+
+      <Modal
+        visible={embeddedModalVisible}
+        animationType="slide"
+        presentationStyle="pageSheet"
+        onRequestClose={() => setEmbeddedModalVisible(false)}
+      >
+        {state?.status === 'loaded' ? (
+          <CheckoutPlaygroundEmbeddedView
+            checkout={checkout}
+            mode={config.mode}
+            currency={session.currency}
+            total={session.totals?.total}
+            onClose={() => setEmbeddedModalVisible(false)}
+            onSuccessfulPayment={() => {
+              setEmbeddedModalVisible(false);
+              onSuccessfulPayment();
+            }}
+          />
+        ) : null}
+      </Modal>
     </View>
   );
 }

--- a/example/src/checkoutPlayground/CheckoutPlaygroundCartView.tsx
+++ b/example/src/checkoutPlayground/CheckoutPlaygroundCartView.tsx
@@ -1,12 +1,14 @@
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Modal, ScrollView, View } from 'react-native';
 import {
   AddressSheet,
   AddressSheetError,
+  PaymentSheet,
   PaymentSheetError,
   useStripe,
 } from '@stripe/stripe-react-native';
 import { useCheckout } from '@stripe/stripe-react-native/src/hooks/useCheckout';
+import SelectedPaymentOption from '../components/SelectedPaymentOption';
 import { BottomActionBar, PlaygroundTitle, StatusBanner } from './components';
 import {
   AddressSection,
@@ -37,6 +39,8 @@ type FeedbackState = {
   message: string;
 };
 
+type FlowControllerStatus = 'idle' | 'initializing' | 'ready' | 'failed';
+
 type Props = {
   clientSecret: string;
   config: CheckoutPlaygroundConfig;
@@ -62,15 +66,64 @@ const getErrorCode = (error: unknown): string | undefined => {
   return undefined;
 };
 
+const getPaymentSheetFeedback = ({
+  error,
+  fallbackTitle,
+  fallbackMessage,
+  canceledTitle,
+  canceledMessage,
+}: {
+  error: unknown;
+  fallbackTitle: string;
+  fallbackMessage: string;
+  canceledTitle?: string;
+  canceledMessage?: string;
+}): FeedbackState => {
+  const errorCode = getErrorCode(error);
+
+  if (errorCode === PaymentSheetError.Canceled) {
+    return {
+      tone: 'info',
+      title: canceledTitle ?? fallbackTitle,
+      message:
+        canceledMessage ??
+        'The customer canceled the payment flow before it completed.',
+    };
+  }
+
+  if (errorCode === PaymentSheetError.Timeout) {
+    return {
+      tone: 'error',
+      title: fallbackTitle,
+      message: 'PaymentSheet timed out before the customer completed the flow.',
+    };
+  }
+
+  return {
+    tone: 'error',
+    title: fallbackTitle,
+    message: getErrorMessage(error, fallbackMessage),
+  };
+};
+
 export function CheckoutPlaygroundCartView({
   clientSecret,
   config,
   onSuccessfulPayment,
 }: Props) {
-  const { initPaymentSheet, presentPaymentSheet } = useStripe();
+  const { confirmPaymentSheetPayment, initPaymentSheet, presentPaymentSheet } =
+    useStripe();
   const [promotionCode, setPromotionCode] = useState('');
   const [feedback, setFeedback] = useState<FeedbackState | null>(null);
   const [presentingPaymentSheet, setPresentingPaymentSheet] = useState(false);
+  const [flowControllerStatus, setFlowControllerStatus] =
+    useState<FlowControllerStatus>('idle');
+  const [presentingFlowController, setPresentingFlowController] =
+    useState(false);
+  const [confirmingFlowController, setConfirmingFlowController] =
+    useState(false);
+  const [selectedPaymentOption, setSelectedPaymentOption] =
+    useState<PaymentSheet.PaymentOption | null>(null);
   const [embeddedModalVisible, setEmbeddedModalVisible] = useState(false);
   const [showShippingAddressSheet, setShowShippingAddressSheet] =
     useState(false);
@@ -93,9 +146,19 @@ export function CheckoutPlaygroundCartView({
     checkoutConfiguration
   );
 
+  const isEmbeddedIntegration = config.integrationType === 'embedded';
+  const isFlowControllerIntegration =
+    config.integrationType === 'paymentSheetFlowController';
   const session = state?.session;
   const isUpdating = state?.status === 'loading';
-  const disableActions = isUpdating || presentingPaymentSheet;
+  const isFlowControllerInitializing = flowControllerStatus === 'initializing';
+  const isFlowControllerReady = flowControllerStatus === 'ready';
+  const isProcessingPaymentUi =
+    presentingPaymentSheet ||
+    isFlowControllerInitializing ||
+    presentingFlowController ||
+    confirmingFlowController;
+  const disableActions = isUpdating || isProcessingPaymentUi;
   const shouldShowPromotionSection = supportsAdvancedCollection(config);
   const shouldShowLineItemSection = Boolean(session?.lineItems.length);
   const shouldShowShippingSection = Boolean(session?.shippingOptions.length);
@@ -130,6 +193,86 @@ export function CheckoutPlaygroundCartView({
     () => buildOrderSummaryRows(session?.totals),
     [session?.totals]
   );
+  const flowControllerActionLabel = selectedPaymentOption
+    ? 'Change payment method'
+    : 'Choose payment method';
+  const paymentSheetSetupParams = useMemo(
+    () => ({
+      checkout,
+      merchantDisplayName: 'Checkout Playground',
+      returnURL: 'com.stripe.react.native://stripe-redirect',
+      allowsDelayedPaymentMethods: true,
+      billingDetailsCollectionConfiguration: {
+        // TODO: Remove this once Android updates to set the customer email on the payment method.
+        attachDefaultsToPaymentMethod: true,
+      },
+    }),
+    [checkout]
+  );
+
+  const initialiseFlowController = useCallback(
+    async (options?: { reportError?: boolean }) => {
+      if (state?.status !== 'loaded') {
+        return false;
+      }
+
+      const reportError = options?.reportError ?? true;
+
+      setFlowControllerStatus('initializing');
+      setSelectedPaymentOption(null);
+
+      try {
+        const initResult = await initPaymentSheet({
+          ...paymentSheetSetupParams,
+          customFlow: true,
+        });
+
+        if (initResult.error) {
+          throw initResult.error;
+        }
+
+        setSelectedPaymentOption(initResult.paymentOption ?? null);
+        setFlowControllerStatus('ready');
+        return true;
+      } catch (paymentSheetError: unknown) {
+        setFlowControllerStatus('failed');
+        setSelectedPaymentOption(null);
+
+        if (reportError) {
+          setFeedback(
+            getPaymentSheetFeedback({
+              error: paymentSheetError,
+              fallbackTitle: 'PaymentSheet.FlowController failed',
+              fallbackMessage:
+                'Unable to prepare the custom PaymentSheet flow.',
+            })
+          );
+        }
+
+        return false;
+      }
+    },
+    [initPaymentSheet, paymentSheetSetupParams, state?.status]
+  );
+
+  useEffect(() => {
+    if (!isFlowControllerIntegration) {
+      setFlowControllerStatus('idle');
+      setSelectedPaymentOption(null);
+      return;
+    }
+
+    if (state?.status !== 'loaded' || flowControllerStatus !== 'idle') {
+      return;
+    }
+
+    initialiseFlowController().catch(() => {});
+  }, [
+    flowControllerStatus,
+    initialiseFlowController,
+    isFlowControllerIntegration,
+    state?.status,
+  ]);
 
   const runCheckoutAction = useCallback(
     async (title: string, action: () => Promise<void>) => {
@@ -137,6 +280,10 @@ export function CheckoutPlaygroundCartView({
 
       try {
         await action();
+
+        if (isFlowControllerIntegration) {
+          await initialiseFlowController();
+        }
       } catch (actionError: unknown) {
         setFeedback({
           tone: 'error',
@@ -148,7 +295,7 @@ export function CheckoutPlaygroundCartView({
         });
       }
     },
-    []
+    [initialiseFlowController, isFlowControllerIntegration]
   );
 
   const handleRefresh = useCallback(() => {
@@ -224,16 +371,7 @@ export function CheckoutPlaygroundCartView({
     let shouldNavigateBack = false;
 
     try {
-      const initResult = await initPaymentSheet({
-        checkout,
-        merchantDisplayName: 'Checkout Playground',
-        returnURL: 'com.stripe.react.native://stripe-redirect',
-        allowsDelayedPaymentMethods: true,
-        billingDetailsCollectionConfiguration: {
-          // TODO: Remove this once Android updates to set the customer email on the payment method.
-          attachDefaultsToPaymentMethod: true,
-        },
-      });
+      const initResult = await initPaymentSheet(paymentSheetSetupParams);
 
       if (initResult.error) {
         throw initResult.error;
@@ -254,21 +392,15 @@ export function CheckoutPlaygroundCartView({
         shouldNavigateBack = true;
       }
     } catch (paymentSheetError: unknown) {
-      const errorCode = getErrorCode(paymentSheetError);
-      let message = getErrorMessage(paymentSheetError, 'PaymentSheet failed.');
-
-      if (errorCode === PaymentSheetError.Canceled) {
-        message = 'The customer canceled PaymentSheet.';
-      } else if (errorCode === PaymentSheetError.Timeout) {
-        message =
-          'PaymentSheet timed out before the customer completed the flow.';
-      }
-
-      setFeedback({
-        tone: 'error',
-        title: 'PaymentSheet failed',
-        message,
-      });
+      setFeedback(
+        getPaymentSheetFeedback({
+          error: paymentSheetError,
+          fallbackTitle: 'PaymentSheet failed',
+          fallbackMessage: 'PaymentSheet failed.',
+          canceledTitle: 'PaymentSheet canceled',
+          canceledMessage: 'The customer canceled PaymentSheet.',
+        })
+      );
     } finally {
       setPresentingPaymentSheet(false);
     }
@@ -277,12 +409,106 @@ export function CheckoutPlaygroundCartView({
       onSuccessfulPayment();
     }
   }, [
-    checkout,
     initPaymentSheet,
     onSuccessfulPayment,
+    paymentSheetSetupParams,
     presentPaymentSheet,
     state?.status,
   ]);
+
+  const handleChoosePaymentMethod = useCallback(async () => {
+    if (state?.status !== 'loaded') {
+      return;
+    }
+
+    setFeedback(null);
+
+    let isReady = isFlowControllerReady;
+    if (!isReady) {
+      isReady = await initialiseFlowController();
+    }
+
+    if (!isReady) {
+      return;
+    }
+
+    setPresentingFlowController(true);
+
+    try {
+      const presentResult = await presentPaymentSheet();
+
+      if (presentResult.error) {
+        throw presentResult.error;
+      }
+
+      if (presentResult.paymentOption) {
+        setSelectedPaymentOption(presentResult.paymentOption);
+      } else if (!presentResult.didCancel) {
+        setSelectedPaymentOption(null);
+      }
+
+      if (presentResult.didCancel) {
+        setFeedback({
+          tone: 'info',
+          title: 'Payment method selection canceled',
+          message: 'The customer dismissed payment method selection.',
+        });
+      }
+    } catch (paymentSheetError: unknown) {
+      setFeedback(
+        getPaymentSheetFeedback({
+          error: paymentSheetError,
+          fallbackTitle: 'PaymentSheet.FlowController failed',
+          fallbackMessage: 'Unable to load payment methods.',
+          canceledTitle: 'Payment method selection canceled',
+          canceledMessage: 'The customer dismissed payment method selection.',
+        })
+      );
+    } finally {
+      setPresentingFlowController(false);
+    }
+  }, [
+    initialiseFlowController,
+    isFlowControllerReady,
+    presentPaymentSheet,
+    state?.status,
+  ]);
+
+  const handleConfirmFlowControllerPayment = useCallback(async () => {
+    if (!selectedPaymentOption) {
+      return;
+    }
+
+    setFeedback(null);
+    setConfirmingFlowController(true);
+    let shouldNavigateBack = false;
+
+    try {
+      const confirmResult = await confirmPaymentSheetPayment();
+      if (confirmResult.error) {
+        throw confirmResult.error;
+      }
+
+      shouldNavigateBack = true;
+    } catch (paymentSheetError: unknown) {
+      setFeedback(
+        getPaymentSheetFeedback({
+          error: paymentSheetError,
+          fallbackTitle: 'PaymentSheet.FlowController failed',
+          fallbackMessage: 'Unable to confirm the Checkout Session.',
+          canceledTitle: 'Confirmation canceled',
+          canceledMessage:
+            'The customer canceled before the Checkout Session was confirmed.',
+        })
+      );
+    } finally {
+      setConfirmingFlowController(false);
+    }
+
+    if (shouldNavigateBack) {
+      onSuccessfulPayment();
+    }
+  }, [confirmPaymentSheetPayment, onSuccessfulPayment, selectedPaymentOption]);
 
   if (error) {
     return (
@@ -323,12 +549,19 @@ export function CheckoutPlaygroundCartView({
   return (
     <View style={styles.root}>
       <ScrollView
-        contentContainerStyle={styles.content}
+        contentContainerStyle={[
+          styles.content,
+          { paddingBottom: isFlowControllerIntegration ? 216 : 128 },
+        ]}
         keyboardShouldPersistTaps="handled"
       >
         <PlaygroundTitle
           title="Your Cart"
-          subtitle="Review your items and complete checkout."
+          subtitle={
+            isFlowControllerIntegration
+              ? 'Review your items, choose a payment method, then confirm the Checkout Session.'
+              : 'Review your items and complete checkout.'
+          }
         />
 
         {feedback ? (
@@ -345,6 +578,14 @@ export function CheckoutPlaygroundCartView({
             tone="info"
             title="Updating checkout"
             message="A checkout mutation is in flight. The totals shown below may still be refreshing."
+          />
+        ) : null}
+
+        {isFlowControllerIntegration && isFlowControllerInitializing ? (
+          <StatusBanner
+            tone="info"
+            title="Preparing PaymentSheet.FlowController"
+            message="Refreshing payment options for the latest checkout session."
           />
         ) : null}
 
@@ -437,6 +678,10 @@ export function CheckoutPlaygroundCartView({
             rows={orderSummaryRows}
           />
         ) : null}
+
+        {isFlowControllerIntegration ? (
+          <SelectedPaymentOption paymentOption={selectedPaymentOption} />
+        ) : null}
       </ScrollView>
 
       <AddressSheet
@@ -509,12 +754,25 @@ export function CheckoutPlaygroundCartView({
                 session.currency
               )}`
         }
-        primaryDisabled={state?.status !== 'loaded' || presentingPaymentSheet}
-        primaryLoading={presentingPaymentSheet}
+        primaryDisabled={
+          state?.status !== 'loaded' ||
+          disableActions ||
+          (isFlowControllerIntegration && !selectedPaymentOption)
+        }
+        primaryLoading={presentingPaymentSheet || confirmingFlowController}
+        secondaryLabel={
+          isFlowControllerIntegration ? flowControllerActionLabel : undefined
+        }
+        secondaryDisabled={state?.status !== 'loaded' || disableActions}
+        onSecondaryPress={
+          isFlowControllerIntegration ? handleChoosePaymentMethod : undefined
+        }
         onPrimaryPress={() => {
-          if (config.integrationType === 'embedded') {
+          if (isEmbeddedIntegration) {
             setFeedback(null);
             setEmbeddedModalVisible(true);
+          } else if (isFlowControllerIntegration) {
+            handleConfirmFlowControllerPayment();
           } else {
             handlePresentPaymentSheet();
           }

--- a/example/src/checkoutPlayground/CheckoutPlaygroundConfigView.tsx
+++ b/example/src/checkoutPlayground/CheckoutPlaygroundConfigView.tsx
@@ -87,7 +87,7 @@ export function CheckoutPlaygroundConfigView({
         <GroupedCard>
           <PickerRow
             title="Integration"
-            description="PaymentSheet or Embedded."
+            description="PaymentSheet, PaymentSheet.FlowController, or Embedded."
             selectedValue={config.integrationType}
             options={integrationTypeOptions}
             onValueChange={(integrationType) =>

--- a/example/src/checkoutPlayground/CheckoutPlaygroundConfigView.tsx
+++ b/example/src/checkoutPlayground/CheckoutPlaygroundConfigView.tsx
@@ -23,6 +23,7 @@ import {
   availablePaymentMethods,
   currencyOptions,
   customerTypeOptions,
+  integrationTypeOptions,
   modeOptions,
   normalizePaymentMethodTypes,
   shouldShowAdaptivePricingCountry,
@@ -71,7 +72,7 @@ export function CheckoutPlaygroundConfigView({
       >
         <PlaygroundTitle
           title="Checkout Playground"
-          subtitle="Configure a Checkout Session against the hosted demo backend, then explore the backend-defined cart and PaymentSheet flow."
+          subtitle="Configure a Checkout Session against the hosted demo backend, then explore the backend-defined cart and payment flow."
         />
 
         {errorMessage ? (
@@ -84,6 +85,18 @@ export function CheckoutPlaygroundConfigView({
 
         <SectionHeader badge="G" title="Configuration" />
         <GroupedCard>
+          <PickerRow
+            title="Integration"
+            description="PaymentSheet or Embedded."
+            selectedValue={config.integrationType}
+            options={integrationTypeOptions}
+            onValueChange={(integrationType) =>
+              updateConfig({
+                integrationType:
+                  integrationType as CheckoutPlaygroundConfig['integrationType'],
+              })
+            }
+          />
           <PickerRow
             title="Mode"
             description="Payment, subscription, or setup."

--- a/example/src/checkoutPlayground/CheckoutPlaygroundEmbeddedView.tsx
+++ b/example/src/checkoutPlayground/CheckoutPlaygroundEmbeddedView.tsx
@@ -1,0 +1,257 @@
+import React, { useCallback, useMemo, useRef, useState } from 'react';
+import {
+  ActivityIndicator,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import {
+  useEmbeddedPaymentElement,
+  type EmbeddedPaymentElementResult,
+} from '@stripe/stripe-react-native';
+import type { Checkout } from '@stripe/stripe-react-native/src/types/Checkout';
+import { colors } from '../colors';
+import SelectedPaymentOption from '../components/SelectedPaymentOption';
+import { BottomActionBar, StatusBanner } from './components';
+import { formatCurrencyAmount, type CheckoutPlaygroundMode } from './types';
+
+type FeedbackState = {
+  tone: 'error' | 'success' | 'info';
+  title: string;
+  message: string;
+};
+
+type Props = {
+  checkout: Checkout;
+  mode: CheckoutPlaygroundMode;
+  currency?: string;
+  total?: number;
+  onClose(): void;
+  onSuccessfulPayment(): void;
+};
+
+export function CheckoutPlaygroundEmbeddedView({
+  checkout,
+  mode,
+  currency,
+  total,
+  onClose,
+  onSuccessfulPayment,
+}: Props) {
+  return (
+    <SafeAreaView style={styles.root} edges={['top', 'left', 'right']}>
+      <View style={styles.header}>
+        <Text style={styles.headerTitle}>Embedded checkout</Text>
+        <TouchableOpacity
+          accessibilityRole="button"
+          accessibilityLabel="Close embedded checkout"
+          onPress={onClose}
+          style={styles.closeButton}
+        >
+          <Text style={styles.closeButtonText}>Close</Text>
+        </TouchableOpacity>
+      </View>
+      <EmbeddedCheckoutBody
+        checkout={checkout}
+        mode={mode}
+        currency={currency}
+        total={total}
+        onSuccessfulPayment={onSuccessfulPayment}
+      />
+    </SafeAreaView>
+  );
+}
+
+type BodyProps = {
+  checkout: Checkout;
+  mode: CheckoutPlaygroundMode;
+  currency?: string;
+  total?: number;
+  onSuccessfulPayment(): void;
+};
+
+function EmbeddedCheckoutBody({
+  checkout,
+  mode,
+  currency,
+  total,
+  onSuccessfulPayment,
+}: BodyProps) {
+  const [feedback, setFeedback] = useState<FeedbackState | null>(null);
+  const [confirming, setConfirming] = useState(false);
+
+  // Refs so the embedded configuration doesn't change identity each render
+  // and force a re-create of the underlying element.
+  const onSuccessfulPaymentRef = useRef(onSuccessfulPayment);
+  onSuccessfulPaymentRef.current = onSuccessfulPayment;
+
+  const handlePaymentResult = useCallback(
+    (result: EmbeddedPaymentElementResult) => {
+      if (result.status === 'completed') {
+        onSuccessfulPaymentRef.current();
+        return;
+      }
+      if (result.status === 'canceled') {
+        setFeedback({
+          tone: 'info',
+          title: 'Payment canceled',
+          message: 'The customer dismissed the payment flow before completing.',
+        });
+        return;
+      }
+      setFeedback({
+        tone: 'error',
+        title: 'Payment failed',
+        message: result.error.message,
+      });
+    },
+    []
+  );
+
+  const embeddedConfiguration = useMemo(
+    () => ({
+      merchantDisplayName: 'Checkout Playground',
+      returnURL: 'com.stripe.react.native://stripe-redirect',
+      // Confirm inside the form sheet for card-style methods. The result
+      // arrives via this callback rather than the external `confirm()` Promise.
+      formSheetAction: {
+        type: 'confirm' as const,
+        onFormSheetConfirmComplete: handlePaymentResult,
+      },
+    }),
+    [handlePaymentResult]
+  );
+
+  const {
+    embeddedPaymentElementView,
+    paymentOption,
+    confirm,
+    loadingError,
+    isLoaded,
+  } = useEmbeddedPaymentElement(checkout, embeddedConfiguration);
+
+  // Used by the bottom action bar for payment methods that don't open a
+  // form sheet (e.g. Apple Pay, saved cards).
+  const handleConfirm = useCallback(async () => {
+    setFeedback(null);
+    setConfirming(true);
+    try {
+      handlePaymentResult(await confirm());
+    } finally {
+      setConfirming(false);
+    }
+  }, [confirm, handlePaymentResult]);
+
+  const primaryLabel =
+    mode === 'setup'
+      ? 'Set up payment method'
+      : `Pay ${formatCurrencyAmount(total ?? 0, currency)}`;
+
+  return (
+    <>
+      <ScrollView
+        contentContainerStyle={styles.content}
+        keyboardShouldPersistTaps="handled"
+      >
+        <Text style={styles.subtitle}>
+          Drives the same Checkout Session through Stripe's Embedded Payment
+          Element.
+        </Text>
+
+        {feedback ? (
+          <StatusBanner
+            tone={feedback.tone}
+            title={feedback.title}
+            message={feedback.message}
+            onDismiss={() => setFeedback(null)}
+          />
+        ) : null}
+
+        {loadingError ? (
+          <StatusBanner
+            tone="error"
+            title="Unable to load payment form"
+            message={loadingError.message}
+          />
+        ) : null}
+
+        <View style={styles.elementWrapper}>
+          <View style={{ opacity: isLoaded ? 1 : 0 }}>
+            {embeddedPaymentElementView}
+          </View>
+          {!isLoaded && !loadingError ? (
+            <View style={styles.loadingOverlay}>
+              <ActivityIndicator color={colors.blurple} />
+              <Text style={styles.loadingText}>Loading payment options...</Text>
+            </View>
+          ) : null}
+        </View>
+
+        <SelectedPaymentOption paymentOption={paymentOption} />
+      </ScrollView>
+
+      <BottomActionBar
+        primaryLabel={primaryLabel}
+        primaryDisabled={!paymentOption || !isLoaded || confirming}
+        primaryLoading={confirming}
+        onPrimaryPress={handleConfirm}
+      />
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+    backgroundColor: '#F6F9FC',
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 20,
+    paddingTop: 24,
+    paddingBottom: 16,
+  },
+  headerTitle: {
+    color: colors.slate,
+    fontSize: 22,
+    fontWeight: '700',
+  },
+  closeButton: {
+    paddingVertical: 8,
+    paddingHorizontal: 12,
+    borderRadius: 999,
+    backgroundColor: '#EEF2FF',
+  },
+  closeButtonText: {
+    color: colors.blurple_dark,
+    fontWeight: '700',
+  },
+  content: {
+    paddingHorizontal: 16,
+    paddingBottom: 160,
+  },
+  subtitle: {
+    color: colors.dark_gray,
+    fontSize: 14,
+    lineHeight: 20,
+    marginBottom: 16,
+  },
+  elementWrapper: {
+    position: 'relative',
+    marginBottom: 8,
+  },
+  loadingOverlay: {
+    paddingVertical: 32,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  loadingText: {
+    color: colors.dark_gray,
+    marginTop: 8,
+  },
+});

--- a/example/src/checkoutPlayground/CheckoutPlaygroundFormRows.tsx
+++ b/example/src/checkoutPlayground/CheckoutPlaygroundFormRows.tsx
@@ -249,7 +249,6 @@ const styles = StyleSheet.create({
   },
   selectionTrigger: {
     minWidth: 116,
-    maxWidth: 152,
     paddingHorizontal: 12,
     paddingVertical: 10,
     borderRadius: 999,
@@ -257,9 +256,9 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'space-between',
+    flexShrink: 0,
   },
   selectionTriggerText: {
-    flex: 1,
     color: colors.slate,
     fontWeight: '600',
     marginRight: 8,

--- a/example/src/checkoutPlayground/CheckoutPlaygroundUI.tsx
+++ b/example/src/checkoutPlayground/CheckoutPlaygroundUI.tsx
@@ -107,6 +107,7 @@ export function BottomActionBar({
   primaryDisabled,
   primaryLoading,
   secondaryLabel,
+  secondaryDisabled,
   onSecondaryPress,
 }: {
   primaryLabel: string;
@@ -114,16 +115,28 @@ export function BottomActionBar({
   primaryDisabled?: boolean;
   primaryLoading?: boolean;
   secondaryLabel?: string;
+  secondaryDisabled?: boolean;
   onSecondaryPress?(): void;
 }) {
   return (
     <View style={styles.actionBar}>
       {secondaryLabel && onSecondaryPress ? (
         <TouchableOpacity
+          disabled={secondaryDisabled}
           onPress={onSecondaryPress}
-          style={styles.secondaryAction}
+          style={[
+            styles.secondaryAction,
+            secondaryDisabled && styles.secondaryActionDisabled,
+          ]}
         >
-          <Text style={styles.secondaryActionText}>{secondaryLabel}</Text>
+          <Text
+            style={[
+              styles.secondaryActionText,
+              secondaryDisabled && styles.secondaryActionTextDisabled,
+            ]}
+          >
+            {secondaryLabel}
+          </Text>
         </TouchableOpacity>
       ) : null}
       <TouchableOpacity
@@ -274,12 +287,27 @@ const styles = StyleSheet.create({
     elevation: 8,
   },
   secondaryAction: {
-    alignSelf: 'center',
+    alignSelf: 'stretch',
+    minHeight: 52,
+    borderRadius: 999,
+    borderWidth: 1,
+    borderColor: colors.blurple,
+    backgroundColor: '#EEF2FF',
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 20,
     marginBottom: 12,
   },
+  secondaryActionDisabled: {
+    opacity: 0.5,
+  },
   secondaryActionText: {
-    color: colors.dark_gray,
-    fontWeight: '600',
+    color: colors.blurple_dark,
+    fontSize: 16,
+    fontWeight: '700',
+  },
+  secondaryActionTextDisabled: {
+    color: '#94A3B8',
   },
   primaryAction: {
     backgroundColor: colors.slate,

--- a/example/src/checkoutPlayground/types.ts
+++ b/example/src/checkoutPlayground/types.ts
@@ -22,6 +22,8 @@ export type AdaptivePricingCountry =
   | 'gb'
   | 'br';
 
+export type CheckoutPlaygroundIntegrationType = 'paymentSheet' | 'embedded';
+
 export type SelectionOption<T extends string> = {
   label: string;
   value: T;
@@ -31,6 +33,7 @@ export type CheckoutPlaygroundConfig = {
   mode: CheckoutPlaygroundMode;
   currency: CheckoutPlaygroundCurrency;
   customerType: CheckoutPlaygroundCustomerType;
+  integrationType: CheckoutPlaygroundIntegrationType;
   enableShipping: boolean;
   allowPromotionCodes: boolean;
   phoneNumberCollection: boolean;
@@ -71,6 +74,12 @@ export const customerTypeOptions: SelectionOption<CheckoutPlaygroundCustomerType
     { label: 'Returning', value: 'returning' },
   ];
 
+export const integrationTypeOptions: SelectionOption<CheckoutPlaygroundIntegrationType>[] =
+  [
+    { label: 'PaymentSheet', value: 'paymentSheet' },
+    { label: 'Embedded', value: 'embedded' },
+  ];
+
 export const adaptivePricingCountryOptions: SelectionOption<AdaptivePricingCountry>[] =
   [
     { label: 'None', value: 'none' },
@@ -94,6 +103,7 @@ export const defaultCheckoutPlaygroundConfig: CheckoutPlaygroundConfig = {
   mode: 'payment',
   currency: 'usd',
   customerType: 'guest',
+  integrationType: 'paymentSheet',
   enableShipping: true,
   allowPromotionCodes: true,
   phoneNumberCollection: false,

--- a/example/src/checkoutPlayground/types.ts
+++ b/example/src/checkoutPlayground/types.ts
@@ -22,7 +22,10 @@ export type AdaptivePricingCountry =
   | 'gb'
   | 'br';
 
-export type CheckoutPlaygroundIntegrationType = 'paymentSheet' | 'embedded';
+export type CheckoutPlaygroundIntegrationType =
+  | 'paymentSheet'
+  | 'paymentSheetFlowController'
+  | 'embedded';
 
 export type SelectionOption<T extends string> = {
   label: string;
@@ -77,6 +80,10 @@ export const customerTypeOptions: SelectionOption<CheckoutPlaygroundCustomerType
 export const integrationTypeOptions: SelectionOption<CheckoutPlaygroundIntegrationType>[] =
   [
     { label: 'PaymentSheet', value: 'paymentSheet' },
+    {
+      label: 'PaymentSheet.FlowController',
+      value: 'paymentSheetFlowController',
+    },
     { label: 'Embedded', value: 'embedded' },
   ];
 
@@ -151,6 +158,12 @@ export const normalizePaymentMethodTypes = (
 
 export const getCurrencyOption = (currency: string) =>
   currencyOptions.find((option) => option.value === currency);
+
+export const getIntegrationTypeLabel = (
+  integrationType: CheckoutPlaygroundIntegrationType
+): string =>
+  integrationTypeOptions.find((option) => option.value === integrationType)
+    ?.label ?? integrationType;
 
 export const formatCurrencyAmount = (
   amount?: number,

--- a/example/src/screens/CheckoutScreen.tsx
+++ b/example/src/screens/CheckoutScreen.tsx
@@ -1,5 +1,6 @@
 import { useNavigation } from '@react-navigation/native';
 import React, { useCallback, useState } from 'react';
+import { Alert } from 'react-native';
 import { initStripe } from '@stripe/stripe-react-native';
 import { fetchCheckoutSessionParams } from '../api/checkoutSession';
 import { CheckoutPlaygroundCartView } from '../checkoutPlayground/CheckoutPlaygroundCartView';
@@ -70,6 +71,10 @@ export default function CheckoutScreen() {
         config={config}
         onSuccessfulPayment={() => {
           navigation.goBack();
+          Alert.alert(
+            'Payment successful',
+            'The Checkout Session was confirmed.'
+          );
         }}
       />
     );

--- a/ios/StripeSdk.mm
+++ b/ios/StripeSdk.mm
@@ -553,6 +553,17 @@ RCT_EXPORT_METHOD(createEmbeddedPaymentElement:(nonnull NSDictionary *)intentCon
                                               reject:reject];
 }
 
+RCT_EXPORT_METHOD(createEmbeddedPaymentElementWithCheckout:(nonnull NSString *)sessionKey
+                                             configuration:(nonnull NSDictionary *)configuration
+                                                   resolve:(nonnull RCTPromiseResolveBlock)resolve
+                                                    reject:(nonnull RCTPromiseRejectBlock)reject)
+{
+  [StripeSdkImpl.shared createEmbeddedPaymentElementWithCheckout:sessionKey
+                                                   configuration:configuration
+                                                         resolve:resolve
+                                                          reject:reject];
+}
+
 RCT_EXPORT_METHOD(confirmEmbeddedPaymentElement:(NSInteger)viewTag
                                         resolve:(nonnull RCTPromiseResolveBlock)resolve
                                          reject:(nonnull RCTPromiseRejectBlock)reject)

--- a/ios/StripeSdkImpl+Embedded.swift
+++ b/ios/StripeSdkImpl+Embedded.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-@_spi(EmbeddedPaymentElementPrivateBeta) @_spi(ExperimentalAllowsRemovalOfLastSavedPaymentMethodAPI) @_spi(CustomerSessionBetaAccess) @_spi(STP) @_spi(CustomPaymentMethodsBeta) @_spi(CardFundingFilteringPrivatePreview) import StripePaymentSheet
+@_spi(EmbeddedPaymentElementPrivateBeta) @_spi(ExperimentalAllowsRemovalOfLastSavedPaymentMethodAPI) @_spi(CustomerSessionBetaAccess) @_spi(STP) @_spi(CustomPaymentMethodsBeta) @_spi(CardFundingFilteringPrivatePreview) @_spi(CheckoutSessionsPreview) import StripePaymentSheet
 
 @objc(StripeSdkImpl)
 extension StripeSdkImpl {
@@ -18,20 +18,26 @@ extension StripeSdkImpl {
                                            configuration: NSDictionary,
                                            resolve: @escaping RCTPromiseResolveBlock,
                                            reject: @escaping RCTPromiseRejectBlock) {
+    // JS only listens for the loading-failed event, so surface validation
+    // errors via emitLoadingFailed and resolve nil — the resolved value
+    // would otherwise be dropped on the floor.
     guard let modeParams = intentConfig["mode"] as? NSDictionary else {
-      resolve(Errors.createError(ErrorType.Failed, "One of `paymentIntentClientSecret`, `setupIntentClientSecret`, or `intentConfiguration.mode` is required"))
+      emitLoadingFailed(message: "One of `paymentIntentClientSecret`, `setupIntentClientSecret`, or `intentConfiguration.mode` is required")
+      resolve(nil)
       return
     }
     let hasConfirmHandler = intentConfig.object(forKey: "confirmHandler") != nil
     let hasConfirmationTokenHandler = intentConfig.object(forKey: "confirmationTokenConfirmHandler") != nil
 
     if !hasConfirmHandler && !hasConfirmationTokenHandler {
-      resolve(Errors.createError(ErrorType.Failed, "You must provide either `intentConfiguration.confirmHandler` or `intentConfiguration.confirmationTokenConfirmHandler` if you are not passing an intent client secret"))
+      emitLoadingFailed(message: "You must provide either `intentConfiguration.confirmHandler` or `intentConfiguration.confirmationTokenConfirmHandler` if you are not passing an intent client secret")
+      resolve(nil)
       return
     }
 
     if hasConfirmHandler && hasConfirmationTokenHandler {
-      resolve(Errors.createError(ErrorType.Failed, "You must provide either `confirmHandler` or `confirmationTokenConfirmHandler`, but not both"))
+      emitLoadingFailed(message: "You must provide either `confirmHandler` or `confirmationTokenConfirmHandler`, but not both")
+      resolve(nil)
       return
     }
     let captureMethodString = intentConfig["captureMethod"] as? String
@@ -44,7 +50,8 @@ extension StripeSdkImpl {
     )
 
     guard let configuration = buildEmbeddedPaymentElementConfiguration(params: configuration).configuration else {
-      resolve(Errors.createError(ErrorType.Failed, "Invalid configuration"))
+      emitLoadingFailed(message: "Invalid configuration")
+      resolve(nil)
       return
     }
 
@@ -54,26 +61,75 @@ extension StripeSdkImpl {
           intentConfiguration: intentConfig,
           configuration: configuration
         )
-        embeddedPaymentElement.delegate = embeddedInstanceDelegate
-        embeddedPaymentElement.presentingViewController = RCTPresentedViewController()
-        self.embeddedInstance = embeddedPaymentElement
-
-        // success: resolve promise
+        attachEmbedded(embeddedPaymentElement)
         resolve(nil)
-
-        // publish initial state
-        embeddedInstanceDelegate.embeddedPaymentElementDidUpdateHeight(embeddedPaymentElement: embeddedPaymentElement)
-        embeddedInstanceDelegate.embeddedPaymentElementDidUpdatePaymentOption(embeddedPaymentElement: embeddedPaymentElement)
       } catch {
-        // 1) still resolve the promise so JS hook can finish loading
+        emitLoadingFailed(error: error)
+        // Resolve so the JS hook can finish loading; loading errors are
+        // surfaced through the embeddedPaymentElementLoadingFailed event.
         resolve(nil)
-
-        // 2) emit a loading‐failed event with the error message
-        let msg = error.localizedDescription
-        self.emitter?.emitEmbeddedPaymentElementLoadingFailed(["message": msg])
       }
     }
+  }
 
+  @objc(createEmbeddedPaymentElementWithCheckout:configuration:resolve:reject:)
+  public func createEmbeddedPaymentElementWithCheckout(
+    sessionKey: String,
+    configuration: NSDictionary,
+    resolve: @escaping RCTPromiseResolveBlock,
+    reject: @escaping RCTPromiseRejectBlock
+  ) {
+    guard let checkout = checkoutInstances[sessionKey] else {
+      // Emit so a stale or unknown session key shows up as the JS hook's
+      // loadingError, rather than a silently resolved error payload.
+      emitLoadingFailed(message: "Checkout session not found")
+      resolve(nil)
+      return
+    }
+
+    guard let configuration = buildEmbeddedPaymentElementConfiguration(params: configuration).configuration else {
+      emitLoadingFailed(message: "Invalid configuration")
+      resolve(nil)
+      return
+    }
+
+    Task {
+      do {
+        let embeddedPaymentElement = try await EmbeddedPaymentElement.create(
+          checkout: checkout,
+          configuration: configuration
+        )
+        attachEmbedded(embeddedPaymentElement)
+        resolve(nil)
+      } catch {
+        emitLoadingFailed(error: error)
+        // Resolve so the JS hook can finish loading; loading errors are
+        // surfaced through the embeddedPaymentElementLoadingFailed event.
+        resolve(nil)
+      }
+    }
+  }
+
+  /// Wires up a freshly created element and emits its initial height /
+  /// payment-option state to JS.
+  @nonobjc
+  private func attachEmbedded(_ element: EmbeddedPaymentElement) {
+    element.delegate = embeddedInstanceDelegate
+    element.presentingViewController = RCTPresentedViewController()
+    self.embeddedInstance = element
+
+    embeddedInstanceDelegate.embeddedPaymentElementDidUpdateHeight(embeddedPaymentElement: element)
+    embeddedInstanceDelegate.embeddedPaymentElementDidUpdatePaymentOption(embeddedPaymentElement: element)
+  }
+
+  @nonobjc
+  private func emitLoadingFailed(message: String) {
+    self.emitter?.emitEmbeddedPaymentElementLoadingFailed(["message": message])
+  }
+
+  @nonobjc
+  private func emitLoadingFailed(error: Error) {
+    emitLoadingFailed(message: error.localizedDescription)
   }
 
   @objc(confirmEmbeddedPaymentElement:reject:)

--- a/ios/StripeSdkImpl+Embedded.swift
+++ b/ios/StripeSdkImpl+Embedded.swift
@@ -18,9 +18,6 @@ extension StripeSdkImpl {
                                            configuration: NSDictionary,
                                            resolve: @escaping RCTPromiseResolveBlock,
                                            reject: @escaping RCTPromiseRejectBlock) {
-    // JS only listens for the loading-failed event, so surface validation
-    // errors via emitLoadingFailed and resolve nil — the resolved value
-    // would otherwise be dropped on the floor.
     guard let modeParams = intentConfig["mode"] as? NSDictionary else {
       emitLoadingFailed(message: "One of `paymentIntentClientSecret`, `setupIntentClientSecret`, or `intentConfiguration.mode` is required")
       resolve(nil)
@@ -80,8 +77,6 @@ extension StripeSdkImpl {
     reject: @escaping RCTPromiseRejectBlock
   ) {
     guard let checkout = checkoutInstances[sessionKey] else {
-      // Emit so a stale or unknown session key shows up as the JS hook's
-      // loadingError, rather than a silently resolved error payload.
       emitLoadingFailed(message: "Checkout session not found")
       resolve(nil)
       return
@@ -103,8 +98,6 @@ extension StripeSdkImpl {
         resolve(nil)
       } catch {
         emitLoadingFailed(error: error)
-        // Resolve so the JS hook can finish loading; loading errors are
-        // surfaced through the embeddedPaymentElementLoadingFailed event.
         resolve(nil)
       }
     }

--- a/src/hooks/useCheckout.tsx
+++ b/src/hooks/useCheckout.tsx
@@ -11,12 +11,6 @@ import type { Checkout } from '../types/Checkout';
  *
  * Pass the returned `checkout` to `initPaymentSheet` to complete the purchase.
  *
- * The returned `checkout` handle is a stable reference, but its `sessionKey`
- * is not valid until `state.status === 'loaded'`. When passing `checkout` to
- * `useEmbeddedPaymentElement`, gate rendering on the loaded state and split
- * the consumer into a child component (see `useEmbeddedPaymentElement` docs
- * for an example).
- *
  * @internal
  */
 export function useCheckout(

--- a/src/hooks/useCheckout.tsx
+++ b/src/hooks/useCheckout.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import NativeStripeSdk from '../specs/NativeStripeSdkModule';
 import type { Checkout } from '../types/Checkout';
 
@@ -10,6 +10,12 @@ import type { Checkout } from '../types/Checkout';
  * `loading` as mutations are performed.
  *
  * Pass the returned `checkout` to `initPaymentSheet` to complete the purchase.
+ *
+ * The returned `checkout` handle is a stable reference, but its `sessionKey`
+ * is not valid until `state.status === 'loaded'`. When passing `checkout` to
+ * `useEmbeddedPaymentElement`, gate rendering on the loaded state and split
+ * the consumer into a child component (see `useEmbeddedPaymentElement` docs
+ * for an example).
  *
  * @internal
  */
@@ -89,80 +95,110 @@ export function useCheckout(
     []
   );
 
-  // Mutation methods — each delegates to withLoading.
-  const checkout: Checkout = {
-    get sessionKey(): string {
-      if (!sessionKeyRef.current) {
-        throw new Error('Checkout session not initialized.');
-      }
-      return sessionKeyRef.current;
-    },
-    updateShippingAddress: useCallback(
-      (address, name, phone) =>
-        withLoading((key) =>
-          NativeStripeSdk.checkoutUpdateShippingAddress(
-            key,
-            address,
-            name ?? null,
-            phone ?? null
-          )
-        ),
-      [withLoading]
-    ),
-    updateBillingAddress: useCallback(
-      (address, name, phone) =>
-        withLoading((key) =>
-          NativeStripeSdk.checkoutUpdateBillingAddress(
-            key,
-            address,
-            name ?? null,
-            phone ?? null
-          )
-        ),
-      [withLoading]
-    ),
-    applyPromotionCode: useCallback(
-      (code) =>
-        withLoading((key) =>
-          NativeStripeSdk.checkoutApplyPromotionCode(key, code)
-        ),
-      [withLoading]
-    ),
-    removePromotionCode: useCallback(
-      () =>
-        withLoading((key) => NativeStripeSdk.checkoutRemovePromotionCode(key)),
-      [withLoading]
-    ),
-    updateLineItemQuantity: useCallback(
-      (lineItemId, quantity) =>
-        withLoading((key) =>
-          NativeStripeSdk.checkoutUpdateLineItemQuantity(
-            key,
-            lineItemId,
-            quantity
-          )
-        ),
-      [withLoading]
-    ),
-    selectShippingOption: useCallback(
-      (id) =>
-        withLoading((key) =>
-          NativeStripeSdk.checkoutSelectShippingOption(key, id)
-        ),
-      [withLoading]
-    ),
-    updateTaxId: useCallback(
-      (type, value) =>
-        withLoading((key) =>
-          NativeStripeSdk.checkoutUpdateTaxId(key, type, value)
-        ),
-      [withLoading]
-    ),
-    refresh: useCallback(
-      () => withLoading((key) => NativeStripeSdk.checkoutRefresh(key)),
-      [withLoading]
-    ),
-  };
+  // Mutation methods — each delegates to withLoading. Hoisted out as
+  // individual useCallbacks so the memoized `checkout` below has a stable
+  // identity across renders (downstream consumers, e.g. `useEmbeddedPaymentElement`,
+  // rely on this).
+  const updateShippingAddress = useCallback<Checkout['updateShippingAddress']>(
+    (address, name, phone) =>
+      withLoading((key) =>
+        NativeStripeSdk.checkoutUpdateShippingAddress(
+          key,
+          address,
+          name ?? null,
+          phone ?? null
+        )
+      ),
+    [withLoading]
+  );
+  const updateBillingAddress = useCallback<Checkout['updateBillingAddress']>(
+    (address, name, phone) =>
+      withLoading((key) =>
+        NativeStripeSdk.checkoutUpdateBillingAddress(
+          key,
+          address,
+          name ?? null,
+          phone ?? null
+        )
+      ),
+    [withLoading]
+  );
+  const applyPromotionCode = useCallback<Checkout['applyPromotionCode']>(
+    (code) =>
+      withLoading((key) =>
+        NativeStripeSdk.checkoutApplyPromotionCode(key, code)
+      ),
+    [withLoading]
+  );
+  const removePromotionCode = useCallback<Checkout['removePromotionCode']>(
+    () =>
+      withLoading((key) => NativeStripeSdk.checkoutRemovePromotionCode(key)),
+    [withLoading]
+  );
+  const updateLineItemQuantity = useCallback<
+    Checkout['updateLineItemQuantity']
+  >(
+    (lineItemId, quantity) =>
+      withLoading((key) =>
+        NativeStripeSdk.checkoutUpdateLineItemQuantity(
+          key,
+          lineItemId,
+          quantity
+        )
+      ),
+    [withLoading]
+  );
+  const selectShippingOption = useCallback<Checkout['selectShippingOption']>(
+    (id) =>
+      withLoading((key) =>
+        NativeStripeSdk.checkoutSelectShippingOption(key, id)
+      ),
+    [withLoading]
+  );
+  const updateTaxId = useCallback<Checkout['updateTaxId']>(
+    (type, value) =>
+      withLoading((key) =>
+        NativeStripeSdk.checkoutUpdateTaxId(key, type, value)
+      ),
+    [withLoading]
+  );
+  const refresh = useCallback<Checkout['refresh']>(
+    () => withLoading((key) => NativeStripeSdk.checkoutRefresh(key)),
+    [withLoading]
+  );
+
+  const checkout = useMemo<Checkout>(
+    () => ({
+      get sessionKey(): string {
+        if (!sessionKeyRef.current) {
+          throw new Error(
+            'Checkout session not initialized. Wait for `state.status === "loaded"` ' +
+              'before passing `checkout` to `useEmbeddedPaymentElement` or calling a ' +
+              'mutation method (e.g. `applyPromotionCode`).'
+          );
+        }
+        return sessionKeyRef.current;
+      },
+      updateShippingAddress,
+      updateBillingAddress,
+      applyPromotionCode,
+      removePromotionCode,
+      updateLineItemQuantity,
+      selectShippingOption,
+      updateTaxId,
+      refresh,
+    }),
+    [
+      updateShippingAddress,
+      updateBillingAddress,
+      applyPromotionCode,
+      removePromotionCode,
+      updateLineItemQuantity,
+      selectShippingOption,
+      updateTaxId,
+      refresh,
+    ]
+  );
 
   return { state, checkout, error };
 }

--- a/src/hooks/useCheckout.tsx
+++ b/src/hooks/useCheckout.tsx
@@ -89,10 +89,7 @@ export function useCheckout(
     []
   );
 
-  // Mutation methods — each delegates to withLoading. Hoisted out as
-  // individual useCallbacks so the memoized `checkout` below has a stable
-  // identity across renders (downstream consumers, e.g. `useEmbeddedPaymentElement`,
-  // rely on this).
+  // Mutation methods. Each is memoized so `checkout` has a stable identity.
   const updateShippingAddress = useCallback<Checkout['updateShippingAddress']>(
     (address, name, phone) =>
       withLoading((key) =>

--- a/src/specs/NativeEmbeddedPaymentElement.ts
+++ b/src/specs/NativeEmbeddedPaymentElement.ts
@@ -7,7 +7,8 @@ import type { UnsafeMixed } from './utils';
 
 export interface NativeProps extends ViewProps {
   configuration: UnsafeMixed<EmbeddedPaymentElementConfiguration>;
-  intentConfiguration: UnsafeMixed<IntentConfiguration>;
+  intentConfiguration?: UnsafeMixed<IntentConfiguration>;
+  checkout?: UnsafeMixed<{ sessionKey: string }>;
 }
 
 export interface NativeCommands {

--- a/src/specs/NativeStripeSdkModule.ts
+++ b/src/specs/NativeStripeSdkModule.ts
@@ -199,6 +199,10 @@ export interface Spec extends TurboModule {
     intentConfig: UnsafeObject<IntentConfiguration>,
     configuration: UnsafeObject<EmbeddedPaymentElementConfiguration>
   ): Promise<void>;
+  createEmbeddedPaymentElementWithCheckout(
+    sessionKey: string,
+    configuration: UnsafeObject<EmbeddedPaymentElementConfiguration>
+  ): Promise<void>;
   confirmEmbeddedPaymentElement(
     viewTag: Int32
   ): Promise<EmbeddedPaymentElementResult>;

--- a/src/types/EmbeddedPaymentElement.tsx
+++ b/src/types/EmbeddedPaymentElement.tsx
@@ -223,11 +223,14 @@ export interface EmbeddedPaymentElementConfiguration {
   opensCardScannerAutomatically?: boolean;
 }
 
-// `Checkout` has `sessionKey`, `IntentConfiguration` has `mode`. We use `in`
-// to avoid tripping the throwing `sessionKey` getter on an unloaded handle.
+// Narrows a value to `Checkout` vs. `IntentConfiguration`.
 const isCheckoutSession = (
   value: PaymentSheetTypes.IntentConfiguration | Checkout
-): value is Checkout => 'sessionKey' in value && !('mode' in value);
+): value is Checkout =>
+  typeof value === 'object' &&
+  value !== null &&
+  'sessionKey' in value &&
+  !('mode' in value);
 
 // -----------------------------------------------------------------------------
 // Embedded API

--- a/src/types/EmbeddedPaymentElement.tsx
+++ b/src/types/EmbeddedPaymentElement.tsx
@@ -13,6 +13,7 @@ import type {
   CardBrand,
 } from './Common';
 import type { PaymentMethod } from '.';
+import type { Checkout } from './Checkout';
 import type * as ConfirmationToken from './ConfirmationToken';
 import * as PaymentSheetTypes from './PaymentSheet';
 import NativeStripeSdkModule from '../specs/NativeStripeSdkModule';
@@ -222,6 +223,17 @@ export interface EmbeddedPaymentElementConfiguration {
   opensCardScannerAutomatically?: boolean;
 }
 
+// `IntentConfiguration` requires `mode`; `Checkout` always has `sessionKey`
+// and never has `mode`. Check both so a stray object with a `sessionKey`
+// field doesn't get classified as a Checkout handle. We use `in` rather
+// than property access so we don't trigger the throwing `sessionKey`
+// getter on an unloaded handle.
+const isCheckout = (intent: unknown): intent is Checkout =>
+  typeof intent === 'object' &&
+  intent !== null &&
+  'sessionKey' in intent &&
+  !('mode' in intent);
+
 // -----------------------------------------------------------------------------
 // Embedded API
 // -----------------------------------------------------------------------------
@@ -268,21 +280,28 @@ let customPaymentMethodConfirmCallback: EventSubscription | null = null;
 let rowSelectionCallback: EventSubscription | null = null;
 
 async function createEmbeddedPaymentElement(
-  intentConfig: PaymentSheetTypes.IntentConfiguration,
+  intent: PaymentSheetTypes.IntentConfiguration | Checkout,
   configuration: EmbeddedPaymentElementConfiguration
 ): Promise<EmbeddedPaymentElement> {
-  setupConfirmAndSelectionHandlers(intentConfig, configuration);
+  setupConfigurationHandlers(configuration);
 
-  await NativeStripeSdkModule.createEmbeddedPaymentElement(
-    intentConfig,
-    configuration
-  );
+  if (isCheckout(intent)) {
+    await NativeStripeSdkModule.createEmbeddedPaymentElementWithCheckout(
+      intent.sessionKey,
+      configuration
+    );
+  } else {
+    setupIntentConfirmHandlers(intent);
+    await NativeStripeSdkModule.createEmbeddedPaymentElement(
+      intent,
+      configuration
+    );
+  }
   return new EmbeddedPaymentElement();
 }
 
-function setupConfirmAndSelectionHandlers(
-  intentConfig: PaymentSheetTypes.IntentConfiguration,
-  configuration: EmbeddedPaymentElementConfiguration
+function setupIntentConfirmHandlers(
+  intentConfig: PaymentSheetTypes.IntentConfiguration
 ) {
   const confirmHandler = intentConfig.confirmHandler;
   if (confirmHandler) {
@@ -323,7 +342,11 @@ function setupConfirmAndSelectionHandlers(
       }
     );
   }
+}
 
+function setupConfigurationHandlers(
+  configuration: EmbeddedPaymentElementConfiguration
+) {
   if (configuration.formSheetAction?.type === 'confirm') {
     const confirmFormSheetHandler =
       configuration.formSheetAction.onFormSheetConfirmComplete;
@@ -429,6 +452,41 @@ export interface UseEmbeddedPaymentElementResult {
 export function useEmbeddedPaymentElement(
   intentConfig: PaymentSheetTypes.IntentConfiguration,
   configuration: EmbeddedPaymentElementConfiguration
+): UseEmbeddedPaymentElementResult;
+/**
+ * Initializes an `EmbeddedPaymentElement` from a Checkout session.
+ *
+ * The `checkout` argument must be a loaded handle (i.e. `state.status === 'loaded'`
+ * from `useCheckout`). Because hooks must be called unconditionally, gate the
+ * consuming component on the loaded state and pass the handle into a child
+ * component, e.g.:
+ *
+ * @example
+ * function CheckoutScreen() {
+ *   const { checkout, state, error } = useCheckout(clientSecret);
+ *   if (error) return <ErrorView error={error} />;
+ *   if (state?.status !== 'loaded') return <Loading />;
+ *   return <EmbeddedView checkout={checkout} />;
+ * }
+ *
+ * function EmbeddedView({ checkout }: { checkout: Checkout }) {
+ *   const { embeddedPaymentElementView } =
+ *     useEmbeddedPaymentElement(checkout, configuration);
+ *   return embeddedPaymentElementView;
+ * }
+ *
+ * @param checkout - A loaded `Checkout` handle from `useCheckout`. Accessing
+ *   `checkout.sessionKey` (which this hook does internally) throws if the
+ *   session has not finished loading.
+ * @param configuration - Configuration for the embedded element.
+ */
+export function useEmbeddedPaymentElement(
+  checkout: Checkout,
+  configuration: EmbeddedPaymentElementConfiguration
+): UseEmbeddedPaymentElementResult;
+export function useEmbeddedPaymentElement(
+  intent: PaymentSheetTypes.IntentConfiguration | Checkout,
+  configuration: EmbeddedPaymentElementConfiguration
 ): UseEmbeddedPaymentElementResult {
   const isAndroid = Platform.OS === 'android';
   const elementRef = useRef<EmbeddedPaymentElement | null>(null);
@@ -454,12 +512,23 @@ export function useEmbeddedPaymentElement(
     return ref.current;
   }
 
+  // For Checkout the dep collapses to the session key string so we don't
+  // re-create the element when only the handle reference changes. For
+  // IntentConfiguration the dep is the intent object itself.
+  const intentKey: string | PaymentSheetTypes.IntentConfiguration = isCheckout(
+    intent
+  )
+    ? intent.sessionKey
+    : intent;
+  const intentRef = useRef(intent);
+  intentRef.current = intent;
+
   // Create embedded payment element
   useEffect(() => {
     let active = true;
     (async () => {
       const el = await createEmbeddedPaymentElement(
-        intentConfig,
+        intentRef.current,
         configuration
       );
       if (!active) return;
@@ -471,7 +540,7 @@ export function useEmbeddedPaymentElement(
       elementRef.current = null;
       setElement(null);
     };
-  }, [intentConfig, configuration, viewRef, isAndroid]);
+  }, [intentKey, configuration, viewRef, isAndroid]);
 
   useEffect(() => {
     const sub = addListener(
@@ -509,13 +578,18 @@ export function useEmbeddedPaymentElement(
 
   // Render the embedded view
   const embeddedPaymentElementView = useMemo(() => {
-    if (isAndroid && configuration && intentConfig) {
+    const intentProps =
+      typeof intentKey === 'string'
+        ? { checkout: { sessionKey: intentKey } }
+        : { intentConfiguration: intentKey };
+
+    if (isAndroid && configuration && intentKey) {
       return (
         <NativeEmbeddedPaymentElement
           ref={viewRef}
           style={[{ width: '100%', height: height }]}
           configuration={configuration}
-          intentConfiguration={intentConfig}
+          {...intentProps}
         />
       );
     }
@@ -525,10 +599,10 @@ export function useEmbeddedPaymentElement(
         ref={viewRef}
         style={{ width: '100%', height }}
         configuration={configuration}
-        intentConfiguration={intentConfig}
+        {...intentProps}
       />
     );
-  }, [configuration, element, height, intentConfig, isAndroid]);
+  }, [configuration, element, height, intentKey, isAndroid]);
 
   // Other APIs
   const confirm = useCallback((): Promise<EmbeddedPaymentElementResult> => {

--- a/src/types/EmbeddedPaymentElement.tsx
+++ b/src/types/EmbeddedPaymentElement.tsx
@@ -223,16 +223,11 @@ export interface EmbeddedPaymentElementConfiguration {
   opensCardScannerAutomatically?: boolean;
 }
 
-// `IntentConfiguration` requires `mode`; `Checkout` always has `sessionKey`
-// and never has `mode`. Check both so a stray object with a `sessionKey`
-// field doesn't get classified as a Checkout handle. We use `in` rather
-// than property access so we don't trigger the throwing `sessionKey`
-// getter on an unloaded handle.
-const isCheckout = (intent: unknown): intent is Checkout =>
-  typeof intent === 'object' &&
-  intent !== null &&
-  'sessionKey' in intent &&
-  !('mode' in intent);
+// `Checkout` has `sessionKey`, `IntentConfiguration` has `mode`. We use `in`
+// to avoid tripping the throwing `sessionKey` getter on an unloaded handle.
+const isCheckoutSession = (
+  value: PaymentSheetTypes.IntentConfiguration | Checkout
+): value is Checkout => 'sessionKey' in value && !('mode' in value);
 
 // -----------------------------------------------------------------------------
 // Embedded API
@@ -285,7 +280,7 @@ async function createEmbeddedPaymentElement(
 ): Promise<EmbeddedPaymentElement> {
   setupConfigurationHandlers(configuration);
 
-  if (isCheckout(intent)) {
+  if (isCheckoutSession(intent)) {
     await NativeStripeSdkModule.createEmbeddedPaymentElementWithCheckout(
       intent.sessionKey,
       configuration
@@ -454,30 +449,25 @@ export function useEmbeddedPaymentElement(
   configuration: EmbeddedPaymentElementConfiguration
 ): UseEmbeddedPaymentElementResult;
 /**
- * Initializes an `EmbeddedPaymentElement` from a Checkout session.
+ * Initializes an `EmbeddedPaymentElement` from a Stripe Checkout Session.
  *
- * The `checkout` argument must be a loaded handle (i.e. `state.status === 'loaded'`
- * from `useCheckout`). Because hooks must be called unconditionally, gate the
- * consuming component on the loaded state and pass the handle into a child
- * component, e.g.:
+ * Pass a loaded handle from `useCheckout`. Render the consumer in a child
+ * component so the hook only runs once `state.status === 'loaded'`.
  *
  * @example
- * function CheckoutScreen() {
- *   const { checkout, state, error } = useCheckout(clientSecret);
- *   if (error) return <ErrorView error={error} />;
- *   if (state?.status !== 'loaded') return <Loading />;
- *   return <EmbeddedView checkout={checkout} />;
+ * function Cart() {
+ *   const { checkout, state } = useCheckout(clientSecret);
+ *   if (state?.status !== 'loaded') return null;
+ *   return <EmbeddedCheckout checkout={checkout} />;
  * }
  *
- * function EmbeddedView({ checkout }: { checkout: Checkout }) {
+ * function EmbeddedCheckout({ checkout }: { checkout: Checkout }) {
  *   const { embeddedPaymentElementView } =
  *     useEmbeddedPaymentElement(checkout, configuration);
  *   return embeddedPaymentElementView;
  * }
  *
- * @param checkout - A loaded `Checkout` handle from `useCheckout`. Accessing
- *   `checkout.sessionKey` (which this hook does internally) throws if the
- *   session has not finished loading.
+ * @param checkout - A loaded `Checkout` handle from `useCheckout`.
  * @param configuration - Configuration for the embedded element.
  */
 export function useEmbeddedPaymentElement(
@@ -512,14 +502,9 @@ export function useEmbeddedPaymentElement(
     return ref.current;
   }
 
-  // For Checkout the dep collapses to the session key string so we don't
-  // re-create the element when only the handle reference changes. For
-  // IntentConfiguration the dep is the intent object itself.
-  const intentKey: string | PaymentSheetTypes.IntentConfiguration = isCheckout(
-    intent
-  )
-    ? intent.sessionKey
-    : intent;
+  // Re-key on the session key (Checkout) or intent object so we only
+  // recreate the element when the source actually changes.
+  const intentKey = isCheckoutSession(intent) ? intent.sessionKey : intent;
   const intentRef = useRef(intent);
   intentRef.current = intent;
 
@@ -578,6 +563,7 @@ export function useEmbeddedPaymentElement(
 
   // Render the embedded view
   const embeddedPaymentElementView = useMemo(() => {
+    // `intentKey` is the session key string for Checkout, the IntentConfiguration object otherwise.
     const intentProps =
       typeof intentKey === 'string'
         ? { checkout: { sessionKey: intentKey } }


### PR DESCRIPTION
## Summary
- Adds embedded and PS.FC into the playground of Checkout as integration options.

## Motivation
- Easier testing of CheckoutSession

## Testing
- Manual

## Documentation
N/A