### PR TITLE
Updates Android SDK to 23.9.0

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -3,4 +3,4 @@ StripeSdk_compileSdkVersion=36
 StripeSdk_targetSdkVersion=36
 StripeSdk_minSdkVersion=23
 # Keep StripeSdk_stripeVersion in sync with https://github.com/stripe/stripe-identity-react-native/blob/main/android/gradle.properties
-StripeSdk_stripeVersion=23.8.+
+StripeSdk_stripeVersion=23.9.+

--- a/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
+++ b/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
@@ -1882,7 +1882,7 @@ class StripeSdkModule(
     promise: Promise,
   ) {
     performCheckoutMutation(sessionKey, promise) { checkout ->
-      checkout.refresh()
+      checkout.runServerUpdate { Result.success(Unit) }
     }
   }
 


### PR DESCRIPTION
## Summary

Bump stripe-android from 23.8.+ to 23.9.+ and fix the breaking API change introduced in https://github.com/stripe/stripe-android/pull/13110

## Motivation

Onelink

## Testing
- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
