### PR TITLE
Add mapping for StripeException to createError

### DIFF
--- a/android/src/main/java/com/reactnativestripesdk/utils/Errors.kt
+++ b/android/src/main/java/com/reactnativestripesdk/utils/Errors.kt
@@ -5,6 +5,7 @@ import com.facebook.react.bridge.WritableMap
 import com.stripe.android.core.exception.APIException
 import com.stripe.android.core.exception.AuthenticationException
 import com.stripe.android.core.exception.InvalidRequestException
+import com.stripe.android.core.exception.StripeException
 import com.stripe.android.exception.CardException
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.SetupIntent
@@ -171,6 +172,16 @@ internal fun createError(
         error.stripeError?.declineCode,
         error.stripeError?.type,
         error.stripeError?.code,
+      )
+    }
+    is StripeException -> {
+      mapError(
+        code,
+        error.message,
+        error.localizedMessage,
+        error.stripeError?.declineCode,
+        error.stripeError?.type,
+        error.stripeError?.code
       )
     }
     else -> mapError(code, error.message, error.localizedMessage.orEmpty(), null, null, null)


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
- Add mapping for StripeError to createError
Before:
`{stripeErrorCode: null, declineCode: null, localizedMessage: 'Your card has insufficient funds.', message: 'Your card has insufficient funds.', type: null, code: 'Failed'}`
After:
`{stripeErrorCode: 'card_declined', declineCode: 'insufficient_funds', localizedMessage: 'Your card has insufficient funds.', message: 'Your card has insufficient funds.', type: 'card_error', code: 'Failed'}`

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a link to the relevant issue, a code snippet, or an example project that demonstrates the bug. -->
- Properly populate error returned to user
- https://jira.corp.stripe.com/browse/RUN_MOBILESDK-5379

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [X] I tested this manually
- [ ] I added automated tests
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
