### PR TITLE
Add update podfile.lock workflow

### DIFF
--- a/.github/workflows/update-podfile-lock.yml
+++ b/.github/workflows/update-podfile-lock.yml
@@ -1,0 +1,66 @@
+name: Update Podfile.lock
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'stripe-react-native.podspec'  # fired when bump-native-sdks merges an iOS bump
+  release:
+    types: [published]                 # fired when a new stripe-react-native version ships
+  workflow_dispatch:                   # allow manual runs from the Actions UI
+
+jobs:
+  update-podfile-lock:
+    runs-on: macos-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Always run against master. For release events the tag is already
+          # cut, so updating master keeps it current for the next release.
+          ref: master
+          token: ${{ secrets.NATIVE_SDK_BUMP_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.node-version'
+
+      - name: Run yarn bootstrap
+        run: yarn bootstrap
+
+      - name: Open PR with updated Podfile.lock
+        env:
+          GH_TOKEN: ${{ secrets.NATIVE_SDK_BUMP_TOKEN }}
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          if git diff --quiet example/ios/Podfile.lock; then
+            echo "Podfile.lock is already up to date — nothing to do."
+            exit 0
+          fi
+
+          BRANCH="chore/update-podfile-lock"
+
+          git checkout -b "$BRANCH"
+          git add example/ios/Podfile.lock
+          git commit -m "chore: update Podfile.lock"
+          git push --force origin "$BRANCH"
+
+          # If a PR is already open for this branch, the force-push above has
+          # updated it — no need to create another one.
+          if gh pr list --state open --head "$BRANCH" --json number --jq '.[0].number' \
+              2>/dev/null | grep -q '[0-9]'; then
+            echo "PR already open for $BRANCH — updated via force-push."
+            exit 0
+          fi
+
+          gh pr create \
+            --title "chore: update Podfile.lock" \
+            --body  "_Automated by [\`update-podfile-lock\`](.github/workflows/update-podfile-lock.yml)_" \
+            --base  master \
+            --head  "$BRANCH"


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
- Add `update-podfile-lock.yml` workflow that will run `yarn bootstrap` to update the `example/ios/podfile.lock` whenever a new `stripe-react-native` version is released or `stripe-react-native.podspec` is changed.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a link to the relevant issue, a code snippet, or an example project that demonstrates the bug. -->
- Automate update podfile after release/updating native SDKs

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [ ] I tested this manually
- [ ] I added automated tests
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
