### PR TITLE
Remove PaymentSheet.init(Checkout)

### DIFF
--- a/android/src/main/java/com/reactnativestripesdk/PaymentSheetManager.kt
+++ b/android/src/main/java/com/reactnativestripesdk/PaymentSheetManager.kt
@@ -243,7 +243,7 @@ class PaymentSheetManager(
       promise.resolve(
         createError(
           ErrorType.Failed.toString(),
-          "PaymentSheet with checkout is not supported. Use FlowController instead.",
+          "PaymentSheet with checkout is not supported. Use customFlow: true instead.",
         ),
       )
       return

--- a/android/src/main/java/com/reactnativestripesdk/PaymentSheetManager.kt
+++ b/android/src/main/java/com/reactnativestripesdk/PaymentSheetManager.kt
@@ -239,6 +239,16 @@ class PaymentSheetManager(
       return
     }
 
+    if (checkoutSessionKey != null) {
+      promise.resolve(
+        createError(
+          ErrorType.Failed.toString(),
+          "PaymentSheet with checkout is not supported. Use FlowController instead.",
+        ),
+      )
+      return
+    }
+
     lastConfigureWasCustomFlow = false
     if (paymentSheet == null) {
       initPaymentSheet(args, promise)

--- a/android/src/main/java/com/reactnativestripesdk/PaymentSheetManager.kt
+++ b/android/src/main/java/com/reactnativestripesdk/PaymentSheetManager.kt
@@ -437,10 +437,7 @@ class PaymentSheetManager(
   override fun onPresent() {
     keepJsAwake = KeepJsAwakeTask(context).apply { start() }
     if (lastConfigureWasCustomFlow == false) {
-      val checkout = getCheckoutInstanceOrResolveError(promise)
-      if (checkout != null) {
-        paymentSheet?.presentWithCheckout(checkout, paymentSheetConfiguration)
-      } else if (!paymentIntentClientSecret.isNullOrEmpty()) {
+      if (!paymentIntentClientSecret.isNullOrEmpty()) {
         paymentSheet?.presentWithPaymentIntent(
           paymentIntentClientSecret!!,
           paymentSheetConfiguration,

--- a/e2e-tests/ios-only/local-only/checkout-adaptive-pricing.yml
+++ b/e2e-tests/ios-only/local-only/checkout-adaptive-pricing.yml
@@ -66,15 +66,15 @@ appId: ${APP_ID}
 
 - extendedWaitUntil:
     visible:
-      text: "Pay \\$.*"
+      text: "Choose payment method"
     timeout: 60000
 - scrollUntilVisible:
     element:
-      text: "Pay \\$.*"
+      text: "Choose payment method"
     direction: DOWN
     timeout: 30000
 - tapOn:
-    text: "Pay \\$.*"
+    text: "Choose payment method"
 
 - extendedWaitUntil:
     visible: "TEST"
@@ -104,14 +104,26 @@ appId: ${APP_ID}
     optional: true
 - scrollUntilVisible:
     element:
-      text: "Pay \\$.*" # iOS
+      text: "Continue" # iOS
     optional: true
 - tapOn:
     id: primary_button # Android
     optional: true
 - tapOn:
-    text: "Pay \\$.*" # iOS
+    text: "Continue" # iOS
     optional: true
+
+- extendedWaitUntil:
+    visible:
+      text: "Pay \\$.*"
+    timeout: 60000
+- scrollUntilVisible:
+    element:
+      text: "Pay \\$.*"
+    direction: DOWN
+    timeout: 30000
+- tapOn:
+    text: "Pay \\$.*"
 
 - assertVisible:
     text: "Payment successful"

--- a/example/src/checkoutPlayground/CheckoutPlaygroundCartView.tsx
+++ b/example/src/checkoutPlayground/CheckoutPlaygroundCartView.tsx
@@ -363,8 +363,6 @@ export function CheckoutPlaygroundCartView({
     });
   }, [checkout, runCheckoutAction]);
 
-
-
   const handleChoosePaymentMethod = useCallback(async () => {
     if (state?.status !== 'loaded') {
       return;

--- a/example/src/checkoutPlayground/CheckoutPlaygroundCartView.tsx
+++ b/example/src/checkoutPlayground/CheckoutPlaygroundCartView.tsx
@@ -115,7 +115,7 @@ export function CheckoutPlaygroundCartView({
     useStripe();
   const [promotionCode, setPromotionCode] = useState('');
   const [feedback, setFeedback] = useState<FeedbackState | null>(null);
-  const [presentingPaymentSheet, setPresentingPaymentSheet] = useState(false);
+
   const [flowControllerStatus, setFlowControllerStatus] =
     useState<FlowControllerStatus>('idle');
   const [presentingFlowController, setPresentingFlowController] =
@@ -154,7 +154,6 @@ export function CheckoutPlaygroundCartView({
   const isFlowControllerInitializing = flowControllerStatus === 'initializing';
   const isFlowControllerReady = flowControllerStatus === 'ready';
   const isProcessingPaymentUi =
-    presentingPaymentSheet ||
     isFlowControllerInitializing ||
     presentingFlowController ||
     confirmingFlowController;
@@ -364,60 +363,7 @@ export function CheckoutPlaygroundCartView({
     });
   }, [checkout, runCheckoutAction]);
 
-  const handlePresentPaymentSheet = useCallback(async () => {
-    if (state?.status !== 'loaded') {
-      return;
-    }
 
-    setFeedback(null);
-    setPresentingPaymentSheet(true);
-    let shouldNavigateBack = false;
-
-    try {
-      const initResult = await initPaymentSheet(paymentSheetSetupParams);
-
-      if (initResult.error) {
-        throw initResult.error;
-      }
-
-      const presentResult = await presentPaymentSheet();
-      if (presentResult.error) {
-        throw presentResult.error;
-      }
-
-      if (presentResult.didCancel) {
-        setFeedback({
-          tone: 'info',
-          title: 'PaymentSheet canceled',
-          message: 'The customer dismissed the sheet before paying.',
-        });
-      } else {
-        shouldNavigateBack = true;
-      }
-    } catch (paymentSheetError: unknown) {
-      setFeedback(
-        getPaymentSheetFeedback({
-          error: paymentSheetError,
-          fallbackTitle: 'PaymentSheet failed',
-          fallbackMessage: 'PaymentSheet failed.',
-          canceledTitle: 'PaymentSheet canceled',
-          canceledMessage: 'The customer canceled PaymentSheet.',
-        })
-      );
-    } finally {
-      setPresentingPaymentSheet(false);
-    }
-
-    if (shouldNavigateBack) {
-      onSuccessfulPayment();
-    }
-  }, [
-    initPaymentSheet,
-    onSuccessfulPayment,
-    paymentSheetSetupParams,
-    presentPaymentSheet,
-    state?.status,
-  ]);
 
   const handleChoosePaymentMethod = useCallback(async () => {
     if (state?.status !== 'loaded') {
@@ -781,7 +727,7 @@ export function CheckoutPlaygroundCartView({
           disableActions ||
           (isFlowControllerIntegration && !selectedPaymentOption)
         }
-        primaryLoading={presentingPaymentSheet || confirmingFlowController}
+        primaryLoading={confirmingFlowController}
         secondaryLabel={
           isFlowControllerIntegration ? flowControllerActionLabel : undefined
         }
@@ -793,10 +739,8 @@ export function CheckoutPlaygroundCartView({
           if (isEmbeddedIntegration) {
             setFeedback(null);
             setEmbeddedModalVisible(true);
-          } else if (isFlowControllerIntegration) {
-            handleConfirmFlowControllerPayment();
           } else {
-            handlePresentPaymentSheet();
+            handleConfirmFlowControllerPayment();
           }
         }}
       />

--- a/example/src/checkoutPlayground/CheckoutPlaygroundConfigView.tsx
+++ b/example/src/checkoutPlayground/CheckoutPlaygroundConfigView.tsx
@@ -87,7 +87,7 @@ export function CheckoutPlaygroundConfigView({
         <GroupedCard>
           <PickerRow
             title="Integration"
-            description="PaymentSheet, PaymentSheet.FlowController, or Embedded."
+            description="PaymentSheet.FlowController or Embedded."
             selectedValue={config.integrationType}
             options={integrationTypeOptions}
             onValueChange={(integrationType) =>

--- a/example/src/checkoutPlayground/types.ts
+++ b/example/src/checkoutPlayground/types.ts
@@ -23,7 +23,6 @@ export type AdaptivePricingCountry =
   | 'br';
 
 export type CheckoutPlaygroundIntegrationType =
-  | 'paymentSheet'
   | 'paymentSheetFlowController'
   | 'embedded';
 
@@ -79,7 +78,6 @@ export const customerTypeOptions: SelectionOption<CheckoutPlaygroundCustomerType
 
 export const integrationTypeOptions: SelectionOption<CheckoutPlaygroundIntegrationType>[] =
   [
-    { label: 'PaymentSheet', value: 'paymentSheet' },
     {
       label: 'PaymentSheet.FlowController',
       value: 'paymentSheetFlowController',
@@ -110,7 +108,7 @@ export const defaultCheckoutPlaygroundConfig: CheckoutPlaygroundConfig = {
   mode: 'payment',
   currency: 'usd',
   customerType: 'guest',
-  integrationType: 'paymentSheet',
+  integrationType: 'paymentSheetFlowController',
   enableShipping: true,
   allowPromotionCodes: true,
   phoneNumberCollection: false,

--- a/ios/StripeSdkImpl+PaymentSheet.swift
+++ b/ios/StripeSdkImpl+PaymentSheet.swift
@@ -196,7 +196,7 @@ extension StripeSdkImpl {
                     handlePaymentSheetFlowControllerResult(result: result, stripeSdk: self)
                 }
             } else {
-                resolve(Errors.createError(ErrorType.Failed, "PaymentSheet with checkout is not supported. Use FlowController instead."))
+                resolve(Errors.createError(ErrorType.Failed, "PaymentSheet with checkout is not supported. Use customFlow: true instead."))
             }
         } else if let paymentIntentClientSecret = params["paymentIntentClientSecret"] as? String {
             if !Errors.isPIClientSecretValid(clientSecret: paymentIntentClientSecret) {

--- a/ios/StripeSdkImpl+PaymentSheet.swift
+++ b/ios/StripeSdkImpl+PaymentSheet.swift
@@ -196,8 +196,7 @@ extension StripeSdkImpl {
                     handlePaymentSheetFlowControllerResult(result: result, stripeSdk: self)
                 }
             } else {
-                self.paymentSheet = PaymentSheet(checkout: checkout, configuration: configuration)
-                resolve([])
+                resolve(Errors.createError(ErrorType.Failed, "PaymentSheet with checkout is not supported. Use FlowController instead."))
             }
         } else if let paymentIntentClientSecret = params["paymentIntentClientSecret"] as? String {
             if !Errors.isPIClientSecretValid(clientSecret: paymentIntentClientSecret) {


### PR DESCRIPTION
## Summary
- Restricts Checkout usage to EPE and PS.FC
- Updates example app

## Motivation
- https://docs.google.com/document/d/1CWglcOHR6I8cOWKjztPfnhnVG8axucpv-j5cWIoey7E/edit?tab=t.uzy1hgt1h5jt#heading=h.a2lhvmal87zq

## Testing
- Updated tests
- Manual/CI

## Documentation
N/A