### PR TITLE
Add CurrencySelectorElement to checkout playground

### DIFF
--- a/e2e-tests/checkout-adaptive-pricing.yml
+++ b/e2e-tests/checkout-adaptive-pricing.yml
@@ -1,7 +1,8 @@
 # Test the Checkout Playground's CurrencySelectorElement (Adaptive Pricing).
-# Toggles the selector from the merchant currency (USD) to the localized
-# currency (EUR for DE), waits for the session to update, then completes
-# the payment to verify the selected currency flows through PaymentSheet.
+# The session loads with EUR auto-selected for the DE customer; tap the
+# USD option in the selector, wait for the session to re-price, then
+# complete the payment to verify the selected currency flows through
+# PaymentSheet.
 appId: ${APP_ID}
 ---
 - launchApp:
@@ -40,40 +41,40 @@ appId: ${APP_ID}
     timeout: 30000
 - tapOn: "Create checkout session"
 
-# Wait for the cart to load. The Pay button's currency code is the most
-# reliable signal that the session is fully loaded with totals available.
+# Wait for the cart to load. The session auto-selects EUR for the DE
+# customer, so the Pay button starts as "Pay EUR …".
 - extendedWaitUntil:
     visible:
-      text: "Pay USD .*"
+      text: "Pay EUR .*"
     timeout: 150000
 
-# The CurrencySelectorElement is rendered below the promotion code row.
-# Scroll to it and tap the EUR option (matched by currency symbol so the
-# test isn't tied to a specific exchange-rate amount).
+# Scroll down to the CurrencySelectorElement and tap the USD option
+# (matched by currency symbol so the test isn't tied to a specific
+# exchange-rate amount).
 - scrollUntilVisible:
     element:
-      text: ".*€.*"
+      text: ".*\\$.*"
     direction: DOWN
     timeout: 30000
 - tapOn:
-    text: ".*€.*"
+    text: ".*\\$.*"
 
-# After tapping EUR, the session re-prices and the Pay button updates.
+# After tapping USD, the session re-prices and the Pay button updates.
 # Waiting on this transition guards against asserting before the
 # selectCurrency network round-trip completes.
 - extendedWaitUntil:
     visible:
-      text: "Pay EUR .*"
+      text: "Pay USD .*"
     timeout: 60000
 
 # Open PaymentSheet and pay with a test card.
 - scrollUntilVisible:
     element:
-      text: "Pay EUR .*"
+      text: "Pay USD .*"
     direction: DOWN
     timeout: 30000
 - tapOn:
-    text: "Pay EUR .*"
+    text: "Pay USD .*"
 
 - extendedWaitUntil:
     visible: "TEST"

--- a/e2e-tests/checkout-adaptive-pricing.yml
+++ b/e2e-tests/checkout-adaptive-pricing.yml
@@ -39,9 +39,15 @@ appId: ${APP_ID}
     element:
       text: ".*\\$.*"
     direction: DOWN
+    centerElement: true
+    timeout: 30000
+- extendedWaitUntil:
+    visible:
+      text: ".*USD = .*EUR.*"
     timeout: 30000
 - tapOn:
     text: ".*\\$.*"
+    selected: false
 
 - extendedWaitUntil:
     visible:

--- a/e2e-tests/checkout-adaptive-pricing.yml
+++ b/e2e-tests/checkout-adaptive-pricing.yml
@@ -1,8 +1,3 @@
-# Test the Checkout Playground's CurrencySelectorElement (Adaptive Pricing).
-# The session loads with EUR auto-selected for the DE customer; tap the
-# USD option in the selector, wait for the session to re-price, then
-# complete the payment to verify the selected currency flows through
-# PaymentSheet.
 appId: ${APP_ID}
 ---
 - launchApp:
@@ -10,8 +5,6 @@ appId: ${APP_ID}
 - tapOn: "Accept a payment"
 - tapOn: "Checkout Playground"
 
-# Enable Adaptive Pricing. The toggle lives below the fold, so scroll
-# until it's visible regardless of where it lands on a given screen size.
 - scrollUntilVisible:
     element:
       id: "adaptive_pricing_toggle"
@@ -20,8 +13,6 @@ appId: ${APP_ID}
 - tapOn:
     id: "adaptive_pricing_toggle"
 
-# Pick a country that produces a different currency than the session's
-# USD merchant currency so the selector renders both options.
 - scrollUntilVisible:
     element:
       id: "adaptive_pricing_country_picker"
@@ -29,8 +20,6 @@ appId: ${APP_ID}
     timeout: 30000
 - tapOn:
     id: "adaptive_pricing_country_picker"
-# The picker option's accessibility label combines the country code with
-# its selection state ("DE, Choose"), so match the country prefix.
 - tapOn:
     text: "DE, .*"
 
@@ -41,16 +30,11 @@ appId: ${APP_ID}
     timeout: 30000
 - tapOn: "Create checkout session"
 
-# Wait for the cart to load. The session auto-selects EUR for the DE
-# customer, so the Pay button starts as "Pay EUR …".
 - extendedWaitUntil:
     visible:
       text: "Pay EUR .*"
     timeout: 150000
 
-# Scroll down to the CurrencySelectorElement and tap the USD option
-# (matched by currency symbol so the test isn't tied to a specific
-# exchange-rate amount).
 - scrollUntilVisible:
     element:
       text: ".*\\$.*"
@@ -59,15 +43,11 @@ appId: ${APP_ID}
 - tapOn:
     text: ".*\\$.*"
 
-# After tapping USD, the session re-prices and the Pay button updates.
-# Waiting on this transition guards against asserting before the
-# selectCurrency network round-trip completes.
 - extendedWaitUntil:
     visible:
       text: "Pay USD .*"
     timeout: 60000
 
-# Open PaymentSheet and pay with a test card.
 - scrollUntilVisible:
     element:
       text: "Pay USD .*"
@@ -94,6 +74,9 @@ appId: ${APP_ID}
     optional: true
 - inputText: "0145"
 - inputText: "123"
+- tapOn:
+    text: "ZIP"
+- inputText: "12345"
 
 - scrollUntilVisible:
     element:
@@ -101,13 +84,13 @@ appId: ${APP_ID}
     optional: true
 - scrollUntilVisible:
     element:
-      text: "purchase!" # iOS
+      text: "Pay \\$.*" # iOS
     optional: true
 - tapOn:
     id: primary_button # Android
     optional: true
 - tapOn:
-    text: "purchase!" # iOS
+    text: "Pay \\$.*" # iOS
     optional: true
 
 - assertVisible:

--- a/e2e-tests/checkout-adaptive-pricing.yml
+++ b/e2e-tests/checkout-adaptive-pricing.yml
@@ -51,7 +51,7 @@ appId: ${APP_ID}
 - scrollUntilVisible:
     element:
       text: "Add shipping address"
-    direction: UP
+    direction: DOWN
     timeout: 30000
 - tapOn: "Add shipping address"
 - extendedWaitUntil:

--- a/e2e-tests/checkout-adaptive-pricing.yml
+++ b/e2e-tests/checkout-adaptive-pricing.yml
@@ -50,10 +50,11 @@ appId: ${APP_ID}
 
 - scrollUntilVisible:
     element:
-      text: "Add shipping address"
+      text: "Add shipping address.*"
     direction: DOWN
     timeout: 30000
-- tapOn: "Add shipping address"
+- tapOn:
+    text: "Add shipping address.*"
 - extendedWaitUntil:
     visible: "Shipping address"
     timeout: 30000

--- a/e2e-tests/checkout-adaptive-pricing.yml
+++ b/e2e-tests/checkout-adaptive-pricing.yml
@@ -21,7 +21,7 @@ appId: ${APP_ID}
 - tapOn:
     id: "adaptive_pricing_country_picker"
 - tapOn:
-    text: "DE, .*"
+    text: "DE.*"
 
 - scrollUntilVisible:
     element:

--- a/e2e-tests/checkout-adaptive-pricing.yml
+++ b/e2e-tests/checkout-adaptive-pricing.yml
@@ -37,17 +37,22 @@ appId: ${APP_ID}
 
 - scrollUntilVisible:
     element:
-      text: ".*\\$.*"
+      id: "currency_selector_element"
     direction: DOWN
     centerElement: true
     timeout: 30000
-- extendedWaitUntil:
-    visible:
-      text: ".*USD = .*EUR.*"
-    timeout: 30000
-- tapOn:
-    text: ".*\\$.*"
-    selected: false
+- runFlow:
+    when:
+      platform: ios
+    commands:
+      - tapOn:
+          text: ".*\\$.*"
+- runFlow:
+    when:
+      platform: android
+    commands:
+      - tapOn:
+          point: "25%,58%"
 
 - extendedWaitUntil:
     visible:
@@ -100,7 +105,7 @@ appId: ${APP_ID}
 - inputText: "0145"
 - inputText: "123"
 - tapOn:
-    text: "ZIP"
+    text: "ZIP.*"
 - inputText: "12345"
 
 - scrollUntilVisible:

--- a/e2e-tests/checkout-adaptive-pricing.yml
+++ b/e2e-tests/checkout-adaptive-pricing.yml
@@ -1,0 +1,111 @@
+# Test the Checkout Playground's CurrencySelectorElement (Adaptive Pricing).
+# Toggles the selector from the merchant currency (USD) to the localized
+# currency (EUR for DE), waits for the session to update, then completes
+# the payment to verify the selected currency flows through PaymentSheet.
+appId: ${APP_ID}
+---
+- launchApp:
+    clearState: true
+- tapOn: "Accept a payment"
+- tapOn: "Checkout Playground"
+
+# Enable Adaptive Pricing. The toggle lives below the fold, so scroll
+# until it's visible regardless of where it lands on a given screen size.
+- scrollUntilVisible:
+    element:
+      id: "adaptive_pricing_toggle"
+    direction: DOWN
+    timeout: 30000
+- tapOn:
+    id: "adaptive_pricing_toggle"
+
+# Pick a country that produces a different currency than the session's
+# USD merchant currency so the selector renders both options.
+- scrollUntilVisible:
+    element:
+      id: "adaptive_pricing_country_picker"
+    direction: DOWN
+    timeout: 30000
+- tapOn:
+    id: "adaptive_pricing_country_picker"
+- tapOn: "DE"
+
+- scrollUntilVisible:
+    element:
+      text: "Create checkout session"
+    direction: DOWN
+    timeout: 30000
+- tapOn: "Create checkout session"
+
+# Wait for the cart to load. The Pay button's currency code is the most
+# reliable signal that the session is fully loaded with totals available.
+- extendedWaitUntil:
+    visible:
+      text: "Pay USD .*"
+    timeout: 150000
+
+# The CurrencySelectorElement is rendered below the promotion code row.
+# Scroll to it and tap the EUR option (matched by currency symbol so the
+# test isn't tied to a specific exchange-rate amount).
+- scrollUntilVisible:
+    element:
+      text: ".*€.*"
+    direction: DOWN
+    timeout: 30000
+- tapOn:
+    text: ".*€.*"
+
+# After tapping EUR, the session re-prices and the Pay button updates.
+# Waiting on this transition guards against asserting before the
+# selectCurrency network round-trip completes.
+- extendedWaitUntil:
+    visible:
+      text: "Pay EUR .*"
+    timeout: 60000
+
+# Open PaymentSheet and pay with a test card.
+- scrollUntilVisible:
+    element:
+      text: "Pay EUR .*"
+    direction: DOWN
+    timeout: 30000
+- tapOn:
+    text: "Pay EUR .*"
+
+- extendedWaitUntil:
+    visible: "TEST"
+    timeout: 150000
+- tapOn:
+    text: "Card"
+    optional: true
+- tapOn:
+    text: "New card"
+    optional: true
+
+- tapOn:
+    text: "Card number"
+- inputText: "4242424242424242"
+- tapOn:
+    text: "MM / YY"
+    optional: true
+- inputText: "0145"
+- inputText: "123"
+
+- scrollUntilVisible:
+    element:
+      id: primary_button # Android
+    optional: true
+- scrollUntilVisible:
+    element:
+      text: "purchase!" # iOS
+    optional: true
+- tapOn:
+    id: primary_button # Android
+    optional: true
+- tapOn:
+    text: "purchase!" # iOS
+    optional: true
+
+- assertVisible:
+    text: "Payment successful"
+- tapOn: "OK"

--- a/e2e-tests/checkout-adaptive-pricing.yml
+++ b/e2e-tests/checkout-adaptive-pricing.yml
@@ -50,6 +50,24 @@ appId: ${APP_ID}
 
 - scrollUntilVisible:
     element:
+      text: "Add shipping address"
+    direction: UP
+    timeout: 30000
+- tapOn: "Add shipping address"
+- extendedWaitUntil:
+    visible: "Shipping address"
+    timeout: 30000
+- tapOn:
+    text: "Full name"
+- inputText: "Jenny Rosen"
+- tapOn: "Use shipping address"
+
+- extendedWaitUntil:
+    visible:
+      text: "Pay USD .*"
+    timeout: 60000
+- scrollUntilVisible:
+    element:
       text: "Pay USD .*"
     direction: DOWN
     timeout: 30000

--- a/e2e-tests/checkout-adaptive-pricing.yml
+++ b/e2e-tests/checkout-adaptive-pricing.yml
@@ -28,7 +28,10 @@ appId: ${APP_ID}
     timeout: 30000
 - tapOn:
     id: "adaptive_pricing_country_picker"
-- tapOn: "DE"
+# The picker option's accessibility label combines the country code with
+# its selection state ("DE, Choose"), so match the country prefix.
+- tapOn:
+    text: "DE, .*"
 
 - scrollUntilVisible:
     element:

--- a/e2e-tests/checkout-adaptive-pricing.yml
+++ b/e2e-tests/checkout-adaptive-pricing.yml
@@ -41,18 +41,8 @@ appId: ${APP_ID}
     direction: DOWN
     centerElement: true
     timeout: 30000
-- runFlow:
-    when:
-      platform: ios
-    commands:
-      - tapOn:
-          text: ".*\\$.*"
-- runFlow:
-    when:
-      platform: android
-    commands:
-      - tapOn:
-          point: "25%,58%"
+- tapOn:
+    text: ".*\\$.*"
 
 - extendedWaitUntil:
     visible:

--- a/example/src/checkoutPlayground/CheckoutPlaygroundCartView.tsx
+++ b/example/src/checkoutPlayground/CheckoutPlaygroundCartView.tsx
@@ -674,7 +674,7 @@ export function CheckoutPlaygroundCartView({
         ) : null}
 
         {config.adaptivePricing ? (
-          <View style={{ marginBottom: 16 }}>
+          <View style={{ marginBottom: 16 }} testID="currency_selector_element">
             <CurrencySelectorElement
               checkout={checkout}
               disabled={isUpdating}

--- a/example/src/checkoutPlayground/CheckoutPlaygroundCartView.tsx
+++ b/example/src/checkoutPlayground/CheckoutPlaygroundCartView.tsx
@@ -7,6 +7,7 @@ import {
   PaymentSheetError,
   useStripe,
 } from '@stripe/stripe-react-native';
+import { CurrencySelectorElement } from '@stripe/stripe-react-native/src/components/CurrencySelectorElement';
 import { useCheckout } from '@stripe/stripe-react-native/src/hooks/useCheckout';
 import SelectedPaymentOption from '../components/SelectedPaymentOption';
 import { BottomActionBar, PlaygroundTitle, StatusBanner } from './components';
@@ -670,6 +671,15 @@ export function CheckoutPlaygroundCartView({
             }}
             promotionCode={promotionCode}
           />
+        ) : null}
+
+        {config.adaptivePricing ? (
+          <View style={{ marginBottom: 16 }}>
+            <CurrencySelectorElement
+              checkout={checkout}
+              disabled={isUpdating}
+            />
+          </View>
         ) : null}
 
         {orderSummaryRows.length > 0 ? (

--- a/example/src/checkoutPlayground/CheckoutPlaygroundConfigView.tsx
+++ b/example/src/checkoutPlayground/CheckoutPlaygroundConfigView.tsx
@@ -186,6 +186,7 @@ export function CheckoutPlaygroundConfigView({
                 />
               ) : null}
               <ToggleRow
+                testID="adaptive_pricing_toggle"
                 title="Adaptive pricing"
                 description="Requests localized pricing when available."
                 value={config.adaptivePricing}
@@ -216,6 +217,7 @@ export function CheckoutPlaygroundConfigView({
               />
               {shouldShowAdaptivePricingCountry(config) ? (
                 <PickerRow
+                  testID="adaptive_pricing_country_picker"
                   title="Adaptive pricing country"
                   description="Adds a location-based customer email override."
                   selectedValue={config.adaptivePricingCountry}

--- a/example/src/checkoutPlayground/CheckoutPlaygroundFormRows.tsx
+++ b/example/src/checkoutPlayground/CheckoutPlaygroundFormRows.tsx
@@ -19,12 +19,14 @@ export function PickerRow({
   selectedValue,
   options,
   onValueChange,
+  testID,
 }: {
   title: string;
   description?: string;
   selectedValue: string;
   options: SelectionOption<string>[];
   onValueChange(value: string): void;
+  testID?: string;
 }) {
   const [isSelectionVisible, setSelectionVisible] = useState(false);
   const selectedOption = options.find(
@@ -37,6 +39,7 @@ export function PickerRow({
         activeOpacity={0.85}
         onPress={() => setSelectionVisible(true)}
         style={styles.row}
+        testID={testID}
       >
         <View style={styles.rowTextContainer}>
           <Text style={styles.rowTitle}>{title}</Text>
@@ -73,11 +76,13 @@ export function ToggleRow({
   description,
   value,
   onValueChange,
+  testID,
 }: {
   title: string;
   description?: string;
   value: boolean;
   onValueChange(nextValue: boolean): void;
+  testID?: string;
 }) {
   return (
     <View style={styles.row}>
@@ -92,6 +97,7 @@ export function ToggleRow({
         onValueChange={onValueChange}
         trackColor={{ false: '#DCE6F1', true: '#A3BCFF' }}
         thumbColor={value ? colors.blurple : colors.white}
+        testID={testID}
       />
     </View>
   );


### PR DESCRIPTION

## Summary
- Shows the currency selector in the cart view when adaptive pricing is enabled, with bottom margin and disabled state while updating.
- Adds an E2E test for AP/CS

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a link to the relevant issue, a code snippet, or an example project that demonstrates the bug. -->

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [ ] I tested this manually
- [x] I added automated tests
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
