### PR TITLE
fix(ios): Remove spurious onExit firing during Connect onboarding identity verification

### DIFF
--- a/ios/ConnectAccountOnboarding/ConnectAccountOnboardingViewController.swift
+++ b/ios/ConnectAccountOnboarding/ConnectAccountOnboardingViewController.swift
@@ -122,12 +122,10 @@ class ConnectAccountOnboardingViewController: UIViewController {
         reactContentView?.layoutIfNeeded()
     }
 
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-
-        // If being dismissed (not just going to background), notify
-        if isBeingDismissed {
-            onClose?()
-        }
-    }
+    // No viewWillDisappear/isBeingDismissed handler here. The modal uses .fullScreen
+    // presentation which prevents swipe-to-dismiss, so the only user-initiated exit path
+    // is the close button (handleCloseButtonPressed). Adding isBeingDismissed here would
+    // cause spurious onExit events when iOS presents a child VC (e.g. ASWebAuthenticationSession
+    // for identity verification) over this modal — UIKit calls viewWillDisappear and reports
+    // isBeingDismissed = true even though the user didn't close the modal.
 }


### PR DESCRIPTION
## Summary

Remove the `viewWillDisappear`/`isBeingDismissed` handler from `ConnectAccountOnboardingViewController`. It was causing spurious `onExit` events when `ASWebAuthenticationSession` (e.g. identity verification) presented over the Connect onboarding modal.

The video shows that `onExit` is being triggered in two situations:
- User dismisses `ASWebAuthenticationSession`
- User dismisses the onboarding modal.

https://github.com/user-attachments/assets/af8ec06a-fbb9-4ada-9738-212ab28b3b12


## Motivation

On iOS, when `ASWebAuthenticationSession` presents its Safari view controller over the fullScreen modal, UIKit calls `viewWillDisappear` and reports `isBeingDismissed = true` — even though the user didn't close anything. This triggered the full exit chain mid-flow, dismissing the modal unexpectedly. Android is unaffected because it doesn't use this pattern.

Since the modal uses `.fullScreen` presentation (which disables swipe-to-dismiss), the close button is the only valid user exit path — the `viewWillDisappear` handler was unnecessary.

Fixes RUN_MXMOBILE-16445.

## Testing

- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one:
- [x] This PR does not result in any developer-facing changes.