### PR TITLE
Propose 0.66.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 0.66.0 - 2026-05-19
+asdfasdas
+
 ## 0.65.1 - 2026-05-11
 **Fixes**
 * [Fixed] Fixed bug preventing PaymentSheet from dismissing when presenting with timeout. ([#2451](https://github.com/stripe/stripe-react-native/pull/2451))

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "typescript": "tsc --noEmit",
     "lint": "eslint \"**/*.{js,ts,tsx}\" --ignore-pattern \"docs/api-reference/*\" --ignore-path .gitignore",
     "prepare": "bob build && rm -rf lib/*/package.json && husky",
+    "propose": "./scripts/propose.rb",
     "release": "./scripts/publish.rb",
     "example": "yarn --cwd example",
     "pods": "cd example && npx pod-install --quiet",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stripe/stripe-react-native",
-  "version": "0.65.1",
+  "version": "0.66.0",
   "author": "Stripe",
   "description": "Stripe SDK for React Native",
   "main": "lib/commonjs/index",

--- a/scripts/helpers.rb
+++ b/scripts/helpers.rb
@@ -1,0 +1,66 @@
+require 'open3'
+require 'json'
+
+def rputs(string)
+  puts "\e[31m#{string}\e[0m"
+end
+
+def execute(command)
+  puts "Executing: #{command}"
+  system(command)
+end
+
+def execute_or_fail(command)
+  puts "Executing: #{command}"
+  system(command) or abort "Failed to execute: #{command}"
+end
+
+def git_status
+  stdout, _, _ = Open3.capture3("git status")
+  stdout
+end
+
+def current_version
+  JSON.parse(File.read("package.json"))["version"]
+end
+
+def ensure_on_master(is_dry_run: false)
+  status = git_status
+  unless status.include?("On branch master")
+    if is_dry_run
+      rputs "Warning: Not on master branch (continuing for dry run)"
+    else
+      abort "Error! Must be on master branch to publish"
+    end
+  end
+end
+
+def ensure_up_to_date(is_dry_run: false)
+  status = git_status
+  unless status.include?("Your branch is up to date with 'origin/master'.")
+    if is_dry_run
+      rputs "Warning: Not up to date with origin/master (continuing for dry run)"
+    else
+      abort "Error! Must be up to date with origin/master to publish"
+    end
+  end
+end
+
+def ensure_clean_repo(is_dry_run: false)
+  status = git_status
+  unless status.include?("working tree clean")
+    if is_dry_run
+      rputs "Warning: Working tree is dirty (continuing for dry run)"
+    else
+      abort "Error! Cannot publish with dirty working tree"
+    end
+  end
+end
+
+def preflight_checks(is_dry_run: false)
+  puts "Fetching git remotes"
+  execute_or_fail("git fetch")
+  ensure_on_master(is_dry_run: is_dry_run)
+  ensure_up_to_date(is_dry_run: is_dry_run)
+  ensure_clean_repo(is_dry_run: is_dry_run)
+end

--- a/scripts/propose.rb
+++ b/scripts/propose.rb
@@ -1,28 +1,14 @@
 #!/usr/bin/env ruby
 
 require 'optparse'
-require 'open3'
-require 'json'
 require 'date'
 require 'tmpdir'
 require 'shellwords'
+require_relative 'helpers'
 
 @release_type = nil
 
 VALID_RELEASE_TYPES = %w[patch minor major].freeze
-
-def rputs(string)
-  puts "\e[31m#{string}\e[0m"
-end
-
-def execute_or_fail(command)
-  puts "Executing: #{command}"
-  system(command) or abort "Failed to execute: #{command}"
-end
-
-def current_version
-  JSON.parse(File.read("package.json"))["version"]
-end
 
 def next_version
   parts = current_version.split(".").map(&:to_i)
@@ -120,6 +106,8 @@ unless VALID_RELEASE_TYPES.include?(@release_type)
 end
 
 Dir.chdir(`git rev-parse --show-toplevel`.strip)
+
+preflight_checks
 
 version = next_version
 puts "Proposing #{version} (currently #{current_version})"

--- a/scripts/propose.rb
+++ b/scripts/propose.rb
@@ -1,0 +1,121 @@
+#!/usr/bin/env ruby
+
+require 'optparse'
+require 'open3'
+require 'json'
+require 'date'
+require 'tmpdir'
+require 'shellwords'
+
+@release_type = nil
+
+VALID_RELEASE_TYPES = %w[patch minor major].freeze
+
+def rputs(string)
+  puts "\e[31m#{string}\e[0m"
+end
+
+def execute_or_fail(command)
+  puts "Executing: #{command}"
+  system(command) or abort "Failed to execute: #{command}"
+end
+
+def current_version
+  JSON.parse(File.read("package.json"))["version"]
+end
+
+def next_version
+  parts = current_version.split(".").map(&:to_i)
+  case @release_type
+  when "major"
+    parts[0] += 1
+    parts[1] = 0
+    parts[2] = 0
+  when "minor"
+    parts[1] += 1
+    parts[2] = 0
+  when "patch"
+    parts[2] += 1
+  end
+  parts.join(".")
+end
+
+def update_changelog(version)
+  changelog = File.read("CHANGELOG.md")
+  header = "## #{version} - #{Date.today}"
+
+  unless changelog.include?("## Unreleased")
+    abort "Error! CHANGELOG.md is missing an '## Unreleased' section"
+  end
+
+  File.write("CHANGELOG.md", changelog.sub("## Unreleased", header))
+end
+
+def create_proposal_pr(version)
+  branch = "release/propose-#{version}"
+  execute_or_fail("git checkout -b #{branch}")
+
+  update_changelog(version)
+
+  execute_or_fail("git add CHANGELOG.md")
+  execute_or_fail("git commit -m 'Propose #{version}'")
+  execute_or_fail("git push -u origin #{branch}")
+
+  pr_message_file = File.join(Dir.tmpdir, "propose-#{version}-pr-body.md")
+  File.write(pr_message_file, <<~BODY)
+    Propose #{version}
+
+    - [x] Ensure the CHANGELOG is up to date with all relevant commits since the last release
+    - [x] Add the version number for this release & the date to the CHANGELOG, underneath "## Unreleased"
+      - e.g. "## 1.2.3 - 2022-02-14"
+    - [x] Update the README if necessary (this is only required when there are breaking changes in the release, such as dropping support for an iOS || Android version)
+  BODY
+
+  puts ""
+  pr_url = `hub pull-request --base master --head #{branch} -F #{pr_message_file.shellescape}`.strip
+  File.delete(pr_message_file) if File.exist?(pr_message_file)
+
+  if $?.success?
+    puts "Proposal PR created: #{pr_url}"
+    system("open", pr_url)
+  else
+    rputs "Could not create PR via hub. Create it manually:"
+    url = "https://github.com/stripe/stripe-react-native/compare/#{branch}?expand=1"
+    puts "  #{url}"
+    system("open", url)
+  end
+end
+
+OptionParser.new do |opts|
+  opts.banner = <<~BANNER
+    USAGE:
+        ./scripts/propose.rb <release_type>
+
+    Creates a proposal PR for the next release. Replaces the '## Unreleased'
+    header in CHANGELOG.md with the new version and today's date, then opens a PR.
+
+    ARGS:
+        <release_type>    "patch", "minor", or "major"
+  BANNER
+
+  opts.on("-h", "--help", "Show this help message") do
+    puts opts
+    exit
+  end
+end.parse!
+
+@release_type = ARGV.shift
+
+if @release_type.nil?
+  abort "Error! Missing release type. Must be one of: #{VALID_RELEASE_TYPES.join(', ')}"
+end
+
+unless VALID_RELEASE_TYPES.include?(@release_type)
+  abort "Error! Invalid release type '#{@release_type}'. Must be one of: #{VALID_RELEASE_TYPES.join(', ')}"
+end
+
+Dir.chdir(`git rev-parse --show-toplevel`.strip)
+
+version = next_version
+puts "Proposing #{version} (currently #{current_version})"
+create_proposal_pr(version)

--- a/scripts/propose.rb
+++ b/scripts/propose.rb
@@ -51,13 +51,18 @@ def update_changelog(version)
   File.write("CHANGELOG.md", changelog.sub("## Unreleased", header))
 end
 
+def bump_version(version)
+  execute_or_fail("yarn version --no-git-tag-version --new-version #{version}")
+end
+
 def create_proposal_pr(version)
   branch = "release/propose-#{version}"
   execute_or_fail("git checkout -b #{branch}")
 
+  bump_version(version)
   update_changelog(version)
 
-  execute_or_fail("git add CHANGELOG.md")
+  execute_or_fail("git add package.json CHANGELOG.md")
   execute_or_fail("git commit -m 'Propose #{version}'")
   execute_or_fail("git push -u origin #{branch}")
 

--- a/scripts/publish.rb
+++ b/scripts/publish.rb
@@ -5,10 +5,7 @@ require 'open3'
 require 'json'
 
 @is_dry_run = false
-@release_type = nil
 @step_index = 1
-
-VALID_RELEASE_TYPES = %w[patch minor major].freeze
 
 def rputs(string)
   puts "\e[31m#{string}\e[0m"
@@ -27,6 +24,10 @@ end
 def git_status
   stdout, _, _ = Open3.capture3("git status")
   stdout
+end
+
+def current_version
+  JSON.parse(File.read("package.json"))["version"]
 end
 
 def ensure_on_master
@@ -80,40 +81,34 @@ def run_tests
   execute_or_fail("yarn run test")
 end
 
-def bump_version
-  @branch_name = "release-branch-#{rand(10000..99999)}"
-  execute_or_fail("git checkout -b #{@branch_name}")
-
-  puts "Bumping package.json #{@release_type} version and tagging commit"
-  execute_or_fail("yarn version --#{@release_type}")
-end
-
-def current_branch
-  @branch_name || `git rev-parse --abbrev-ref HEAD`.strip
+def create_git_tag
+  version = current_version
+  tag = "v#{version}"
+  puts "Creating git tag: #{tag}"
+  execute_or_fail("git tag #{tag}")
 end
 
 def publish_to_npm
+  version = current_version
+
   if @is_dry_run
     puts ""
     puts "[dry-run] Would publish to npm with: npm publish --ignore-scripts --access=public"
-    puts "[dry-run] Would push branch '#{current_branch}' with tags to origin"
+    puts "[dry-run] Would push tag v#{version} to origin"
     puts "[dry-run] Would create a GitHub release"
     puts ""
     puts "Dry run complete. Cleaning up..."
-    version = JSON.parse(File.read("package.json"))["version"]
     execute("git tag -d v#{version}")
-    execute("git checkout master")
-    execute("git branch -D #{current_branch}")
   else
     puts "Publishing release"
     execute_or_fail("npm publish --ignore-scripts --access=public")
     puts "Published to npm!"
 
-    puts "Pushing git commit and tag"
-    execute_or_fail("git push -u origin #{current_branch} --follow-tags")
+    puts "Pushing git tag"
+    execute_or_fail("git push origin v#{version}")
 
     puts ""
-    puts "Tag pushed! Please open a PR for your version bump: https://github.com/stripe/stripe-react-native/pulls"
+    puts "Published v#{version}!"
     puts ""
   end
 end
@@ -147,7 +142,7 @@ def create_github_release
     return
   end
 
-  current_version = version_and_date.split(" -").first.strip
+  current_ver = version_and_date.split(" -").first.strip
 
   release_notes = <<~NOTES
     #{version_and_date}
@@ -158,10 +153,10 @@ def create_github_release
   NOTES
 
   if system("which hub > /dev/null 2>&1")
-    puts "Creating GitHub release for tag: v#{current_version}"
+    puts "Creating GitHub release for tag: v#{current_ver}"
     puts ""
     print "    "
-    execute_or_fail("hub release create -m #{release_notes.shellescape} \"v#{current_version}\"")
+    execute_or_fail("hub release create -m #{release_notes.shellescape} \"v#{current_ver}\"")
   else
     puts ""
     puts "Remember to create a release on GitHub at https://github.com/stripe/stripe-react-native/releases/new"
@@ -192,10 +187,10 @@ end
 OptionParser.new do |opts|
   opts.banner = <<~BANNER
     USAGE:
-        ./scripts/publish [OPTIONS] <release_type>
+        ./scripts/publish.rb [OPTIONS]
 
-    ARGS:
-        <release_type>    A Semantic Versioning release type: "patch", "minor", or "major".
+    Publishes the current version from package.json to npm, creates a git tag,
+    and creates a GitHub release. Run this after the proposal PR has been merged.
 
     OPTIONS:
   BANNER
@@ -214,23 +209,15 @@ OptionParser.new do |opts|
   end
 end.parse!
 
-@release_type = ARGV.shift
-
-if @release_type.nil?
-  abort "Error! Missing release type argument. Must be one of: #{VALID_RELEASE_TYPES.join(', ')}"
-end
-
-unless VALID_RELEASE_TYPES.include?(@release_type)
-  abort "Error! Invalid release type '#{@release_type}'. Must be one of: #{VALID_RELEASE_TYPES.join(', ')}"
-end
-
 Dir.chdir(`git rev-parse --show-toplevel`.strip)
+
+puts "Publishing v#{current_version}"
 
 steps = [
   { name: "Preflight checks", action: method(:preflight_checks) },
   { name: "Install dependencies", action: method(:install_dependencies) },
   { name: "Run tests", action: method(:run_tests) },
-  { name: "Bump version", action: method(:bump_version) },
+  { name: "Create git tag", action: method(:create_git_tag) },
   { name: "Publish to npm", action: method(:publish_to_npm) },
   { name: "Create GitHub release", action: method(:create_github_release) },
 ]

--- a/scripts/publish.rb
+++ b/scripts/publish.rb
@@ -1,75 +1,10 @@
 #!/usr/bin/env ruby
 
 require 'optparse'
-require 'open3'
-require 'json'
+require_relative 'helpers'
 
 @is_dry_run = false
 @step_index = 1
-
-def rputs(string)
-  puts "\e[31m#{string}\e[0m"
-end
-
-def execute(command)
-  puts "Executing: #{command}"
-  system(command)
-end
-
-def execute_or_fail(command)
-  puts "Executing: #{command}"
-  system(command) or raise "Failed to execute: #{command}"
-end
-
-def git_status
-  stdout, _, _ = Open3.capture3("git status")
-  stdout
-end
-
-def current_version
-  JSON.parse(File.read("package.json"))["version"]
-end
-
-def ensure_on_master
-  status = git_status
-  unless status.include?("On branch master")
-    if @is_dry_run
-      rputs "Warning: Not on master branch (continuing for dry run)"
-    else
-      abort "Error! Must be on master branch to publish"
-    end
-  end
-end
-
-def ensure_up_to_date
-  status = git_status
-  unless status.include?("Your branch is up to date with 'origin/master'.")
-    if @is_dry_run
-      rputs "Warning: Not up to date with origin/master (continuing for dry run)"
-    else
-      abort "Error! Must be up to date with origin/master to publish"
-    end
-  end
-end
-
-def ensure_clean_repo
-  status = git_status
-  unless status.include?("working tree clean")
-    if @is_dry_run
-      rputs "Warning: Working tree is dirty (continuing for dry run)"
-    else
-      abort "Error! Cannot publish with dirty working tree"
-    end
-  end
-end
-
-def preflight_checks
-  puts "Fetching git remotes"
-  execute_or_fail("git fetch")
-  ensure_on_master
-  ensure_up_to_date
-  ensure_clean_repo
-end
 
 def install_dependencies
   puts "Installing dependencies according to lockfile"
@@ -214,7 +149,7 @@ Dir.chdir(`git rev-parse --show-toplevel`.strip)
 puts "Publishing v#{current_version}"
 
 steps = [
-  { name: "Preflight checks", action: method(:preflight_checks) },
+  { name: "Preflight checks", action: -> { preflight_checks(is_dry_run: @is_dry_run) } },
   { name: "Install dependencies", action: method(:install_dependencies) },
   { name: "Run tests", action: method(:run_tests) },
   { name: "Create git tag", action: method(:create_git_tag) },

--- a/scripts/publish.rb
+++ b/scripts/publish.rb
@@ -77,8 +77,6 @@ def create_github_release
     return
   end
 
-  current_ver = version_and_date.split(" -").first.strip
-
   release_notes = <<~NOTES
     #{version_and_date}
 
@@ -88,10 +86,10 @@ def create_github_release
   NOTES
 
   if system("which hub > /dev/null 2>&1")
-    puts "Creating GitHub release for tag: v#{current_ver}"
+    puts "Creating GitHub release for tag: v#{current_version}"
     puts ""
     print "    "
-    execute_or_fail("hub release create -m #{release_notes.shellescape} \"v#{current_ver}\"")
+    execute_or_fail("hub release create -m #{release_notes.shellescape} \"v#{current_version}\"")
   else
     puts ""
     puts "Remember to create a release on GitHub at https://github.com/stripe/stripe-react-native/releases/new"


### PR DESCRIPTION
- [x] Ensure the CHANGELOG is up to date with all relevant commits since the last release
- [x] Add the version number for this release & the date to the CHANGELOG, underneath "## Unreleased"
  - e.g. "## 1.2.3 - 2022-02-14"
- [x] Update the README if necessary (this is only required when there are breaking changes in the release, such as dropping support for an iOS || Android version)