### PR TITLE
Remove updateTaxId API from Checkout SDK

### DIFF
--- a/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
+++ b/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
@@ -1869,17 +1869,6 @@ class StripeSdkModule(
     }
   }
 
-  override fun checkoutUpdateTaxId(
-    sessionKey: String,
-    type: String,
-    value: String,
-    promise: Promise,
-  ) {
-    performCheckoutMutation(sessionKey, promise) { checkout ->
-      checkout.updateTaxId(type = type, value = value)
-    }
-  }
-
   override fun checkoutRunServerUpdateStart(
     sessionKey: String,
     promise: Promise,

--- a/android/src/oldarch/java/com/reactnativestripesdk/NativeStripeSdkModuleSpec.java
+++ b/android/src/oldarch/java/com/reactnativestripesdk/NativeStripeSdkModuleSpec.java
@@ -331,10 +331,6 @@ public abstract class NativeStripeSdkModuleSpec extends ReactContextBaseJavaModu
 
   @ReactMethod
   @DoNotStrip
-  public abstract void checkoutUpdateTaxId(String sessionKey, String type, String value, Promise promise);
-
-  @ReactMethod
-  @DoNotStrip
   public abstract void checkoutRunServerUpdateStart(String sessionKey, Promise promise);
 
   @ReactMethod

--- a/ios/StripeSdk.mm
+++ b/ios/StripeSdk.mm
@@ -348,19 +348,6 @@ RCT_EXPORT_METHOD(checkoutSelectShippingOption:(nonnull NSString *)sessionKey
                                             rejecter:reject];
 }
 
-RCT_EXPORT_METHOD(checkoutUpdateTaxId:(nonnull NSString *)sessionKey
-                                  type:(nonnull NSString *)type
-                                 value:(nonnull NSString *)value
-                               resolve:(nonnull RCTPromiseResolveBlock)resolve
-                                reject:(nonnull RCTPromiseRejectBlock)reject)
-{
-  [StripeSdkImpl.shared checkoutUpdateTaxId:sessionKey
-                                       type:type
-                                      value:value
-                                   resolver:resolve
-                                   rejecter:reject];
-}
-
 RCT_EXPORT_METHOD(checkoutRunServerUpdateStart:(nonnull NSString *)sessionKey
                                         resolve:(nonnull RCTPromiseResolveBlock)resolve
                                          reject:(nonnull RCTPromiseRejectBlock)reject)

--- a/ios/StripeSdkImpl+Checkout.swift
+++ b/ios/StripeSdkImpl+Checkout.swift
@@ -179,23 +179,6 @@ extension StripeSdkImpl {
         }
     }
 
-    @objc(checkoutUpdateTaxId:type:value:resolver:rejecter:)
-    public func checkoutUpdateTaxId(
-        sessionKey: String,
-        type: String,
-        value: String,
-        resolver resolve: @escaping RCTPromiseResolveBlock,
-        rejecter reject: @escaping RCTPromiseRejectBlock
-    ) {
-        performCheckoutMutation(
-            sessionKey: sessionKey,
-            resolver: resolve,
-            rejecter: reject
-        ) { checkout in
-            try await checkout.updateTaxId(type: type, value: value)
-        }
-    }
-
     @objc(checkoutRunServerUpdateStart:resolver:rejecter:)
     public func checkoutRunServerUpdateStart(
         sessionKey: String,

--- a/src/hooks/useCheckout.tsx
+++ b/src/hooks/useCheckout.tsx
@@ -158,13 +158,6 @@ export function useCheckout(
       ),
     [withLoading]
   );
-  const updateTaxId = useCallback<Checkout['updateTaxId']>(
-    (type, value) =>
-      withLoading((key) =>
-        NativeStripeSdk.checkoutUpdateTaxId(key, type, value)
-      ),
-    [withLoading]
-  );
   const runServerUpdate = useCallback<Checkout['runServerUpdate']>(
     (serverUpdate) =>
       withLoading(async (key) => {
@@ -204,7 +197,6 @@ export function useCheckout(
       removePromotionCode,
       updateLineItemQuantity,
       selectShippingOption,
-      updateTaxId,
       runServerUpdate,
     }),
     [
@@ -214,7 +206,6 @@ export function useCheckout(
       removePromotionCode,
       updateLineItemQuantity,
       selectShippingOption,
-      updateTaxId,
       runServerUpdate,
     ]
   );

--- a/src/specs/NativeStripeSdkModule.ts
+++ b/src/specs/NativeStripeSdkModule.ts
@@ -256,12 +256,6 @@ export interface Spec extends TurboModule {
     id: string
   ): Promise<UnsafeObject<Checkout.State>>;
 
-  checkoutUpdateTaxId(
-    sessionKey: string,
-    type: string,
-    value: string
-  ): Promise<UnsafeObject<Checkout.State>>;
-
   checkoutRunServerUpdateStart(
     sessionKey: string
   ): Promise<UnsafeObject<Checkout.State>>;

--- a/src/types/Checkout.ts
+++ b/src/types/Checkout.ts
@@ -558,15 +558,6 @@ export interface Checkout {
   selectShippingOption(id: string): Promise<void>;
 
   /**
-   * Sets the customer's tax ID on the session.
-   * @param type - The tax ID type (e.g. `"eu_vat"`).
-   * @param value - The tax ID value (e.g. `"DE123456789"`).
-   * - Throws: `CheckoutError` if updating the tax ID fails.
-   * @internal
-   */
-  updateTaxId(type: string, value: string): Promise<void>;
-
-  /**
    * Runs an async operation that updates the Checkout Session on your server,
    * then automatically refreshes the local session state.
    *


### PR DESCRIPTION
## Summary
- Remove the checkoutUpdateTaxId native method and the updateTaxId TypeScript API from the Checkout interface, hook, native specs, and platform implementations (iOS and Android).

## Motivation
- Not in scope for private preview or possibly GA

## Testing
- CI
