### PR TITLE
Improve Onramp configure attestation error

### DIFF
--- a/example/src/screens/HomeScreen.tsx
+++ b/example/src/screens/HomeScreen.tsx
@@ -95,7 +95,9 @@ export default function HomeScreen() {
         if (result?.error) {
           console.error(
             'Error configuring Onramp:',
-            result.error.developerMessage ?? result.error.message
+            'developerMessage' in result.error && result.error.developerMessage
+              ? result.error.developerMessage
+              : result.error.message
           );
           Alert.alert('Onramp Configuration Error', result.error.message);
         } else {

--- a/example/src/screens/HomeScreen.tsx
+++ b/example/src/screens/HomeScreen.tsx
@@ -93,7 +93,10 @@ export default function HomeScreen() {
     configure(config)
       .then((result) => {
         if (result?.error) {
-          console.error('Error configuring Onramp:', result.error.message);
+          console.error(
+            'Error configuring Onramp:',
+            result.error.developerMessage ?? result.error.message
+          );
           Alert.alert('Onramp Configuration Error', result.error.message);
         } else {
           console.log('Onramp configured successfully.');

--- a/src/components/StripeProvider.tsx
+++ b/src/components/StripeProvider.tsx
@@ -6,6 +6,7 @@ import { isAndroid, shouldAttributeExpo } from '../helpers';
 import type { AppInfo, InitStripeParams, InitialiseParams } from '../types';
 import pjson from '../../package.json';
 import { AppRegistry, Platform } from 'react-native';
+import { setCurrentPublishableKey } from '../internal/stripeConfig';
 
 const EXPO_PARTNER_ID = 'pp_partner_JBN7LkABco2yUu';
 
@@ -50,6 +51,7 @@ export const initStripe = async (params: InitStripeParams): Promise<void> => {
 
   const extendedParams: InitialiseParams = { ...params, appInfo };
   await NativeStripeSdk.initialise(extendedParams);
+  setCurrentPublishableKey(params.publishableKey);
 
   if (Platform.OS === 'android') {
     await NativeOnrampSdk?.initialise(extendedParams);

--- a/src/hooks/useOnramp.tsx
+++ b/src/hooks/useOnramp.tsx
@@ -41,6 +41,10 @@ function publishableKeyMode(): 'live' | 'test' | undefined {
   return undefined;
 }
 
+// Temporary React Native shim: iOS/Android currently surface this configure/create
+// failure as a legacy SDK-level message instead of a typed rich error. This can be
+// removed once the native SDKs map it themselves, though keeping it is harmless as
+// a compatibility fallback for older native SDK versions.
 function mapLegacyConfigureAppAttestationError(result: {
   error?: Onramp.CryptoOnrampError;
 }): { error?: Onramp.CryptoOnrampError } {
@@ -58,9 +62,6 @@ function mapLegacyConfigureAppAttestationError(result: {
     "This app couldn't be verified. Contact the app developer for help.";
   const mode = publishableKeyMode();
 
-  // Temporary React Native shim: this configure/create failure can come from the native SDK
-  // before Crypto Onramp wraps it in an AppAttestation rich error. Remove
-  // this once iOS/Android return a typed rich error for coordinator configure/create.
   const context = [
     'Context:',
     '  operation: configure',

--- a/src/hooks/useOnramp.tsx
+++ b/src/hooks/useOnramp.tsx
@@ -5,6 +5,8 @@ import type { Address } from '../types';
 import { useCallback } from 'react';
 import { addOnrampListener } from '../events';
 import { CryptoPaymentToken } from '../types/Onramp';
+import { getCurrentPublishableKey } from '../internal/stripeConfig';
+import pjson from '../../package.json';
 
 export function requireOnrampModule() {
   if (NativeOnrampSdk == null) {
@@ -24,6 +26,74 @@ export function requireOnrampModule() {
 let onCheckoutClientSecretRequestedSubscription: EventSubscription | null =
   null;
 
+const legacyMissingAppAttestationMessage =
+  'App attestation is missing or device cannot use native Link.';
+const cryptoOnrampAppAttestationUnavailableCode = 'app_attestation_unavailable';
+
+function publishableKeyMode(): 'live' | 'test' | undefined {
+  const publishableKey = getCurrentPublishableKey();
+  if (publishableKey?.startsWith('pk_live_')) {
+    return 'live';
+  }
+  if (publishableKey?.startsWith('pk_test_')) {
+    return 'test';
+  }
+  return undefined;
+}
+
+function mapLegacyConfigureAppAttestationError(result: {
+  error?: Onramp.CryptoOnrampError;
+}): { error?: Onramp.CryptoOnrampError } {
+  const error = result.error;
+  if (
+    error == null ||
+    error.onrampErrorType != null ||
+    (error.message !== legacyMissingAppAttestationMessage &&
+      error.localizedMessage !== legacyMissingAppAttestationMessage)
+  ) {
+    return result;
+  }
+
+  const userMessage =
+    "This app couldn't be verified. Contact the app developer for help.";
+  const mode = publishableKeyMode();
+
+  // Temporary React Native shim: this configure/create failure can come from the native SDK
+  // before Crypto Onramp wraps it in an AppAttestation rich error. Remove
+  // this once iOS/Android return a typed rich error for coordinator configure/create.
+  const context = [
+    'Context:',
+    '  operation: configure',
+    mode != null ? `  mode: ${mode}` : undefined,
+  ].filter((line): line is string => line != null);
+  const appAttestationError = {
+    ...error,
+    message: userMessage,
+    localizedMessage: userMessage,
+    stripeErrorCode: cryptoOnrampAppAttestationUnavailableCode,
+    developerMessage: [
+      "App attestation unavailable: this app isn't configured to use Stripe Crypto Onramp.",
+      '',
+      "This usually means app attestation isn't enabled for this Stripe account, or this app isn't registered as a trusted application. Use your iOS bundle ID or Android package name and contact Stripe to enable app attestation or register the app for this account.",
+      '',
+      ...context,
+      '',
+      `Code: ${cryptoOnrampAppAttestationUnavailableCode}`,
+      '',
+      'Next step: confirm app attestation is enabled for this Stripe account and that the app identifier is registered as trusted, then retry the Onramp flow.',
+      `SDK: stripe-react-native@${pjson.version}`,
+    ].join('\n'),
+    userMessage,
+    operation: 'configure',
+    mode,
+  } as unknown as Onramp.CryptoOnrampError;
+
+  return {
+    ...result,
+    error: appAttestationError,
+  };
+}
+
 /**
  * useOnramp hook
  */
@@ -32,7 +102,9 @@ export function useOnramp() {
     async (
       config: Onramp.Configuration
     ): Promise<{ error?: Onramp.CryptoOnrampError }> => {
-      return requireOnrampModule().configureOnramp(config);
+      return mapLegacyConfigureAppAttestationError(
+        await requireOnrampModule().configureOnramp(config)
+      );
     },
     []
   );

--- a/src/hooks/useOnramp.tsx
+++ b/src/hooks/useOnramp.tsx
@@ -81,7 +81,7 @@ function mapLegacyConfigureAppAttestationError(result: {
       '',
       `Code: ${cryptoOnrampAppAttestationUnavailableCode}`,
       '',
-      'Next step: confirm app attestation is enabled for this Stripe account and that the app identifier is registered as trusted, then retry the Onramp flow.',
+      'Next step: confirm app attestation is enabled for this Stripe account and that the app identifier is registered as trusted, then call configure again.',
       `SDK: stripe-react-native@${pjson.version}`,
     ].join('\n'),
     userMessage,

--- a/src/hooks/useOnramp.tsx
+++ b/src/hooks/useOnramp.tsx
@@ -26,9 +26,17 @@ export function requireOnrampModule() {
 let onCheckoutClientSecretRequestedSubscription: EventSubscription | null =
   null;
 
-const legacyMissingAppAttestationMessage =
-  'App attestation is missing or device cannot use native Link.';
+const legacyAppAttestationUnavailableMessages = [
+  'App attestation is missing or device cannot use native Link.',
+  'Native Link is not available',
+];
 const cryptoOnrampAppAttestationUnavailableCode = 'app_attestation_unavailable';
+
+function isLegacyAppAttestationUnavailableMessage(message?: string): boolean {
+  return (
+    message != null && legacyAppAttestationUnavailableMessages.includes(message)
+  );
+}
 
 function publishableKeyMode(): 'live' | 'test' | undefined {
   const publishableKey = getCurrentPublishableKey();
@@ -52,8 +60,8 @@ function mapLegacyConfigureAppAttestationError(result: {
   if (
     error == null ||
     error.onrampErrorType != null ||
-    (error.message !== legacyMissingAppAttestationMessage &&
-      error.localizedMessage !== legacyMissingAppAttestationMessage)
+    (!isLegacyAppAttestationUnavailableMessage(error.message) &&
+      !isLegacyAppAttestationUnavailableMessage(error.localizedMessage))
   ) {
     return result;
   }

--- a/src/internal/stripeConfig.ts
+++ b/src/internal/stripeConfig.ts
@@ -1,0 +1,9 @@
+let currentPublishableKey: string | undefined;
+
+export function setCurrentPublishableKey(publishableKey: string): void {
+  currentPublishableKey = publishableKey;
+}
+
+export function getCurrentPublishableKey(): string | undefined {
+  return currentPublishableKey;
+}


### PR DESCRIPTION
## What
This adds a temporary React Native shim for the Crypto Onramp configure error that currently surfaces as "App attestation is missing or device cannot use native Link."

Instead of returning that native implementation detail, RN maps it to an SDK-level error with clearer user-facing copy and a developer message that explains the likely Stripe account/app registration issue.

## Why
The native rich error work currently handles API-backed attestation errors, but this configure/create failure happens before that path. This keeps the RN experience usable until iOS/Android return a typed rich error for this case.

## Testing
- Tested that the configure failure is surfaced as a rich SDK-level error with user and developer messages

<img width="1191" height="258" alt="Screenshot 2026-06-09 at 12 57 49 PM" src="https://github.com/user-attachments/assets/a9e09564-f4c6-486e-9394-464299602cf3" />
