### PR TITLE
Add embedded.update(checkout)

### DIFF
--- a/android/src/main/java/com/reactnativestripesdk/EmbeddedPaymentElementView.kt
+++ b/android/src/main/java/com/reactnativestripesdk/EmbeddedPaymentElementView.kt
@@ -64,6 +64,10 @@ class EmbeddedPaymentElementView(
       val intentConfiguration: PaymentSheet.IntentConfiguration,
     ) : Event
 
+    data class UpdateWithCheckout(
+      val checkout: Checkout,
+    ) : Event
+
     data object Confirm : Event
 
     data object ClearPaymentOption : Event
@@ -330,16 +334,7 @@ class EmbeddedPaymentElementView(
           }
 
           is Event.Update -> {
-            val elemConfig = latestElementConfig
-            if (elemConfig == null) {
-              val payload =
-                Arguments.createMap().apply {
-                  putString("message", "Cannot update: no element configuration exists")
-                }
-              requireStripeSdkModule().eventEmitter.emitEmbeddedPaymentElementLoadingFailed(payload)
-              requireStripeSdkModule().eventEmitter.emitEmbeddedPaymentElementUpdateComplete(null)
-              return@collect
-            }
+            val elemConfig = latestElementConfig ?: return@collect emitUpdateMissingConfiguration()
 
             val result =
               embedded.configure(
@@ -347,27 +342,23 @@ class EmbeddedPaymentElementView(
                 configuration = elemConfig,
               )
 
-            when (result) {
-              is EmbeddedPaymentElement.ConfigureResult.Succeeded -> {
-                val payload =
-                  Arguments.createMap().apply {
-                    putString("status", "succeeded")
-                  }
-                requireStripeSdkModule().eventEmitter.emitEmbeddedPaymentElementUpdateComplete(payload)
-              }
-              is EmbeddedPaymentElement.ConfigureResult.Failed -> {
-                val err = result.error
-                val msg = err.localizedMessage ?: err.toString()
-                val failPayload =
-                  Arguments.createMap().apply {
-                    putString("message", msg)
-                  }
-                requireStripeSdkModule().eventEmitter.emitEmbeddedPaymentElementLoadingFailed(failPayload)
-                requireStripeSdkModule().eventEmitter.emitEmbeddedPaymentElementUpdateComplete(null)
-              }
-            }
+            handleUpdateResult(result)
 
             latestIntentConfig = ev.intentConfiguration
+          }
+
+          is Event.UpdateWithCheckout -> {
+            val elemConfig = latestElementConfig ?: return@collect emitUpdateMissingConfiguration()
+
+            val result =
+              embedded.configure(
+                checkout = ev.checkout,
+                configuration = elemConfig,
+              )
+
+            handleUpdateResult(result)
+
+            latestCheckout = ev.checkout
           }
 
           is Event.Confirm -> {
@@ -467,6 +458,35 @@ class EmbeddedPaymentElementView(
     }
   }
 
+  private fun handleUpdateResult(result: EmbeddedPaymentElement.ConfigureResult) {
+    when (result) {
+      is EmbeddedPaymentElement.ConfigureResult.Succeeded -> {
+        val payload =
+          Arguments.createMap().apply {
+            putString("status", "succeeded")
+          }
+        requireStripeSdkModule().eventEmitter.emitEmbeddedPaymentElementUpdateComplete(payload)
+      }
+      is EmbeddedPaymentElement.ConfigureResult.Failed -> {
+        emitUpdateFailed(result.error)
+      }
+    }
+  }
+
+  private fun emitUpdateMissingConfiguration() {
+    emitUpdateFailed(IllegalStateException("Cannot update: no element configuration exists"))
+  }
+
+  private fun emitUpdateFailed(error: Throwable) {
+    val msg = error.localizedMessage ?: error.toString()
+    val payload =
+      Arguments.createMap().apply {
+        putString("message", msg)
+      }
+    requireStripeSdkModule().eventEmitter.emitEmbeddedPaymentElementLoadingFailed(payload)
+    requireStripeSdkModule().eventEmitter.emitEmbeddedPaymentElementUpdateComplete(null)
+  }
+
   // APIs
   fun configure(
     config: EmbeddedPaymentElement.Configuration,
@@ -484,6 +504,10 @@ class EmbeddedPaymentElementView(
 
   fun update(intentConfig: PaymentSheet.IntentConfiguration) {
     events.trySend(Event.Update(intentConfig))
+  }
+
+  fun updateWithCheckout(checkout: Checkout) {
+    events.trySend(Event.UpdateWithCheckout(checkout))
   }
 
   fun confirm() {

--- a/android/src/main/java/com/reactnativestripesdk/EmbeddedPaymentElementViewManager.kt
+++ b/android/src/main/java/com/reactnativestripesdk/EmbeddedPaymentElementViewManager.kt
@@ -32,6 +32,7 @@ import org.json.JSONObject
 
 @ReactModule(name = EmbeddedPaymentElementViewManager.NAME)
 @OptIn(CheckoutSessionPreview::class)
+@Suppress("TooManyFunctions")
 class EmbeddedPaymentElementViewManager :
   ViewGroupManager<EmbeddedPaymentElementView>(),
   EmbeddedPaymentElementViewManagerInterface<EmbeddedPaymentElementView> {
@@ -241,6 +242,28 @@ class EmbeddedPaymentElementViewManager :
         android.util.Log.e("EmbeddedPaymentElement", "Failed to parse intent config JSON", e)
       }
     }
+  }
+
+  override fun updateWithCheckout(
+    view: EmbeddedPaymentElementView,
+    sessionKey: String?,
+  ) {
+    if (sessionKey == null) return
+
+    val stripeSdkModule =
+      (view.context as ThemedReactContext).getNativeModule(StripeSdkModule::class.java)
+    val checkout = stripeSdkModule?.checkoutInstances?.get(sessionKey)
+    if (checkout == null) {
+      val payload =
+        Arguments.createMap().apply {
+          putString("message", "Checkout session not found.")
+        }
+      stripeSdkModule?.eventEmitter?.emitEmbeddedPaymentElementLoadingFailed(payload)
+      stripeSdkModule?.eventEmitter?.emitEmbeddedPaymentElementUpdateComplete(null)
+      return
+    }
+
+    view.updateWithCheckout(checkout)
   }
 
   private fun jsonToWritableMap(json: JSONObject): WritableMap {

--- a/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
+++ b/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
@@ -1390,9 +1390,11 @@ class StripeSdkModule(
     )
   }
 
-  // Android configures the embedded element through view props (see
-  // EmbeddedPaymentElementViewManager), so the bridge calls below are no-ops
-  // and only exist to keep the TurboModule contract symmetric with iOS.
+  // Android owns EmbeddedPaymentElement through its native view. Configuration,
+  // update, confirm, and clear commands are handled by EmbeddedPaymentElementViewManager
+  // so they can target the mounted Compose view instance. iOS stores its
+  // EmbeddedPaymentElement on StripeSdkImpl instead, so the shared TurboModule
+  // spec includes these module methods for the iOS implementation.
 
   @ReactMethod
   override fun createEmbeddedPaymentElement(
@@ -1417,7 +1419,7 @@ class StripeSdkModule(
     viewTag: Double,
     promise: Promise,
   ) {
-    // noop, iOS only
+    // No-op on Android. JS dispatches confirm through the view command instead.
   }
 
   @ReactMethod
@@ -1429,11 +1431,20 @@ class StripeSdkModule(
   }
 
   @ReactMethod
+  override fun updateEmbeddedPaymentElementWithCheckout(
+    sessionKey: String,
+    promise: Promise,
+  ) {
+    // No-op on Android. JS dispatches Checkout updates through the view command instead.
+    promise.resolve(null)
+  }
+
+  @ReactMethod
   override fun clearEmbeddedPaymentOption(
     viewTag: Double,
     promise: Promise,
   ) {
-    // noop, iOS only
+    // No-op on Android. JS dispatches clear through the view command instead.
   }
 
   @ReactMethod

--- a/android/src/oldarch/java/com/facebook/react/viewmanagers/EmbeddedPaymentElementViewManagerDelegate.java
+++ b/android/src/oldarch/java/com/facebook/react/viewmanagers/EmbeddedPaymentElementViewManagerDelegate.java
@@ -50,6 +50,9 @@ public class EmbeddedPaymentElementViewManagerDelegate<T extends View, U extends
       case "update":
         mViewManager.update(view, args != null ? args.getString(0) : null);
         break;
+      case "updateWithCheckout":
+        mViewManager.updateWithCheckout(view, args != null ? args.getString(0) : null);
+        break;
     }
   }
 }

--- a/android/src/oldarch/java/com/facebook/react/viewmanagers/EmbeddedPaymentElementViewManagerInterface.java
+++ b/android/src/oldarch/java/com/facebook/react/viewmanagers/EmbeddedPaymentElementViewManagerInterface.java
@@ -20,4 +20,5 @@ public interface EmbeddedPaymentElementViewManagerInterface<T extends View>  {
   void confirm(T view);
   void clearPaymentOption(T view);
   void update(T view, @Nullable String intentConfigurationJson);
+  void updateWithCheckout(T view, @Nullable String sessionKey);
 }

--- a/android/src/oldarch/java/com/reactnativestripesdk/NativeStripeSdkModuleSpec.java
+++ b/android/src/oldarch/java/com/reactnativestripesdk/NativeStripeSdkModuleSpec.java
@@ -267,6 +267,10 @@ public abstract class NativeStripeSdkModuleSpec extends ReactContextBaseJavaModu
 
   @ReactMethod
   @DoNotStrip
+  public abstract void updateEmbeddedPaymentElementWithCheckout(String sessionKey, Promise promise);
+
+  @ReactMethod
+  @DoNotStrip
   public abstract void clearEmbeddedPaymentOption(double viewTag, Promise promise);
 
   @ReactMethod

--- a/etc/stripe-react-native.api.md
+++ b/etc/stripe-react-native.api.md
@@ -3879,7 +3879,10 @@ export interface UseEmbeddedPaymentElementResult {
     // (undocumented)
     loadingError: Error | null;
     paymentOption: PaymentOptionDisplayData | null;
-    update: (intentConfig: PaymentSheet.IntentConfiguration) => void;
+    update: {
+        (intentConfig: PaymentSheet.IntentConfiguration): void;
+        (checkout: Checkout): void;
+    };
 }
 
 // @public

--- a/etc/stripe-react-native.api.md
+++ b/etc/stripe-react-native.api.md
@@ -3861,10 +3861,12 @@ export function useConfirmSetupIntent(): {
     loading: boolean;
 };
 
+// Warning: (ae-internal-mixed-release-tag) Mixed release tags are not allowed for "useEmbeddedPaymentElement" because one of its declarations is marked as @internal
+//
 // @public
 export function useEmbeddedPaymentElement(intentConfig: PaymentSheet.IntentConfiguration, configuration: EmbeddedPaymentElementConfiguration): UseEmbeddedPaymentElementResult;
 
-// @public
+// @internal
 export function useEmbeddedPaymentElement(checkout: Checkout, configuration: EmbeddedPaymentElementConfiguration): UseEmbeddedPaymentElementResult;
 
 // @public (undocumented)

--- a/ios/NewArch/EmbeddedPaymentElementViewComponentView.mm
+++ b/ios/NewArch/EmbeddedPaymentElementViewComponentView.mm
@@ -48,14 +48,28 @@ using namespace facebook::react;
   RCTEmbeddedPaymentElementViewHandleCommand(self, commandName, args);
 }
 
+#pragma mark - Shared Codegen Commands
+
+// These commands are declared on the shared `NativeEmbeddedPaymentElement`
+// component spec because Android targets its mounted Compose view directly.
+// iOS does not handle EPE actions through this view: the view only hosts
+// `StripeSdkImpl.shared.embeddedInstance.view`, while create/update/confirm/
+// clear are routed through `StripeSdkImpl` module methods. The no-op methods
+// keep the generated Fabric command protocol satisfied on iOS.
 - (void)clearPaymentOption
 {
-  // Android only.
 }
 
 - (void)confirm
 {
-  // Android only.
+}
+
+- (void)update:(NSString *)intentConfigurationJson
+{
+}
+
+- (void)updateWithCheckout:(NSString *)sessionKey
+{
 }
 
 #pragma mark - RCTComponentViewProtocol

--- a/ios/StripeSdk.mm
+++ b/ios/StripeSdk.mm
@@ -578,6 +578,13 @@ RCT_EXPORT_METHOD(updateEmbeddedPaymentElement:(NSDictionary *)intentConfig
   [StripeSdkImpl.shared updateEmbeddedPaymentElement:intentConfig resolve:resolve reject:reject];
 }
 
+RCT_EXPORT_METHOD(updateEmbeddedPaymentElementWithCheckout:(nonnull NSString *)sessionKey
+                                                   resolve:(nonnull RCTPromiseResolveBlock)resolve
+                                                    reject:(nonnull RCTPromiseRejectBlock)reject)
+{
+  [StripeSdkImpl.shared updateEmbeddedPaymentElementWithCheckout:sessionKey resolve:resolve reject:reject];
+}
+
 RCT_EXPORT_METHOD(clearEmbeddedPaymentOption:(NSInteger)viewTag
                                      resolve:(nonnull RCTPromiseResolveBlock)resolve
                                       reject:(nonnull RCTPromiseRejectBlock)reject)

--- a/ios/StripeSdkImpl+Embedded.swift
+++ b/ios/StripeSdkImpl+Embedded.swift
@@ -125,6 +125,23 @@ extension StripeSdkImpl {
     emitLoadingFailed(message: error.localizedDescription)
   }
 
+  @nonobjc
+  private func resolveEmbeddedUpdateResult(
+    _ updateResult: EmbeddedPaymentElement.UpdateResult,
+    resolve: @escaping RCTPromiseResolveBlock
+  ) {
+    switch updateResult {
+    case .succeeded:
+      resolve(["status": "succeeded"])
+    case .canceled:
+      resolve(["status": "canceled"])
+    case .failed(let error):
+      self.emitter?.emitEmbeddedPaymentElementLoadingFailed(["message": error.localizedDescription])
+      // We don't resolve with an error b/c loading errors are handled via the embeddedPaymentElementLoadingFailed event
+      resolve(nil)
+    }
+  }
+
   @objc(confirmEmbeddedPaymentElement:reject:)
   public func confirmEmbeddedPaymentElement(resolve: @escaping RCTPromiseResolveBlock,
                                             reject: @escaping RCTPromiseRejectBlock) {
@@ -192,16 +209,31 @@ extension StripeSdkImpl {
         return
       }
 
-      switch updateResult {
-      case .succeeded:
-        resolve(["status": "succeeded"])
-      case .canceled:
-        resolve(["status": "canceled"])
-      case .failed(let error):
-        self.emitter?.emitEmbeddedPaymentElementLoadingFailed(["message": error.localizedDescription])
-        // We don't resolve with an error b/c loading errors are handled via the embeddedPaymentElementLoadingFailed event
-        resolve(nil)
+      self.resolveEmbeddedUpdateResult(updateResult, resolve: resolve)
+    }
+  }
+
+  @objc(updateEmbeddedPaymentElementWithCheckout:resolve:reject:)
+  public func updateEmbeddedPaymentElementWithCheckout(
+    sessionKey: String,
+    resolve: @escaping RCTPromiseResolveBlock,
+    reject: @escaping RCTPromiseRejectBlock
+  ) {
+    guard let checkout = checkoutInstances[sessionKey] else {
+      resolve(Errors.createError(ErrorType.Failed, "Checkout session not found"))
+      return
+    }
+
+    Task {
+      guard let updateResult = await self.embeddedInstance?.update(checkout: checkout) else {
+        resolve(Errors.createError(
+          ErrorType.Failed,
+          "No EmbeddedPaymentElement instance — did you call create first?"
+        ))
+        return
       }
+
+      self.resolveEmbeddedUpdateResult(updateResult, resolve: resolve)
     }
   }
 

--- a/jest/mock.js
+++ b/jest/mock.js
@@ -278,11 +278,6 @@ const EmbeddedPaymentElementMocks = {
     FAILED: 'failed',
   },
 
-  EmbeddedPaymentElementUpdateStatus: {
-    SUCCEEDED: 'succeeded',
-    CANCELED: 'canceled',
-  },
-
   // Form sheet action types (from EmbeddedFormSheetAction)
   EmbeddedFormSheetActionType: {
     CONFIRM: 'confirm',
@@ -362,8 +357,6 @@ const EmbeddedPaymentElementMocks = {
     canceled: { status: 'canceled' },
     failed: { status: 'failed', error: new Error('Payment failed') },
     networkError: { status: 'failed', error: new Error('Network error') },
-    updateSucceeded: { status: 'succeeded' },
-    updateCanceled: { status: 'canceled' },
   },
 };
 

--- a/jest/mock.js
+++ b/jest/mock.js
@@ -197,7 +197,7 @@ const mockHooks = {
     confirm: jest.fn(async () => ({
       status: 'completed',
     })),
-    update: jest.fn(async () => ({ status: 'completed', error: null })),
+    update: jest.fn(() => {}),
     clearPaymentOption: jest.fn(() => {}),
     loadingError: null,
   })),
@@ -276,6 +276,11 @@ const EmbeddedPaymentElementMocks = {
     COMPLETED: 'completed',
     CANCELED: 'canceled',
     FAILED: 'failed',
+  },
+
+  EmbeddedPaymentElementUpdateStatus: {
+    SUCCEEDED: 'succeeded',
+    CANCELED: 'canceled',
   },
 
   // Form sheet action types (from EmbeddedFormSheetAction)
@@ -357,6 +362,8 @@ const EmbeddedPaymentElementMocks = {
     canceled: { status: 'canceled' },
     failed: { status: 'failed', error: new Error('Payment failed') },
     networkError: { status: 'failed', error: new Error('Network error') },
+    updateSucceeded: { status: 'succeeded' },
+    updateCanceled: { status: 'canceled' },
   },
 };
 
@@ -397,5 +404,17 @@ jest.mock('../src/specs/NativeStripeSdkModule', () => ({
       },
     })),
     openAuthenticatedWebView: jest.fn(),
+    createEmbeddedPaymentElement: jest.fn(async () => undefined),
+    createEmbeddedPaymentElementWithCheckout: jest.fn(async () => undefined),
+    confirmEmbeddedPaymentElement: jest.fn(async () => ({
+      status: 'completed',
+    })),
+    updateEmbeddedPaymentElement: jest.fn(async () => ({
+      status: 'succeeded',
+    })),
+    updateEmbeddedPaymentElementWithCheckout: jest.fn(async () => ({
+      status: 'succeeded',
+    })),
+    clearEmbeddedPaymentOption: jest.fn(async () => undefined),
   },
 }));

--- a/patches/old-arch-codegen-fix.patch
+++ b/patches/old-arch-codegen-fix.patch
@@ -8,11 +8,14 @@
    Int32,
  } from 'react-native/Libraries/Types/CodegenTypes';
  import type {
-@@ -185,38 +184,50 @@
+@@ -185,43 +184,59 @@
    ): Promise<void>;
+   updateEmbeddedPaymentElement(
+     intentConfig: UnsafeObject<IntentConfiguration>
+   ): Promise<UnsafeObject<any> | null>;
    updateEmbeddedPaymentElementWithCheckout(
      sessionKey: string
-   ): Promise<EmbeddedPaymentElementUpdateResult>;
+   ): Promise<UnsafeObject<any> | null>;
    clearEmbeddedPaymentOption(viewTag: Int32): Promise<void>;
 
 -  // Events

--- a/patches/old-arch-codegen-fix.patch
+++ b/patches/old-arch-codegen-fix.patch
@@ -8,8 +8,11 @@
    Int32,
  } from 'react-native/Libraries/Types/CodegenTypes';
  import type {
-@@ -185,35 +184,47 @@
+@@ -185,38 +184,50 @@
    ): Promise<void>;
+   updateEmbeddedPaymentElementWithCheckout(
+     sessionKey: string
+   ): Promise<EmbeddedPaymentElementUpdateResult>;
    clearEmbeddedPaymentOption(viewTag: Int32): Promise<void>;
 
 -  // Events

--- a/src/specs/NativeEmbeddedPaymentElement.ts
+++ b/src/specs/NativeEmbeddedPaymentElement.ts
@@ -20,10 +20,19 @@ export interface NativeCommands {
     viewRef: React.ElementRef<HostComponent<NativeProps>>,
     intentConfigurationJson: string
   ) => void;
+  updateWithCheckout: (
+    viewRef: React.ElementRef<HostComponent<NativeProps>>,
+    sessionKey: string
+  ) => void;
 }
 
 export const Commands: NativeCommands = codegenNativeCommands<NativeCommands>({
-  supportedCommands: ['confirm', 'clearPaymentOption', 'update'],
+  supportedCommands: [
+    'confirm',
+    'clearPaymentOption',
+    'update',
+    'updateWithCheckout',
+  ],
 });
 
 type ComponentType = HostComponent<NativeProps>;

--- a/src/specs/NativeStripeSdkModule.ts
+++ b/src/specs/NativeStripeSdkModule.ts
@@ -208,7 +208,10 @@ export interface Spec extends TurboModule {
   ): Promise<EmbeddedPaymentElementResult>;
   updateEmbeddedPaymentElement(
     intentConfig: UnsafeObject<IntentConfiguration>
-  ): Promise<void>;
+  ): Promise<UnsafeObject<any> | null>;
+  updateEmbeddedPaymentElementWithCheckout(
+    sessionKey: string
+  ): Promise<UnsafeObject<any> | null>;
   clearEmbeddedPaymentOption(viewTag: Int32): Promise<void>;
   createRadarSession(): Promise<CreateRadarSessionResult>;
 

--- a/src/types/EmbeddedPaymentElement.tsx
+++ b/src/types/EmbeddedPaymentElement.tsx
@@ -440,6 +440,12 @@ export interface UseEmbeddedPaymentElementResult {
    */
   update: {
     (intentConfig: PaymentSheetTypes.IntentConfiguration): void;
+    /**
+     * Call this method when the Checkout Session values you used to initialize
+     * `EmbeddedPaymentElement` change.
+     * @checkoutSessionsPreview
+     * @internal
+     */
     (checkout: Checkout): void;
   };
   // Sets the currently selected payment option to null
@@ -483,6 +489,8 @@ export function useEmbeddedPaymentElement(
  *
  * @param checkout - A loaded `Checkout` handle from `useCheckout`.
  * @param configuration - Configuration for the embedded element.
+ * @checkoutSessionsPreview
+ * @internal
  */
 export function useEmbeddedPaymentElement(
   checkout: Checkout,

--- a/src/types/EmbeddedPaymentElement.tsx
+++ b/src/types/EmbeddedPaymentElement.tsx
@@ -238,15 +238,26 @@ const isCheckoutSession = (
 
 class EmbeddedPaymentElement {
   /**
-   * Call this when the intent configuration changes (e.g., amount or currency).
+   * Call this when the intent configuration or Checkout Session changes.
    * Cancels any in-progress update. Ensures the correct payment methods are shown and fields are collected.
    * If the selected payment option becomes invalid, it may be cleared.
    * Returns the final result of the update; earlier in-flight updates will return `{ status: 'canceled' }`.
    */
-  async update(intentConfig: PaymentSheetTypes.IntentConfiguration) {
-    const result =
-      await NativeStripeSdkModule.updateEmbeddedPaymentElement(intentConfig);
-    return result;
+  async updateIntent(
+    intentConfig: PaymentSheetTypes.IntentConfiguration
+  ): Promise<unknown> {
+    return await NativeStripeSdkModule.updateEmbeddedPaymentElement(
+      intentConfig
+    );
+  }
+
+  async updateCheckout(checkout: Checkout): Promise<unknown> {
+    if (isCheckoutSession(checkout)) {
+      return await NativeStripeSdkModule.updateEmbeddedPaymentElementWithCheckout(
+        checkout.sessionKey
+      );
+    }
+    return null;
   }
 
   /**
@@ -430,7 +441,10 @@ export interface UseEmbeddedPaymentElementResult {
    * @note Upon completion, `paymentOption` may become null if it's no longer available.
    * @note If you call `update` while a previous call to `update` is still in progress, the previous call is canceled.
    */
-  update: (intentConfig: PaymentSheetTypes.IntentConfiguration) => void;
+  update: {
+    (intentConfig: PaymentSheetTypes.IntentConfiguration): void;
+    (checkout: Checkout): void;
+  };
   // Sets the currently selected payment option to null
   clearPaymentOption: () => void;
   // Any error encountered during creation/update, or null
@@ -623,19 +637,25 @@ export function useEmbeddedPaymentElement(
     return getElementOrThrow(elementRef).confirm();
   }, [isAndroid]);
   const update = useCallback(
-    (cfg: PaymentSheetTypes.IntentConfiguration) => {
+    (
+      updateSource: PaymentSheetTypes.IntentConfiguration | Checkout
+    ): Promise<unknown> => {
       if (isAndroid) {
         const currentRef = viewRef.current;
         if (currentRef) {
-          return new Promise<{ status: string } | null>((resolve) => {
+          return new Promise((resolve) => {
             const sub = addListener(
               'embeddedPaymentElementUpdateComplete',
-              (result: { status: string } | null) => {
+              (result) => {
                 sub.remove();
                 resolve(result);
               }
             );
-            Commands.update(currentRef, JSON.stringify(cfg));
+            if (isCheckoutSession(updateSource)) {
+              Commands.updateWithCheckout(currentRef, updateSource.sessionKey);
+            } else {
+              Commands.update(currentRef, JSON.stringify(updateSource));
+            }
           });
         }
         return Promise.reject(
@@ -644,7 +664,10 @@ export function useEmbeddedPaymentElement(
       }
 
       // iOS: use native module directly
-      return getElementOrThrow(elementRef).update(cfg);
+      const embeddedElement = getElementOrThrow(elementRef);
+      return isCheckoutSession(updateSource)
+        ? embeddedElement.updateCheckout(updateSource)
+        : embeddedElement.updateIntent(updateSource);
     },
     [isAndroid]
   );

--- a/src/types/EmbeddedPaymentElement.tsx
+++ b/src/types/EmbeddedPaymentElement.tsx
@@ -252,12 +252,9 @@ class EmbeddedPaymentElement {
   }
 
   async updateCheckout(checkout: Checkout): Promise<unknown> {
-    if (isCheckoutSession(checkout)) {
-      return await NativeStripeSdkModule.updateEmbeddedPaymentElementWithCheckout(
-        checkout.sessionKey
-      );
-    }
-    return null;
+    return await NativeStripeSdkModule.updateEmbeddedPaymentElementWithCheckout(
+      checkout.sessionKey
+    );
   }
 
   /**


### PR DESCRIPTION
## Summary
- Adds a new API to embedded payment element that is update(Checkout)

## Motivation
- React Native Checkout Sessions API

## Testing
- Manual

## Documentation
N/A
