### PR TITLE
Propose 0.68.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 0.68.0 - 2026-05-27
+asdfkahsdfdas
+
 ## 0.66.0 - 2026-05-20
 **Changes**
 * Updated Stripe iOS SDK from 25.14.0 to 25.15.0.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stripe/stripe-react-native",
-  "version": "0.66.0",
+  "version": "0.68.0",
   "author": "Stripe",
   "description": "Stripe SDK for React Native",
   "main": "lib/commonjs/index",

--- a/scripts/helpers.rb
+++ b/scripts/helpers.rb
@@ -57,10 +57,31 @@ def ensure_clean_repo(is_dry_run: false)
   end
 end
 
+<<<<<<< Updated upstream
+=======
+def ensure_gh_installed
+  unless system("which gh > /dev/null 2>&1")
+    abort "Error! `gh` is not installed. Please run `brew install gh` and try again."
+  end
+end
+
+def ensure_gh_authenticated
+  _, _, status = Open3.capture3({"GH_HOST" => "github.com"}, "gh auth status")
+  unless status.success?
+    abort "Error! Not authenticated with gh for github.com. Please run `GH_HOST=github.com gh auth login` and try again."
+  end
+end
+
+>>>>>>> Stashed changes
 def preflight_checks(is_dry_run: false)
   puts "Fetching git remotes"
   execute_or_fail("git fetch")
   ensure_on_master(is_dry_run: is_dry_run)
   ensure_up_to_date(is_dry_run: is_dry_run)
   ensure_clean_repo(is_dry_run: is_dry_run)
+<<<<<<< Updated upstream
+=======
+  ensure_gh_installed
+  ensure_gh_authenticated
+>>>>>>> Stashed changes
 end

--- a/scripts/propose.rb
+++ b/scripts/propose.rb
@@ -54,8 +54,6 @@ def create_proposal_pr(version)
 
   pr_message_file = File.join(Dir.tmpdir, "propose-#{version}-pr-body.md")
   File.write(pr_message_file, <<~BODY)
-    Propose #{version}
-
     - [x] Ensure the CHANGELOG is up to date with all relevant commits since the last release
     - [x] Add the version number for this release & the date to the CHANGELOG, underneath "## Unreleased"
       - e.g. "## 1.2.3 - 2022-02-14"
@@ -63,14 +61,14 @@ def create_proposal_pr(version)
   BODY
 
   puts ""
-  pr_url = `hub pull-request --base master --head #{branch} -F #{pr_message_file.shellescape}`.strip
+  pr_url = `GH_HOST=github.com gh pr create --repo stripe/stripe-react-native --base master --head #{branch} --title "Propose #{version}" --body-file #{pr_message_file.shellescape}`.strip
   File.delete(pr_message_file) if File.exist?(pr_message_file)
 
   if $?.success?
     puts "Proposal PR created: #{pr_url}"
     system("open", pr_url)
   else
-    rputs "Could not create PR via hub. Create it manually:"
+    rputs "Could not create PR via gh. Create it manually:"
     url = "https://github.com/stripe/stripe-react-native/compare/#{branch}?expand=1"
     puts "  #{url}"
     system("open", url)

--- a/scripts/publish.rb
+++ b/scripts/publish.rb
@@ -85,11 +85,11 @@ def create_github_release
     Please [see the changelog](https://github.com/stripe/stripe-react-native/blob/master/CHANGELOG.md) for additional details.
   NOTES
 
-  if system("which hub > /dev/null 2>&1")
+  if system("which gh > /dev/null 2>&1")
     puts "Creating GitHub release for tag: v#{current_version}"
     puts ""
     print "    "
-    execute_or_fail("hub release create -m #{release_notes.shellescape} \"v#{current_version}\"")
+    execute_or_fail("GH_HOST=github.com gh release create \"v#{current_version}\" --repo stripe/stripe-react-native --title #{version_and_date.shellescape} --notes #{changelog.strip.shellescape}")
   else
     puts ""
     puts "Remember to create a release on GitHub at https://github.com/stripe/stripe-react-native/releases/new"


### PR DESCRIPTION
- [x] Ensure the CHANGELOG is up to date with all relevant commits since the last release
- [x] Add the version number for this release & the date to the CHANGELOG, underneath "## Unreleased"
  - e.g. "## 1.2.3 - 2022-02-14"
- [x] Update the README if necessary (this is only required when there are breaking changes in the release, such as dropping support for an iOS || Android version)
