### PR TITLE
Add run server update

### DIFF
--- a/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
+++ b/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
@@ -82,6 +82,7 @@ import com.stripe.android.model.Token
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.payments.bankaccount.CollectBankAccountConfiguration
 import com.stripe.android.paymentsheet.PaymentSheet
+import kotlinx.coroutines.CancellableContinuation
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -89,6 +90,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
 import org.json.JSONObject
 import java.util.UUID
 
@@ -116,6 +118,8 @@ class StripeSdkModule(
   private var googlePayLauncherManager: GooglePayLauncherManager? = null
   private var googlePayPaymentMethodLauncherManager: GooglePayPaymentMethodLauncherManager? = null
   internal val checkoutInstances = mutableMapOf<String, Checkout>()
+  private val serverUpdateContinuations =
+    mutableMapOf<String, CancellableContinuation<Result<Unit>>>()
 
   // / Tracks the long-running coroutine that observes each Checkout's
   // / `checkoutSession` + `isLoading` flows and forwards transitions to JS as
@@ -1875,6 +1879,50 @@ class StripeSdkModule(
     performCheckoutMutation(sessionKey, promise) { checkout ->
       checkout.updateTaxId(type = type, value = value)
     }
+  }
+
+  override fun checkoutRunServerUpdateStart(
+    sessionKey: String,
+    promise: Promise,
+  ) {
+    val checkout = checkoutInstances[sessionKey] ?: run {
+      promise.reject(ErrorType.Failed.toString(), "Checkout session not found.")
+      return
+    }
+
+    if (serverUpdateContinuations.containsKey(sessionKey)) {
+      promise.reject(ErrorType.Failed.toString(), "A server update is already in progress for this session.")
+      return
+    }
+
+    CoroutineScope(Dispatchers.Main).launch {
+      checkout.runServerUpdate {
+        suspendCancellableCoroutine { continuation ->
+          serverUpdateContinuations[sessionKey] = continuation
+        }
+      }.fold(
+        onSuccess = { promise.resolve(mapFromCheckoutState(checkout)) },
+        onFailure = { promise.reject(ErrorType.Failed.toString(), it.message, it) },
+      )
+    }
+  }
+
+  override fun checkoutRunServerUpdateComplete(
+    sessionKey: String,
+    error: String?,
+    promise: Promise,
+  ) {
+    val continuation = serverUpdateContinuations.remove(sessionKey) ?: run {
+      promise.reject(ErrorType.Failed.toString(), "No pending server update for this session.")
+      return
+    }
+
+    if (error != null) {
+      continuation.resume(Result.failure(Exception(error))) {}
+    } else {
+      continuation.resume(Result.success(Unit)) {}
+    }
+    promise.resolve(null)
   }
 
   private fun buildCheckoutConfiguration(configuration: ReadableMap): Checkout.Configuration {

--- a/android/src/oldarch/java/com/reactnativestripesdk/NativeStripeSdkModuleSpec.java
+++ b/android/src/oldarch/java/com/reactnativestripesdk/NativeStripeSdkModuleSpec.java
@@ -335,6 +335,14 @@ public abstract class NativeStripeSdkModuleSpec extends ReactContextBaseJavaModu
 
   @ReactMethod
   @DoNotStrip
+  public abstract void checkoutRunServerUpdateStart(String sessionKey, Promise promise);
+
+  @ReactMethod
+  @DoNotStrip
+  public abstract void checkoutRunServerUpdateComplete(String sessionKey, @Nullable String error, Promise promise);
+
+  @ReactMethod
+  @DoNotStrip
   public abstract void addListener(String eventType);
 
   @ReactMethod

--- a/example/src/checkoutPlayground/CheckoutPlaygroundCartView.tsx
+++ b/example/src/checkoutPlayground/CheckoutPlaygroundCartView.tsx
@@ -354,7 +354,7 @@ export function CheckoutPlaygroundCartView({
     await runCheckoutAction('Server update', async () => {
       await checkout.runServerUpdate(async () => {
         // Simulate a server call with a short delay
-        await new Promise((resolve) => setTimeout(resolve, 2000));
+        await new Promise<void>((resolve) => setTimeout(resolve, 2000));
       });
       setFeedback({
         tone: 'success',

--- a/example/src/checkoutPlayground/CheckoutPlaygroundCartView.tsx
+++ b/example/src/checkoutPlayground/CheckoutPlaygroundCartView.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { Modal, ScrollView, View } from 'react-native';
+import { Modal, ScrollView, Text, TouchableOpacity, View } from 'react-native';
 import {
   AddressSheet,
   AddressSheetError,
@@ -350,6 +350,20 @@ export function CheckoutPlaygroundCartView({
     });
   }, [checkout, runCheckoutAction]);
 
+  const handleRunServerUpdate = useCallback(async () => {
+    await runCheckoutAction('Server update', async () => {
+      await checkout.runServerUpdate(async () => {
+        // Simulate a server call with a short delay
+        await new Promise((resolve) => setTimeout(resolve, 2000));
+      });
+      setFeedback({
+        tone: 'success',
+        title: 'Server update complete',
+        message: 'The session was refreshed after the simulated server call.',
+      });
+    });
+  }, [checkout, runCheckoutAction]);
+
   const handlePresentPaymentSheet = useCallback(async () => {
     if (state?.status !== 'loaded') {
       return;
@@ -591,6 +605,27 @@ export function CheckoutPlaygroundCartView({
         ) : null}
 
         <SessionSection config={config} session={session} />
+
+        <TouchableOpacity
+          disabled={disableActions}
+          onPress={handleRunServerUpdate}
+          style={{
+            marginBottom: 16,
+            padding: 12,
+            borderRadius: 8,
+            backgroundColor: disableActions ? '#E5E7EB' : '#EEF2FF',
+            alignItems: 'center',
+          }}
+        >
+          <Text
+            style={{
+              color: disableActions ? '#9CA3AF' : '#4338CA',
+              fontWeight: '600',
+            }}
+          >
+            Test runServerUpdate (2s simulated server call)
+          </Text>
+        </TouchableOpacity>
 
         {shouldShowLineItemSection ? (
           <ItemsSection

--- a/ios/StripeSdk.mm
+++ b/ios/StripeSdk.mm
@@ -361,6 +361,26 @@ RCT_EXPORT_METHOD(checkoutUpdateTaxId:(nonnull NSString *)sessionKey
                                    rejecter:reject];
 }
 
+RCT_EXPORT_METHOD(checkoutRunServerUpdateStart:(nonnull NSString *)sessionKey
+                                        resolve:(nonnull RCTPromiseResolveBlock)resolve
+                                         reject:(nonnull RCTPromiseRejectBlock)reject)
+{
+  [StripeSdkImpl.shared checkoutRunServerUpdateStart:sessionKey
+                                            resolver:resolve
+                                            rejecter:reject];
+}
+
+RCT_EXPORT_METHOD(checkoutRunServerUpdateComplete:(nonnull NSString *)sessionKey
+                                            error:(NSString *)error
+                                          resolve:(nonnull RCTPromiseResolveBlock)resolve
+                                           reject:(nonnull RCTPromiseRejectBlock)reject)
+{
+  [StripeSdkImpl.shared checkoutRunServerUpdateComplete:sessionKey
+                                                  error:error
+                                               resolver:resolve
+                                               rejecter:reject];
+}
+
 RCT_EXPORT_METHOD(initCustomerSheet:(nonnull NSDictionary *)params
           customerAdapterOverrides:(nonnull NSDictionary *)customerAdapterOverrides
                            resolve:(nonnull RCTPromiseResolveBlock)resolve

--- a/ios/StripeSdkImpl+Checkout.swift
+++ b/ios/StripeSdkImpl+Checkout.swift
@@ -196,6 +196,61 @@ extension StripeSdkImpl {
         }
     }
 
+    @objc(checkoutRunServerUpdateStart:resolver:rejecter:)
+    public func checkoutRunServerUpdateStart(
+        sessionKey: String,
+        resolver resolve: @escaping RCTPromiseResolveBlock,
+        rejecter reject: @escaping RCTPromiseRejectBlock
+    ) {
+        Task { @MainActor [weak self] in
+            guard let self else {
+                reject(ErrorType.Failed, "Stripe SDK is unavailable", nil)
+                return
+            }
+
+            guard let checkout = self.checkoutInstances[sessionKey] else {
+                reject(ErrorType.Failed, "Checkout session not found", nil)
+                return
+            }
+
+            guard self.serverUpdateContinuations[sessionKey] == nil else {
+                reject(ErrorType.Failed, "A server update is already in progress for this session", nil)
+                return
+            }
+
+            do {
+                try await checkout.runServerUpdate {
+                    try await withCheckedThrowingContinuation { continuation in
+                        self.serverUpdateContinuations[sessionKey] = continuation
+                    }
+                }
+                resolve(self.currentCheckoutStateResult(checkout: checkout))
+            } catch {
+                reject(self.checkoutErrorCode(for: error), error.localizedDescription, error)
+            }
+        }
+    }
+
+    @objc(checkoutRunServerUpdateComplete:error:resolver:rejecter:)
+    public func checkoutRunServerUpdateComplete(
+        sessionKey: String,
+        error: String?,
+        resolver resolve: @escaping RCTPromiseResolveBlock,
+        rejecter reject: @escaping RCTPromiseRejectBlock
+    ) {
+        guard let continuation = serverUpdateContinuations.removeValue(forKey: sessionKey) else {
+            reject(ErrorType.Failed, "No pending server update for this session", nil)
+            return
+        }
+
+        if let error {
+            continuation.resume(throwing: CheckoutError.apiError(message: error))
+        } else {
+            continuation.resume()
+        }
+        resolve(nil)
+    }
+
     internal func buildCheckoutConfiguration(params: NSDictionary) -> Checkout.Configuration {
         var configuration = Checkout.Configuration()
 

--- a/ios/StripeSdkImpl.swift
+++ b/ios/StripeSdkImpl.swift
@@ -65,6 +65,7 @@ public class StripeSdkImpl: NSObject, UIAdaptivePresentationControllerDelegate {
     internal var paymentSheetFlowController: PaymentSheet.FlowController?
     internal var checkoutInstances: [String: Checkout] = [:]
     internal var checkoutStateCancellables: [String: AnyCancellable] = [:]
+    internal var serverUpdateContinuations: [String: CheckedContinuation<Void, Error>] = [:]
     var paymentSheetIntentCreationCallback: ((Result<String, Error>) -> Void)?
     var paymentSheetConfirmationTokenIntentCreationCallback: ((Result<String, Error>) -> Void)?
 

--- a/src/hooks/useCheckout.tsx
+++ b/src/hooks/useCheckout.tsx
@@ -165,6 +165,27 @@ export function useCheckout(
       ),
     [withLoading]
   );
+  const runServerUpdate = useCallback<Checkout['runServerUpdate']>(
+    (serverUpdate) =>
+      withLoading(async (key) => {
+        const startPromise = NativeStripeSdk.checkoutRunServerUpdateStart(key);
+
+        try {
+          await serverUpdate();
+          await NativeStripeSdk.checkoutRunServerUpdateComplete(key, null);
+        } catch (e: any) {
+          await NativeStripeSdk.checkoutRunServerUpdateComplete(
+            key,
+            e.message ?? 'Server update failed'
+          );
+          throw e;
+        }
+
+        return await startPromise;
+      }),
+    [withLoading]
+  );
+
   const checkout = useMemo<Checkout>(
     () => ({
       get sessionKey(): string {
@@ -184,6 +205,7 @@ export function useCheckout(
       updateLineItemQuantity,
       selectShippingOption,
       updateTaxId,
+      runServerUpdate,
     }),
     [
       updateShippingAddress,
@@ -193,6 +215,7 @@ export function useCheckout(
       updateLineItemQuantity,
       selectShippingOption,
       updateTaxId,
+      runServerUpdate,
     ]
   );
 

--- a/src/specs/NativeStripeSdkModule.ts
+++ b/src/specs/NativeStripeSdkModule.ts
@@ -262,6 +262,15 @@ export interface Spec extends TurboModule {
     value: string
   ): Promise<UnsafeObject<Checkout.State>>;
 
+  checkoutRunServerUpdateStart(
+    sessionKey: string
+  ): Promise<UnsafeObject<Checkout.State>>;
+
+  checkoutRunServerUpdateComplete(
+    sessionKey: string,
+    error: string | null
+  ): Promise<void>;
+
   setFinancialConnectionsForceNativeFlow(enabled: boolean): Promise<void>;
 
   openAuthenticatedWebView(

--- a/src/types/Checkout.ts
+++ b/src/types/Checkout.ts
@@ -565,4 +565,18 @@ export interface Checkout {
    * @internal
    */
   updateTaxId(type: string, value: string): Promise<void>;
+
+  /**
+   * Runs an async operation that updates the Checkout Session on your server,
+   * then automatically refreshes the local session state.
+   *
+   * Call your server inside `serverUpdate` to modify the Checkout Session.
+   * A 20-second timeout is enforced by the native SDK.
+   *
+   * @param serverUpdate - An async function that calls your server to update the session.
+   * - Throws: `CheckoutError` if the operation times out or fails.
+   * @checkoutSessionsPreview
+   * @internal
+   */
+  runServerUpdate(serverUpdate: () => Promise<void>): Promise<void>;
 }


### PR DESCRIPTION
## Summary
-   Adds runServerUpdate to the Checkout interface, allowing merchants to call their server to update the Checkout Session and have the SDK automatically refresh the local session state afterward.

## Motivation
- CheckoutSession

## Testing
- Manual

## Documentation
N/A