### PR TITLE
Fix NullPointerException in setupComposeCompatView by using Activity context

### DIFF
--- a/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
+++ b/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
@@ -2055,12 +2055,11 @@ class StripeSdkModule(
 
   private fun setupComposeCompatView() {
     UiThreadUtil.runOnUiThread {
+      val activity = reactApplicationContext.currentActivity ?: return@runOnUiThread
       composeCompatView = composeCompatView ?: StripeAbstractComposeView.CompatView(
-        context = reactApplicationContext
+        context = activity
       ).also {
-        reactApplicationContext.currentActivity?.findViewById<ViewGroup>(android.R.id.content)?.addView(
-          it,
-        )
+        activity.findViewById<ViewGroup>(android.R.id.content)?.addView(it)
       }
     }
   }


### PR DESCRIPTION
## Summary

- Use the current Activity context instead of `reactApplicationContext` when creating `StripeAbstractComposeView.CompatView` in `setupComposeCompatView()`
- Bail out early if no Activity is available

## Problem

`setupComposeCompatView()` passes `reactApplicationContext` (an Application context) to `StripeAbstractComposeView.CompatView`. When the view is attached to the Activity's content view, `AndroidComposeView.<init>` crashes with a `NullPointerException` because Jetpack Compose requires an Activity context to resolve the window manager and lifecycle/saved-state registry owners.

```
java.lang.NullPointerException
    at androidx.compose.ui.platform.AndroidComposeView.<init>(SourceFile:743)
    at androidx.compose.ui.platform.AbstractComposeView.onAttachedToWindow(SourceFile:17)
    ...
    at com.reactnativestripesdk.StripeSdkModule.setupComposeCompatView$lambda$0(SourceFile:40)
```

Fixes #2477

## Test plan

- [x] Verified on Android 15 (API 36) device with React Native 0.79, Kotlin 2.3.0, Compose UI 1.7.8
- [x] App no longer crashes on Stripe SDK initialization
- [x] Stripe payment flows continue to work normally