### PR TITLE
fix: Fix presentWithTimeout

### DIFF
--- a/android/src/main/java/com/reactnativestripesdk/PaymentSheetManager.kt
+++ b/android/src/main/java/com/reactnativestripesdk/PaymentSheetManager.kt
@@ -474,7 +474,8 @@ class PaymentSheetManager(
           savedInstanceState: Bundle?,
         ) {
           if (activity.javaClass.name == PAYMENT_SHEET_ACTIVITY ||
-            activity.javaClass.name == PAYMENT_OPTIONS_ACTIVITY) {
+            activity.javaClass.name == PAYMENT_OPTIONS_ACTIVITY
+          ) {
             paymentSheetActivity = activity
           }
         }
@@ -496,7 +497,7 @@ class PaymentSheetManager(
         override fun onActivityDestroyed(activity: Activity) {
           if (activity.javaClass.name == PAYMENT_SHEET_ACTIVITY ||
             activity.javaClass.name == PAYMENT_OPTIONS_ACTIVITY
-            ) {
+          ) {
             paymentSheetActivity = null
             context.currentActivity?.application?.unregisterActivityLifecycleCallbacks(this)
           }

--- a/android/src/main/java/com/reactnativestripesdk/PaymentSheetManager.kt
+++ b/android/src/main/java/com/reactnativestripesdk/PaymentSheetManager.kt
@@ -473,7 +473,10 @@ class PaymentSheetManager(
           activity: Activity,
           savedInstanceState: Bundle?,
         ) {
-          paymentSheetActivity = activity
+          if (activity.javaClass.name == PAYMENT_SHEET_ACTIVITY ||
+            activity.javaClass.name == PAYMENT_OPTIONS_ACTIVITY) {
+            paymentSheetActivity = activity
+          }
         }
 
         override fun onActivityStarted(activity: Activity) {}
@@ -491,8 +494,12 @@ class PaymentSheetManager(
         }
 
         override fun onActivityDestroyed(activity: Activity) {
-          paymentSheetActivity = null
-          context.currentActivity?.application?.unregisterActivityLifecycleCallbacks(this)
+          if (activity.javaClass.name == PAYMENT_SHEET_ACTIVITY ||
+            activity.javaClass.name == PAYMENT_OPTIONS_ACTIVITY
+            ) {
+            paymentSheetActivity = null
+            context.currentActivity?.application?.unregisterActivityLifecycleCallbacks(this)
+          }
         }
       }
 
@@ -846,3 +853,5 @@ internal fun handleFlowControllerConfigured(
 }
 
 private const val BITMAP_COMPRESS_QUALITY = 100
+private const val PAYMENT_SHEET_ACTIVITY = "com.stripe.android.paymentsheet.PaymentSheetActivity"
+private const val PAYMENT_OPTIONS_ACTIVITY = "com.stripe.android.paymentsheet.PaymentOptionsActivity"


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
Check if activity is `PaymentSheetActivity` or `PaymentOptionsActivity` before assigning to `paymentSheetActivity` var that we call cancel on post delay

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a link to the relevant issue, a code snippet, or an example project that demonstrates the bug. -->
Other activities, e.g. `PassiveChallengeWarmerActivity` can be launched by stripe-android, which will be captured by `Application.ActivityLifecycleCallbacks` and assigned to `paymentSheetActivity` causing us to call `finish()` on the wrong activity.

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [X] I tested this manually
- [ ] I added automated tests
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
