### PR TITLE
Updates iOS SDK to 25.14.0

### DIFF
--- a/e2e-tests/customersheet.yml
+++ b/e2e-tests/customersheet.yml
@@ -13,7 +13,7 @@ appId: ${APP_ID}
     visible: "TEST"
     timeout: 150000
 - tapOn:
-    text: "Card number"
+    text: "Card number. Supported cards include.*"
 - inputText: "4242424242424242"
 - tapOn:
     text: "MM / YY"

--- a/e2e-tests/embedded-discount-toggle.yml
+++ b/e2e-tests/embedded-discount-toggle.yml
@@ -18,7 +18,7 @@ appId: ${APP_ID}
 - tapOn:
     text: "Card"
 - tapOn:
-    text: "Card number"
+    text: "Card number. Supported cards include.*"
 - inputText: "4242424242424242"
 - inputText: "0145"
 - inputText: "123"

--- a/e2e-tests/embedded-immediate-action.yml
+++ b/e2e-tests/embedded-immediate-action.yml
@@ -10,7 +10,7 @@ appId: ${APP_ID}
 - tapOn:
     text: "Card"
 - tapOn:
-    text: "Card number"
+    text: "Card number. Supported cards include.*"
 - inputText: "4242424242424242"
 - inputText: "0145"
 - inputText: "123"

--- a/e2e-tests/embedded.yml
+++ b/e2e-tests/embedded.yml
@@ -10,7 +10,7 @@ appId: ${APP_ID}
 - tapOn:
     text: "Card"
 - tapOn:
-    text: "Card number"
+    text: "Card number. Supported cards include.*"
 - inputText: "4242424242424242"
 - inputText: "0145"
 - inputText: "123"

--- a/e2e-tests/payment-sheet-pmo-sfu.yml
+++ b/e2e-tests/payment-sheet-pmo-sfu.yml
@@ -12,12 +12,12 @@ appId: ${APP_ID}
     text: "Card"
     optional: true
 - tapOn:
-    text: "New card"
+    text: "+ Add"
     optional: true
 - assertVisible:
     text: "By providing your card information, you allow Example Inc. to charge your card for future payments in accordance with their terms."
 - tapOn:
-    text: "Card number"
+    text: "Card number. Supported cards include.*"
 - inputText: "4242424242424242"
 - tapOn:
     text: "MM / YY"

--- a/e2e-tests/paymentsheet-basic.yml
+++ b/e2e-tests/paymentsheet-basic.yml
@@ -16,7 +16,7 @@ appId: ${APP_ID}
     optional: true
 
 - tapOn:
-    text: "Card number"
+    text: "Card number. Supported cards include.*"
 - inputText: "4242424242424242"
 - tapOn:
     text: "MM / YY"

--- a/e2e-tests/paymentsheet-customFlow-decoupled.yml
+++ b/e2e-tests/paymentsheet-customFlow-decoupled.yml
@@ -16,7 +16,7 @@ appId: ${APP_ID}
     text: "Card"
     optional: true
 - tapOn:
-    text: "Card number"
+    text: "Card number. Supported cards include.*"
 - inputText: "4242424242424242"
 - tapOn:
     text: "MM / YY"

--- a/e2e-tests/paymentsheet-customFlow.yml
+++ b/e2e-tests/paymentsheet-customFlow.yml
@@ -16,7 +16,7 @@ appId: ${APP_ID}
     text: "Card"
     optional: true
 - tapOn:
-    text: "Card number"
+    text: "Card number. Supported cards include.*"
 - inputText: "4242424242424242"
 - tapOn:
     text: "MM / YY"

--- a/e2e-tests/paymentsheet-decoupled.yml
+++ b/e2e-tests/paymentsheet-decoupled.yml
@@ -15,7 +15,7 @@ appId: ${APP_ID}
     text: "New card"
     optional: true
 - tapOn:
-    text: "Card number"
+    text: "Card number. Supported cards include.*"
 - inputText: "4242424242424242"
 - tapOn:
     text: "MM / YY"

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1820,14 +1820,14 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - Stripe (25.12.0):
-    - StripeApplePay (= 25.12.0)
-    - StripeCore (= 25.12.0)
-    - StripeIssuing (= 25.12.0)
-    - StripePayments (= 25.12.0)
-    - StripePaymentsUI (= 25.12.0)
-    - StripeUICore (= 25.12.0)
-  - stripe-react-native (0.64.0):
+  - Stripe (25.14.0):
+    - StripeApplePay (= 25.14.0)
+    - StripeCore (= 25.14.0)
+    - StripeIssuing (= 25.14.0)
+    - StripePayments (= 25.14.0)
+    - StripePaymentsUI (= 25.14.0)
+    - StripeUICore (= 25.14.0)
+  - stripe-react-native (0.65.1):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1848,10 +1848,10 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-    - stripe-react-native/Core (= 0.64.0)
-    - stripe-react-native/NewArch (= 0.64.0)
+    - stripe-react-native/Core (= 0.65.1)
+    - stripe-react-native/NewArch (= 0.65.1)
     - Yoga
-  - stripe-react-native/Core (0.64.0):
+  - stripe-react-native/Core (0.65.1):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1872,14 +1872,14 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-    - Stripe (~> 25.12.0)
-    - StripeApplePay (~> 25.12.0)
-    - StripeFinancialConnections (~> 25.12.0)
-    - StripePayments (~> 25.12.0)
-    - StripePaymentSheet (~> 25.12.0)
-    - StripePaymentsUI (~> 25.12.0)
+    - Stripe (~> 25.14.0)
+    - StripeApplePay (~> 25.14.0)
+    - StripeFinancialConnections (~> 25.14.0)
+    - StripePayments (~> 25.14.0)
+    - StripePaymentSheet (~> 25.14.0)
+    - StripePaymentsUI (~> 25.14.0)
     - Yoga
-  - stripe-react-native/NewArch (0.64.0):
+  - stripe-react-native/NewArch (0.65.1):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1901,7 +1901,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - stripe-react-native/Onramp (0.64.0):
+  - stripe-react-native/Onramp (0.65.1):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1923,9 +1923,9 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - stripe-react-native/Core
-    - StripeCryptoOnramp (~> 25.12.0)
+    - StripeCryptoOnramp (~> 25.14.0)
     - Yoga
-  - stripe-react-native/Tests (0.64.0):
+  - stripe-react-native/Tests (0.65.1):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1947,46 +1947,46 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - StripeApplePay (25.12.0):
-    - StripeCore (= 25.12.0)
-  - StripeCameraCore (25.12.0):
-    - StripeCore (= 25.12.0)
-  - StripeCore (25.12.0)
-  - StripeCryptoOnramp (25.12.0):
-    - StripeApplePay (= 25.12.0)
-    - StripeCore (= 25.12.0)
-    - StripeIdentity (= 25.12.0)
-    - StripePayments (= 25.12.0)
-    - StripePaymentSheet (= 25.12.0)
-    - StripePaymentsUI (= 25.12.0)
-    - StripeUICore (= 25.12.0)
-  - StripeFinancialConnections (25.12.0):
-    - StripeCore (= 25.12.0)
-    - StripeUICore (= 25.12.0)
-  - StripeIdentity (25.12.0):
-    - StripeCameraCore (= 25.12.0)
-    - StripeCore (= 25.12.0)
-    - StripeUICore (= 25.12.0)
-  - StripeIssuing (25.12.0):
-    - StripeCore (= 25.12.0)
-    - StripePayments (= 25.12.0)
-    - StripePaymentsUI (= 25.12.0)
-  - StripePayments (25.12.0):
-    - StripeCore (= 25.12.0)
-    - StripePayments/Stripe3DS2 (= 25.12.0)
-  - StripePayments/Stripe3DS2 (25.12.0):
-    - StripeCore (= 25.12.0)
-  - StripePaymentSheet (25.12.0):
-    - StripeApplePay (= 25.12.0)
-    - StripeCore (= 25.12.0)
-    - StripePayments (= 25.12.0)
-    - StripePaymentsUI (= 25.12.0)
-  - StripePaymentsUI (25.12.0):
-    - StripeCore (= 25.12.0)
-    - StripePayments (= 25.12.0)
-    - StripeUICore (= 25.12.0)
-  - StripeUICore (25.12.0):
-    - StripeCore (= 25.12.0)
+  - StripeApplePay (25.14.0):
+    - StripeCore (= 25.14.0)
+  - StripeCameraCore (25.14.0):
+    - StripeCore (= 25.14.0)
+  - StripeCore (25.14.0)
+  - StripeCryptoOnramp (25.14.0):
+    - StripeApplePay (= 25.14.0)
+    - StripeCore (= 25.14.0)
+    - StripeIdentity (= 25.14.0)
+    - StripePayments (= 25.14.0)
+    - StripePaymentSheet (= 25.14.0)
+    - StripePaymentsUI (= 25.14.0)
+    - StripeUICore (= 25.14.0)
+  - StripeFinancialConnections (25.14.0):
+    - StripeCore (= 25.14.0)
+    - StripeUICore (= 25.14.0)
+  - StripeIdentity (25.14.0):
+    - StripeCameraCore (= 25.14.0)
+    - StripeCore (= 25.14.0)
+    - StripeUICore (= 25.14.0)
+  - StripeIssuing (25.14.0):
+    - StripeCore (= 25.14.0)
+    - StripePayments (= 25.14.0)
+    - StripePaymentsUI (= 25.14.0)
+  - StripePayments (25.14.0):
+    - StripeCore (= 25.14.0)
+    - StripePayments/Stripe3DS2 (= 25.14.0)
+  - StripePayments/Stripe3DS2 (25.14.0):
+    - StripeCore (= 25.14.0)
+  - StripePaymentSheet (25.14.0):
+    - StripeApplePay (= 25.14.0)
+    - StripeCore (= 25.14.0)
+    - StripePayments (= 25.14.0)
+    - StripePaymentsUI (= 25.14.0)
+  - StripePaymentsUI (25.14.0):
+    - StripeCore (= 25.14.0)
+    - StripePayments (= 25.14.0)
+    - StripeUICore (= 25.14.0)
+  - StripeUICore (25.14.0):
+    - StripeCore (= 25.14.0)
   - Yoga (0.0.0)
 
 DEPENDENCIES:
@@ -2311,20 +2311,20 @@ SPEC CHECKSUMS:
   RNCAsyncStorage: 3a4f5e2777dae1688b781a487923a08569e27fe4
   RNCPicker: c8a3584b74133464ee926224463fcc54dfdaebca
   RNScreens: 61c18865ab074f4d995ac8d7cf5060522a649d05
-  Stripe: 0befd1ef4c49e9e1b5a781f1e61805c856bb9c1c
-  stripe-react-native: 1a655d668d564118f064973d4bbad07ddce53a76
-  StripeApplePay: a58f76d25970050c4b3447cf6d34ce098cd0b517
-  StripeCameraCore: 8b5ff52f138220cfb96713c1736f36b764e3cdc0
-  StripeCore: c10a35ed2d1f2165ccb8db8077e10c6fa488c6b8
-  StripeCryptoOnramp: 68016bb14054aeea13cf1da61e6d7ad09865825c
-  StripeFinancialConnections: 6abb9257f511f8ba1fd17df07d48058f48eb7b22
-  StripeIdentity: b9a2bb898d6da31b527768c9532585bf49ba0891
-  StripeIssuing: c92d94e7f1e068d728715aa382f8b7907499b83f
-  StripePayments: fb4105c822f9f07ca2092c86b68ab366b5d4a144
-  StripePaymentSheet: 7285761bacc685b160fc31871632554577beec35
-  StripePaymentsUI: 6aabff3711d0543db04632a2d102deac7a139095
-  StripeUICore: fb5f1c2f7d702b2879f706e3db3a7b793125256e
-  Yoga: 3fd22c2cae22d7a2b0f0b538f55f7c2a17dc94d5
+  Stripe: 58a32c0e9499ff221e01177a91d2e28bad606641
+  stripe-react-native: 0835a5d00e890d6aeb3d0ddb1a46ff30aec4afc1
+  StripeApplePay: 0236ae974253092d0dbaa19535348c0dc7cac8e4
+  StripeCameraCore: 26d512ed1ed202d8d652a1b5971c0465e4798c1c
+  StripeCore: ddb6e6604c55c993bb2f18334d2efa329d6f2ab9
+  StripeCryptoOnramp: 21792b033abe97cd70d9790d42d33fdb77d616e7
+  StripeFinancialConnections: 294d37af2074cd649ac39feeaf621f6b95511760
+  StripeIdentity: 97597e034843c2077a5af59e88aeb64a20e4f4e6
+  StripeIssuing: a0fa7726fc2fca2846d979554d2976a2be8e9066
+  StripePayments: 66d0c87a7663ea98c8393514f90e1188de295ae0
+  StripePaymentSheet: 6077f1963fb255730653ea8d39fb321bc03ee12d
+  StripePaymentsUI: 126e0f87a7504a714723c63430500f2e9ce1013d
+  StripeUICore: 9f1c8de8020df0ffcca64bde013f1aad1367837d
+  Yoga: 5934998fbeaef7845dbf698f698518695ab4cd1a
 
 PODFILE CHECKSUM: 605f3cad878b7c0eee93ebb4a78a8141d34cd328
 

--- a/ios/CurrencySelectorElementView.swift
+++ b/ios/CurrencySelectorElementView.swift
@@ -7,7 +7,7 @@
 
 import Combine
 import Foundation
-@_spi(CheckoutSessionsPreview) import StripePaymentSheet
+@_spi(ReactNativeSDK) import StripePaymentSheet
 import UIKit
 
 @objc(StripeCurrencySelectorElementManager)

--- a/ios/EmbeddedPaymentElementView.swift
+++ b/ios/EmbeddedPaymentElementView.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-@_spi(EmbeddedPaymentElementPrivateBeta) import StripePaymentSheet
+import StripePaymentSheet
 import UIKit
 
 @objc(EmbeddedPaymentElementView)

--- a/ios/Mappers+Checkout.swift
+++ b/ios/Mappers+Checkout.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-@_spi(CheckoutSessionsPreview) import StripePaymentSheet
+@_spi(ReactNativeSDK) import StripePaymentSheet
 
 extension Mappers {
     class func mapFromCheckoutState(_ state: Checkout.State) -> NSDictionary {
@@ -56,7 +56,7 @@ extension Mappers {
         return result
     }
 
-    class func mapFromCheckoutAddressUpdate(_ addressUpdate: Checkout.AddressUpdate) -> NSDictionary {
+    class func mapFromCheckoutAddressUpdate(_ addressUpdate: Checkout.ContactAddress) -> NSDictionary {
         let result = NSMutableDictionary()
         result["address"] = mapFromCheckoutAddress(addressUpdate.address)
 

--- a/ios/Mappers.swift
+++ b/ios/Mappers.swift
@@ -3,7 +3,7 @@ import Stripe
 @_spi(ConfirmationTokensPublicPreview) import StripePayments
 #if canImport(StripeCryptoOnramp)
 @_spi(CryptoOnrampAlpha) import StripeCryptoOnramp
-@_spi(STP) import StripePaymentSheet
+@_spi(CryptoOnrampAlpha) import StripePaymentSheet
 #else
 import StripePaymentSheet
 #endif

--- a/ios/PaymentOptionDisplayData+ReactNative.swift
+++ b/ios/PaymentOptionDisplayData+ReactNative.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-@_spi(EmbeddedPaymentElementPrivateBeta) import StripePaymentSheet
+import StripePaymentSheet
 
 extension EmbeddedPaymentElement.PaymentOptionDisplayData {
     /// Convert `PaymentOptionDisplayData` into a dictionary compatible with React Native bridge.

--- a/ios/PaymentSheetAppearance.swift
+++ b/ios/PaymentSheetAppearance.swift
@@ -4,7 +4,7 @@
 //
 //  Created by Charles Cruzan on 5/11/22.
 //
-@_spi(EmbeddedPaymentElementPrivateBeta) import StripePaymentSheet
+import StripePaymentSheet
 
 internal class PaymentSheetAppearance {
     class func buildAppearanceFromParams(userParams: NSDictionary?) throws -> PaymentSheet.Appearance {

--- a/ios/StripeSdkImpl+Checkout.swift
+++ b/ios/StripeSdkImpl+Checkout.swift
@@ -7,7 +7,7 @@
 
 import Combine
 import Foundation
-@_spi(CheckoutSessionsPreview) import StripePaymentSheet
+@_spi(ReactNativeSDK) import StripePaymentSheet
 
 extension StripeSdkImpl {
     internal func currentCheckoutStateResult(checkout: Checkout) -> NSDictionary {
@@ -76,7 +76,11 @@ extension StripeSdkImpl {
             resolver: resolve,
             rejecter: reject
         ) { checkout, addressUpdate in
-            try await checkout.updateShippingAddress(addressUpdate)
+            try await checkout.updateShippingAddress(
+                name: addressUpdate.name,
+                phone: addressUpdate.phone,
+                address: addressUpdate.address
+            )
         }
     }
 
@@ -98,7 +102,11 @@ extension StripeSdkImpl {
             resolver: resolve,
             rejecter: reject
         ) { checkout, addressUpdate in
-            try await checkout.updateBillingAddress(addressUpdate)
+            try await checkout.updateBillingAddress(
+                name: addressUpdate.name,
+                phone: addressUpdate.phone,
+                address: addressUpdate.address
+            )
         }
     }
 
@@ -146,17 +154,12 @@ extension StripeSdkImpl {
             return
         }
 
-        let lineItemUpdate = Checkout.LineItemUpdate(
-            lineItemId: lineItemId,
-            quantity: integerQuantity
-        )
-
         performCheckoutMutation(
             sessionKey: sessionKey,
             resolver: resolve,
             rejecter: reject
         ) { checkout in
-            try await checkout.updateQuantity(with: lineItemUpdate)
+            try await checkout.updateQuantity(lineItemId: lineItemId, quantity: integerQuantity)
         }
     }
 
@@ -184,14 +187,12 @@ extension StripeSdkImpl {
         resolver resolve: @escaping RCTPromiseResolveBlock,
         rejecter reject: @escaping RCTPromiseRejectBlock
     ) {
-        let taxIdUpdate = Checkout.TaxIdUpdate(type: type, value: value)
-
         performCheckoutMutation(
             sessionKey: sessionKey,
             resolver: resolve,
             rejecter: reject
         ) { checkout in
-            try await checkout.updateTaxId(with: taxIdUpdate)
+            try await checkout.updateTaxId(type: type, value: value)
         }
     }
 
@@ -255,7 +256,7 @@ extension StripeSdkImpl {
         missingCountryMessage: String,
         resolver resolve: @escaping RCTPromiseResolveBlock,
         rejecter reject: @escaping RCTPromiseRejectBlock,
-        operation: @escaping (Checkout, Checkout.AddressUpdate) async throws -> Void
+        operation: @escaping (Checkout, Checkout.ContactAddress) async throws -> Void
     ) {
         guard let addressUpdate = buildCheckoutAddressUpdate(
             address: address,
@@ -279,7 +280,7 @@ extension StripeSdkImpl {
         address: NSDictionary,
         name: String?,
         phone: String?
-    ) -> Checkout.AddressUpdate? {
+    ) -> Checkout.ContactAddress? {
         guard let country = address["country"] as? String, !country.isEmpty else {
             return nil
         }
@@ -293,7 +294,7 @@ extension StripeSdkImpl {
             postalCode: address["postalCode"] as? String
         )
 
-        return Checkout.AddressUpdate(
+        return Checkout.ContactAddress(
             name: name,
             phone: phone,
             address: checkoutAddress

--- a/ios/StripeSdkImpl+CustomerSheet.swift
+++ b/ios/StripeSdkImpl+CustomerSheet.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-@_spi(PrivateBetaCustomerSheet) @_spi(CustomerSessionBetaAccess) @_spi(STP) import StripePaymentSheet
+@_spi(PrivateBetaCustomerSheet) @_spi(STP) import StripePaymentSheet
 extension StripeSdkImpl {
     @objc(initCustomerSheet:customerAdapterOverrides:resolver:rejecter:)
     public func initCustomerSheet(params: NSDictionary,

--- a/ios/StripeSdkImpl+Embedded.swift
+++ b/ios/StripeSdkImpl+Embedded.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-@_spi(EmbeddedPaymentElementPrivateBeta) @_spi(ExperimentalAllowsRemovalOfLastSavedPaymentMethodAPI) @_spi(CustomerSessionBetaAccess) @_spi(STP) @_spi(CustomPaymentMethodsBeta) @_spi(CardFundingFilteringPrivatePreview) @_spi(CheckoutSessionsPreview) import StripePaymentSheet
+@_spi(EmbeddedPaymentElementPrivateBeta) @_spi(ExperimentalAllowsRemovalOfLastSavedPaymentMethodAPI) @_spi(CustomerSessionBetaAccess) @_spi(STP) @_spi(CustomPaymentMethodsBeta) @_spi(CardFundingFilteringPrivatePreview) import StripePaymentSheet
 
 @objc(StripeSdkImpl)
 extension StripeSdkImpl {

--- a/ios/StripeSdkImpl+Embedded.swift
+++ b/ios/StripeSdkImpl+Embedded.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-@_spi(EmbeddedPaymentElementPrivateBeta) @_spi(ExperimentalAllowsRemovalOfLastSavedPaymentMethodAPI) @_spi(CustomerSessionBetaAccess) @_spi(STP) @_spi(CustomPaymentMethodsBeta) @_spi(CardFundingFilteringPrivatePreview) import StripePaymentSheet
+@_spi(ExperimentalAllowsRemovalOfLastSavedPaymentMethodAPI) @_spi(STP) @_spi(CustomPaymentMethodsBeta) @_spi(CardFundingFilteringPrivatePreview) import StripePaymentSheet
 
 @objc(StripeSdkImpl)
 extension StripeSdkImpl {

--- a/ios/StripeSdkImpl+PaymentSheet.swift
+++ b/ios/StripeSdkImpl+PaymentSheet.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-@_spi(ExperimentalAllowsRemovalOfLastSavedPaymentMethodAPI) @_spi(CustomerSessionBetaAccess) @_spi(EmbeddedPaymentElementPrivateBeta) @_spi(STP) @_spi(PaymentMethodOptionsSetupFutureUsagePreview) @_spi(CustomPaymentMethodsBeta) @_spi(ConfirmationTokensPublicPreview) @_spi(CardFundingFilteringPrivatePreview) @_spi(CheckoutSessionsPreview) import StripePaymentSheet
+@_spi(ExperimentalAllowsRemovalOfLastSavedPaymentMethodAPI) @_spi(CustomerSessionBetaAccess) @_spi(EmbeddedPaymentElementPrivateBeta) @_spi(STP) @_spi(PaymentMethodOptionsSetupFutureUsagePreview) @_spi(CustomPaymentMethodsBeta) @_spi(ConfirmationTokensPublicPreview) @_spi(CardFundingFilteringPrivatePreview) import StripePaymentSheet
 
 extension StripeSdkImpl {
     internal func buildPaymentSheetConfiguration(

--- a/ios/StripeSdkImpl+PaymentSheet.swift
+++ b/ios/StripeSdkImpl+PaymentSheet.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-@_spi(ExperimentalAllowsRemovalOfLastSavedPaymentMethodAPI) @_spi(CustomerSessionBetaAccess) @_spi(EmbeddedPaymentElementPrivateBeta) @_spi(STP) @_spi(PaymentMethodOptionsSetupFutureUsagePreview) @_spi(CustomPaymentMethodsBeta) @_spi(ConfirmationTokensPublicPreview) @_spi(CardFundingFilteringPrivatePreview) import StripePaymentSheet
+@_spi(ExperimentalAllowsRemovalOfLastSavedPaymentMethodAPI) @_spi(STP) @_spi(PaymentMethodOptionsSetupFutureUsagePreview) @_spi(CustomPaymentMethodsBeta) @_spi(ConfirmationTokensPublicPreview) @_spi(CardFundingFilteringPrivatePreview) import StripePaymentSheet
 
 extension StripeSdkImpl {
     internal func buildPaymentSheetConfiguration(

--- a/ios/StripeSdkImpl.swift
+++ b/ios/StripeSdkImpl.swift
@@ -11,14 +11,13 @@ import UIKit
 #if canImport(StripeCryptoOnramp)
 @_spi(CryptoOnrampAlpha) import StripeCryptoOnramp
 
-@_spi(STP)
-@_spi(EmbeddedPaymentElementPrivateBeta)
+@_spi(CryptoOnrampAlpha)
+@_spi(ReactNativeSDK)
 @_spi(CustomerSessionBetaAccess)
 @_spi(AppearanceAPIAdditionsPreview)
-@_spi(CheckoutSessionsPreview)
 import StripePaymentSheet
 #else
-@_spi(EmbeddedPaymentElementPrivateBeta) @_spi(CustomerSessionBetaAccess) @_spi(CheckoutSessionsPreview) import StripePaymentSheet
+@_spi(EmbeddedPaymentElementPrivateBeta) @_spi(CustomerSessionBetaAccess) @_spi(ReactNativeSDK) import StripePaymentSheet
 #endif
 
 @available(iOS 13.0, *)

--- a/ios/StripeSdkImpl.swift
+++ b/ios/StripeSdkImpl.swift
@@ -10,14 +10,9 @@ import StripePaymentsUI
 import UIKit
 #if canImport(StripeCryptoOnramp)
 @_spi(CryptoOnrampAlpha) import StripeCryptoOnramp
-
-@_spi(CryptoOnrampAlpha)
-@_spi(ReactNativeSDK)
-@_spi(CustomerSessionBetaAccess)
-@_spi(AppearanceAPIAdditionsPreview)
-import StripePaymentSheet
+@_spi(CryptoOnrampAlpha) @_spi(ReactNativeSDK) @_spi(AppearanceAPIAdditionsPreview) import StripePaymentSheet
 #else
-@_spi(EmbeddedPaymentElementPrivateBeta) @_spi(CustomerSessionBetaAccess) @_spi(ReactNativeSDK) import StripePaymentSheet
+@_spi(ReactNativeSDK) import StripePaymentSheet
 #endif
 
 @available(iOS 13.0, *)

--- a/ios/Tests/CheckoutBridgeTests.swift
+++ b/ios/Tests/CheckoutBridgeTests.swift
@@ -6,12 +6,12 @@
 //
 
 @testable import stripe_react_native
-@_spi(CheckoutSessionsPreview) import StripePaymentSheet
+@_spi(ReactNativeSDK) import StripePaymentSheet
 import XCTest
 
 class CheckoutBridgeTests: XCTestCase {
     func test_mapFromCheckoutAddressUpdate_mapsOptionalFields() throws {
-        let addressUpdate = Checkout.AddressUpdate(
+        let addressUpdate = Checkout.ContactAddress(
             name: "Billing Name",
             phone: "+15555550101",
             address: Checkout.Address(
@@ -95,7 +95,7 @@ class CheckoutBridgeTests: XCTestCase {
         let customerId: String? = "cus_123"
         let customerEmail: String? = "customer@example.com"
         let url: URL? = URL(string: "https://example.com")
-        let billingAddress: Checkout.AddressUpdate? = Checkout.AddressUpdate(
+        let billingAddress: Checkout.ContactAddress? = Checkout.ContactAddress(
             name: "Billing Name",
             phone: "+15555550101",
             address: Checkout.Address(
@@ -106,7 +106,7 @@ class CheckoutBridgeTests: XCTestCase {
                 postalCode: "94111"
             )
         )
-        let shippingAddress: Checkout.AddressUpdate? = Checkout.AddressUpdate(
+        let shippingAddress: Checkout.ContactAddress? = Checkout.ContactAddress(
             name: "Shipping Name",
             phone: "+447700900000",
             address: Checkout.Address(

--- a/ios/Tests/OnrampMappersTests.swift
+++ b/ios/Tests/OnrampMappersTests.swift
@@ -1,5 +1,5 @@
 @testable import stripe_react_native
-@_spi(STP) import StripePaymentSheet
+@_spi(CryptoOnrampAlpha) import StripePaymentSheet
 import UIKit
 import XCTest
 

--- a/ios/Tests/PaymentSheetAppearanceTests.swift
+++ b/ios/Tests/PaymentSheetAppearanceTests.swift
@@ -1,5 +1,5 @@
 @testable import stripe_react_native
-@_spi(EmbeddedPaymentElementPrivateBeta) import StripePaymentSheet
+import StripePaymentSheet
 import XCTest
 
 class PaymentSheetAppearanceTests: XCTestCase {

--- a/ios/Tests/PaymentSheetUtilsTests.swift
+++ b/ios/Tests/PaymentSheetUtilsTests.swift
@@ -1,5 +1,5 @@
 @testable import stripe_react_native
-@_spi(ExperimentalAllowsRemovalOfLastSavedPaymentMethodAPI) @_spi(CustomerSessionBetaAccess) @_spi(EmbeddedPaymentElementPrivateBeta) @_spi(STP) @_spi(PaymentMethodOptionsSetupFutureUsagePreview) @_spi(CustomPaymentMethodsBeta) @_spi(CardFundingFilteringPrivatePreview) import StripePaymentSheet
+@_spi(ExperimentalAllowsRemovalOfLastSavedPaymentMethodAPI) @_spi(STP) @_spi(PaymentMethodOptionsSetupFutureUsagePreview) @_spi(CustomPaymentMethodsBeta) @_spi(CardFundingFilteringPrivatePreview) import StripePaymentSheet
 import XCTest
 
 class PaymentSheetUtilsTests: XCTestCase {

--- a/stripe-react-native.podspec
+++ b/stripe-react-native.podspec
@@ -2,7 +2,7 @@ require 'json'
 
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 # Keep stripe_version in sync with https://github.com/stripe/stripe-identity-react-native/blob/main/stripe-identity-react-native.podspec
-stripe_version = '~> 25.12.0'
+stripe_version = '~> 25.14.0'
 
 fabric_enabled = ENV['RCT_NEW_ARCH_ENABLED'] == '1'
 


### PR DESCRIPTION
## Summary
Updates the iOS SDK to the latest release. Two major changes seen here are:
- Migration away from using `@_spi(STP)` imports for Crypto Onramp via https://github.com/stripe/stripe-ios/pull/6401
- CheckoutSessions API changes via https://github.com/stripe/stripe-ios/pull/6381

Additionally, many e2e tests were failing due to updated accessibility labels. Those have been addressed as well.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a link to the relevant issue, a code snippet, or an example project that demonstrates the bug. -->
New SDK Releases

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [ ] I added automated tests
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->
Tested by fixing and running the automation tests locally.

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
