### PR TITLE
Propose 0.67.0; fix deploy script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## X.Y.Z - changes pending release
+## 0.67.0 - 2026-06-09
 **Changes**
 * Updated Stripe iOS SDK from 25.16.0 to 25.17.0.
 * Updated Stripe Android SDK from 23.9.+ to 23.10.+.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stripe/stripe-react-native",
-  "version": "0.66.0",
+  "version": "0.67.0",
   "author": "Stripe",
   "description": "Stripe SDK for React Native",
   "main": "lib/commonjs/index",

--- a/scripts/propose.rb
+++ b/scripts/propose.rb
@@ -30,11 +30,11 @@ def update_changelog(version)
   changelog = File.read("CHANGELOG.md")
   header = "## #{version} - #{Date.today}"
 
-  unless changelog.include?("## Unreleased")
-    abort "Error! CHANGELOG.md is missing an '## Unreleased' section"
+  unless changelog.include?("## X.Y.Z - changes pending release")
+    abort "Error! CHANGELOG.md is missing an '## X.Y.Z - changes pending release' section"
   end
 
-  File.write("CHANGELOG.md", changelog.sub("## Unreleased", header))
+  File.write("CHANGELOG.md", changelog.sub("## X.Y.Z - changes pending release", header))
 end
 
 def bump_version(version)
@@ -55,7 +55,7 @@ def create_proposal_pr(version)
   pr_message_file = File.join(Dir.tmpdir, "propose-#{version}-pr-body.md")
   File.write(pr_message_file, <<~BODY)
     - [x] Ensure the CHANGELOG is up to date with all relevant commits since the last release
-    - [x] Add the version number for this release & the date to the CHANGELOG, underneath "## Unreleased"
+    - [x] Add the version number for this release & the date to the CHANGELOG, underneath "## X.Y.Z - changes pending release"
       - e.g. "## 1.2.3 - 2022-02-14"
     - [x] Update the README if necessary (this is only required when there are breaking changes in the release, such as dropping support for an iOS || Android version)
   BODY
@@ -80,7 +80,7 @@ OptionParser.new do |opts|
     USAGE:
         ./scripts/propose.rb <release_type>
 
-    Creates a proposal PR for the next release. Replaces the '## Unreleased'
+    Creates a proposal PR for the next release. Replaces the '## X.Y.Z - changes pending release'
     header in CHANGELOG.md with the new version and today's date, then opens a PR.
 
     ARGS:


### PR DESCRIPTION
- [ ] Ensure the CHANGELOG is up to date with all relevant commits since the last release
- [ ] Add the version number for this release & the date to the CHANGELOG, underneath "## Unreleased" 
  - e.g. "## 1.2.3 - 2022-02-14"
- [ ] Update the README if necessary (this is only required when there are breaking changes in the release, such as dropping support for an iOS || Android version)