### PR TITLE
Remove updateCheckout from EmbeddedPaymentElement

### DIFF
--- a/android/src/main/java/com/reactnativestripesdk/EmbeddedPaymentElementView.kt
+++ b/android/src/main/java/com/reactnativestripesdk/EmbeddedPaymentElementView.kt
@@ -64,10 +64,6 @@ class EmbeddedPaymentElementView(
       val intentConfiguration: PaymentSheet.IntentConfiguration,
     ) : Event
 
-    data class UpdateWithCheckout(
-      val checkout: Checkout,
-    ) : Event
-
     data object Confirm : Event
 
     data object ClearPaymentOption : Event
@@ -347,20 +343,6 @@ class EmbeddedPaymentElementView(
             latestIntentConfig = ev.intentConfiguration
           }
 
-          is Event.UpdateWithCheckout -> {
-            val elemConfig = latestElementConfig ?: return@collect emitUpdateMissingConfiguration()
-
-            val result =
-              embedded.configure(
-                checkout = ev.checkout,
-                configuration = elemConfig,
-              )
-
-            handleUpdateResult(result)
-
-            latestCheckout = ev.checkout
-          }
-
           is Event.Confirm -> {
             embedded.confirm()
           }
@@ -504,10 +486,6 @@ class EmbeddedPaymentElementView(
 
   fun update(intentConfig: PaymentSheet.IntentConfiguration) {
     events.trySend(Event.Update(intentConfig))
-  }
-
-  fun updateWithCheckout(checkout: Checkout) {
-    events.trySend(Event.UpdateWithCheckout(checkout))
   }
 
   fun confirm() {

--- a/android/src/main/java/com/reactnativestripesdk/EmbeddedPaymentElementViewManager.kt
+++ b/android/src/main/java/com/reactnativestripesdk/EmbeddedPaymentElementViewManager.kt
@@ -244,28 +244,6 @@ class EmbeddedPaymentElementViewManager :
     }
   }
 
-  override fun updateWithCheckout(
-    view: EmbeddedPaymentElementView,
-    sessionKey: String?,
-  ) {
-    if (sessionKey == null) return
-
-    val stripeSdkModule =
-      (view.context as ThemedReactContext).getNativeModule(StripeSdkModule::class.java)
-    val checkout = stripeSdkModule?.checkoutInstances?.get(sessionKey)
-    if (checkout == null) {
-      val payload =
-        Arguments.createMap().apply {
-          putString("message", "Checkout session not found.")
-        }
-      stripeSdkModule?.eventEmitter?.emitEmbeddedPaymentElementLoadingFailed(payload)
-      stripeSdkModule?.eventEmitter?.emitEmbeddedPaymentElementUpdateComplete(null)
-      return
-    }
-
-    view.updateWithCheckout(checkout)
-  }
-
   private fun jsonToWritableMap(json: JSONObject): WritableMap {
     val map = Arguments.createMap()
     val keys = json.keys()

--- a/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
+++ b/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
@@ -1444,15 +1444,6 @@ class StripeSdkModule(
   }
 
   @ReactMethod
-  override fun updateEmbeddedPaymentElementWithCheckout(
-    sessionKey: String,
-    promise: Promise,
-  ) {
-    // No-op on Android. JS dispatches Checkout updates through the view command instead.
-    promise.resolve(null)
-  }
-
-  @ReactMethod
   override fun clearEmbeddedPaymentOption(
     viewTag: Double,
     promise: Promise,

--- a/android/src/oldarch/java/com/facebook/react/viewmanagers/EmbeddedPaymentElementViewManagerDelegate.java
+++ b/android/src/oldarch/java/com/facebook/react/viewmanagers/EmbeddedPaymentElementViewManagerDelegate.java
@@ -50,9 +50,6 @@ public class EmbeddedPaymentElementViewManagerDelegate<T extends View, U extends
       case "update":
         mViewManager.update(view, args != null ? args.getString(0) : null);
         break;
-      case "updateWithCheckout":
-        mViewManager.updateWithCheckout(view, args != null ? args.getString(0) : null);
-        break;
     }
   }
 }

--- a/android/src/oldarch/java/com/facebook/react/viewmanagers/EmbeddedPaymentElementViewManagerInterface.java
+++ b/android/src/oldarch/java/com/facebook/react/viewmanagers/EmbeddedPaymentElementViewManagerInterface.java
@@ -20,5 +20,4 @@ public interface EmbeddedPaymentElementViewManagerInterface<T extends View>  {
   void confirm(T view);
   void clearPaymentOption(T view);
   void update(T view, @Nullable String intentConfigurationJson);
-  void updateWithCheckout(T view, @Nullable String sessionKey);
 }

--- a/android/src/oldarch/java/com/reactnativestripesdk/NativeStripeSdkModuleSpec.java
+++ b/android/src/oldarch/java/com/reactnativestripesdk/NativeStripeSdkModuleSpec.java
@@ -267,10 +267,6 @@ public abstract class NativeStripeSdkModuleSpec extends ReactContextBaseJavaModu
 
   @ReactMethod
   @DoNotStrip
-  public abstract void updateEmbeddedPaymentElementWithCheckout(String sessionKey, Promise promise);
-
-  @ReactMethod
-  @DoNotStrip
   public abstract void clearEmbeddedPaymentOption(double viewTag, Promise promise);
 
   @ReactMethod

--- a/etc/stripe-react-native.api.md
+++ b/etc/stripe-react-native.api.md
@@ -4000,10 +4000,7 @@ export interface UseEmbeddedPaymentElementResult {
     // (undocumented)
     loadingError: Error | null;
     paymentOption: PaymentOptionDisplayData | null;
-    update: {
-        (intentConfig: PaymentSheet.IntentConfiguration): void;
-        (checkout: Checkout): void;
-    };
+    update: (intentConfig: PaymentSheet.IntentConfiguration) => void;
 }
 
 // @public

--- a/ios/NewArch/EmbeddedPaymentElementViewComponentView.mm
+++ b/ios/NewArch/EmbeddedPaymentElementViewComponentView.mm
@@ -68,10 +68,6 @@ using namespace facebook::react;
 {
 }
 
-- (void)updateWithCheckout:(NSString *)sessionKey
-{
-}
-
 #pragma mark - RCTComponentViewProtocol
 
 + (ComponentDescriptorProvider)componentDescriptorProvider

--- a/ios/StripeSdk.mm
+++ b/ios/StripeSdk.mm
@@ -578,13 +578,6 @@ RCT_EXPORT_METHOD(updateEmbeddedPaymentElement:(NSDictionary *)intentConfig
   [StripeSdkImpl.shared updateEmbeddedPaymentElement:intentConfig resolve:resolve reject:reject];
 }
 
-RCT_EXPORT_METHOD(updateEmbeddedPaymentElementWithCheckout:(nonnull NSString *)sessionKey
-                                                   resolve:(nonnull RCTPromiseResolveBlock)resolve
-                                                    reject:(nonnull RCTPromiseRejectBlock)reject)
-{
-  [StripeSdkImpl.shared updateEmbeddedPaymentElementWithCheckout:sessionKey resolve:resolve reject:reject];
-}
-
 RCT_EXPORT_METHOD(clearEmbeddedPaymentOption:(NSInteger)viewTag
                                      resolve:(nonnull RCTPromiseResolveBlock)resolve
                                       reject:(nonnull RCTPromiseRejectBlock)reject)

--- a/ios/StripeSdkImpl+Embedded.swift
+++ b/ios/StripeSdkImpl+Embedded.swift
@@ -213,30 +213,6 @@ extension StripeSdkImpl {
     }
   }
 
-  @objc(updateEmbeddedPaymentElementWithCheckout:resolve:reject:)
-  public func updateEmbeddedPaymentElementWithCheckout(
-    sessionKey: String,
-    resolve: @escaping RCTPromiseResolveBlock,
-    reject: @escaping RCTPromiseRejectBlock
-  ) {
-    guard let checkout = checkoutInstances[sessionKey] else {
-      resolve(Errors.createError(ErrorType.Failed, "Checkout session not found"))
-      return
-    }
-
-    Task {
-      guard let updateResult = await self.embeddedInstance?.update(checkout: checkout) else {
-        resolve(Errors.createError(
-          ErrorType.Failed,
-          "No EmbeddedPaymentElement instance — did you call create first?"
-        ))
-        return
-      }
-
-      self.resolveEmbeddedUpdateResult(updateResult, resolve: resolve)
-    }
-  }
-
   @objc(clearEmbeddedPaymentOption)
   public func clearEmbeddedPaymentOption() {
     DispatchQueue.main.async {

--- a/src/specs/NativeEmbeddedPaymentElement.ts
+++ b/src/specs/NativeEmbeddedPaymentElement.ts
@@ -20,19 +20,10 @@ export interface NativeCommands {
     viewRef: React.ElementRef<HostComponent<NativeProps>>,
     intentConfigurationJson: string
   ) => void;
-  updateWithCheckout: (
-    viewRef: React.ElementRef<HostComponent<NativeProps>>,
-    sessionKey: string
-  ) => void;
 }
 
 export const Commands: NativeCommands = codegenNativeCommands<NativeCommands>({
-  supportedCommands: [
-    'confirm',
-    'clearPaymentOption',
-    'update',
-    'updateWithCheckout',
-  ],
+  supportedCommands: ['confirm', 'clearPaymentOption', 'update'],
 });
 
 type ComponentType = HostComponent<NativeProps>;

--- a/src/specs/NativeStripeSdkModule.ts
+++ b/src/specs/NativeStripeSdkModule.ts
@@ -209,9 +209,6 @@ export interface Spec extends TurboModule {
   updateEmbeddedPaymentElement(
     intentConfig: UnsafeObject<IntentConfiguration>
   ): Promise<UnsafeObject<any> | null>;
-  updateEmbeddedPaymentElementWithCheckout(
-    sessionKey: string
-  ): Promise<UnsafeObject<any> | null>;
   clearEmbeddedPaymentOption(viewTag: Int32): Promise<void>;
   createRadarSession(): Promise<CreateRadarSessionResult>;
 

--- a/src/types/EmbeddedPaymentElement.tsx
+++ b/src/types/EmbeddedPaymentElement.tsx
@@ -251,12 +251,6 @@ class EmbeddedPaymentElement {
     );
   }
 
-  async updateCheckout(checkout: Checkout): Promise<unknown> {
-    return await NativeStripeSdkModule.updateEmbeddedPaymentElementWithCheckout(
-      checkout.sessionKey
-    );
-  }
-
   /**
    * Confirm the payment or setup intent.
    * Waits for any in-progress `update()` call to finish before proceeding.
@@ -438,16 +432,7 @@ export interface UseEmbeddedPaymentElementResult {
    * @note Upon completion, `paymentOption` may become null if it's no longer available.
    * @note If you call `update` while a previous call to `update` is still in progress, the previous call is canceled.
    */
-  update: {
-    (intentConfig: PaymentSheetTypes.IntentConfiguration): void;
-    /**
-     * Call this method when the Checkout Session values you used to initialize
-     * `EmbeddedPaymentElement` change.
-     * @checkoutSessionsPreview
-     * @internal
-     */
-    (checkout: Checkout): void;
-  };
+  update: (intentConfig: PaymentSheetTypes.IntentConfiguration) => void;
   // Sets the currently selected payment option to null
   clearPaymentOption: () => void;
   // Any error encountered during creation/update, or null
@@ -642,9 +627,7 @@ export function useEmbeddedPaymentElement(
     return getElementOrThrow(elementRef).confirm();
   }, [isAndroid]);
   const update = useCallback(
-    (
-      updateSource: PaymentSheetTypes.IntentConfiguration | Checkout
-    ): Promise<unknown> => {
+    (updateSource: PaymentSheetTypes.IntentConfiguration): Promise<unknown> => {
       if (isAndroid) {
         const currentRef = viewRef.current;
         if (currentRef) {
@@ -656,11 +639,7 @@ export function useEmbeddedPaymentElement(
                 resolve(result);
               }
             );
-            if (isCheckoutSession(updateSource)) {
-              Commands.updateWithCheckout(currentRef, updateSource.sessionKey);
-            } else {
-              Commands.update(currentRef, JSON.stringify(updateSource));
-            }
+            Commands.update(currentRef, JSON.stringify(updateSource));
           });
         }
         return Promise.reject(
@@ -670,9 +649,7 @@ export function useEmbeddedPaymentElement(
 
       // iOS: use native module directly
       const embeddedElement = getElementOrThrow(elementRef);
-      return isCheckoutSession(updateSource)
-        ? embeddedElement.updateCheckout(updateSource)
-        : embeddedElement.updateIntent(updateSource);
+      return embeddedElement.updateIntent(updateSource);
     },
     [isAndroid]
   );


### PR DESCRIPTION
## Summary
- Remove the updateCheckout(checkout) method from the EmbeddedPaymentElement class and all associated native plumbing across iOS, Android, and JS/TS.

## Motivation
- https://docs.google.com/document/d/1CWglcOHR6I8cOWKjztPfnhnVG8axucpv-j5cWIoey7E/edit?tab=t.uzy1hgt1h5jt

## Testing
- CI

## Documentation
N/A
