### PR TITLE
Propose 0.65.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # CHANGELOG
 
-## Unreleased
+## 0.65.1 - 2026-05-11
+**Fixes**
+* [Fixed] Fixed bug preventing PaymentSheet from dismissing when presenting with timeout. ([#2451](https://github.com/stripe/stripe-react-native/pull/2451))
+* [Fixed] Fixed spurious `onExit` events firing when using `ASWebAuthenticationSession`. ([#2447](https://github.com/stripe/stripe-react-native/pull/2447))
 
 ## 0.65.0 - 2026-04-29
 **Changes**


### PR DESCRIPTION
- [x] Ensure the CHANGELOG is up to date with all relevant commits since the last release
- [x] Add the version number for this release & the date to the CHANGELOG, underneath "## Unreleased" 
  - e.g. "## 1.2.3 - 2022-02-14"
- [x] Update the README if necessary (this is only required when there are breaking changes in the release, such as dropping support for an iOS || Android version)