### PR TITLE
Add kycRecipientAccountId internal prop to ConnectAccountOnboarding

### DIFF
--- a/etc/stripe-react-native.api.md
+++ b/etc/stripe-react-native.api.md
@@ -4229,9 +4229,9 @@ interface WeChatPayParams_2 {
 // Warnings were encountered during analysis:
 //
 // src/components/CustomerSheet.tsx:374:27 - (ae-forgotten-export) The symbol "Component" needs to be exported by the entry point index.d.ts
-// src/connect/Components.tsx:74:3 - (ae-forgotten-export) The symbol "StepChange" needs to be exported by the entry point index.d.ts
-// src/connect/Components.tsx:78:3 - (ae-forgotten-export) The symbol "CollectionOptions" needs to be exported by the entry point index.d.ts
-// src/connect/Components.tsx:243:3 - (ae-forgotten-export) The symbol "PaymentsListDefaultFilters" needs to be exported by the entry point index.d.ts
+// src/connect/Components.tsx:75:3 - (ae-forgotten-export) The symbol "StepChange" needs to be exported by the entry point index.d.ts
+// src/connect/Components.tsx:79:3 - (ae-forgotten-export) The symbol "CollectionOptions" needs to be exported by the entry point index.d.ts
+// src/connect/Components.tsx:253:3 - (ae-forgotten-export) The symbol "PaymentsListDefaultFilters" needs to be exported by the entry point index.d.ts
 // src/connect/connectTypes.ts:208:3 - (ae-forgotten-export) The symbol "AppearanceOptions" needs to be exported by the entry point index.d.ts
 // src/connect/connectTypes.ts:218:3 - (ae-forgotten-export) The symbol "CssFontSource" needs to be exported by the entry point index.d.ts
 // src/connect/connectTypes.ts:218:3 - (ae-forgotten-export) The symbol "CustomFontSource" needs to be exported by the entry point index.d.ts

--- a/src/connect/Components.tsx
+++ b/src/connect/Components.tsx
@@ -68,6 +68,7 @@ export function ConnectAccountOnboarding({
   onLoaderStart,
   onLoadError,
   onPageDidLoad,
+  ...rest
 }: {
   title?: string;
   onExit: () => void;
@@ -77,6 +78,13 @@ export function ConnectAccountOnboarding({
   privacyPolicyUrl?: string;
   collectionOptions?: CollectionOptions;
 } & Omit<CommonComponentProps, 'style'>) {
+  // kycRecipientAccountId is intentionally omitted from the public prop types to
+  // discourage use by external integrators. This is API hygiene only — it is not
+  // a security boundary. Real authorization is enforced server-side.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const kycRecipientAccountId = (rest as any).kycRecipientAccountId as
+    | string
+    | undefined;
   const [visible, setVisible] = useState(true);
   const [loading, setLoading] = useState(true);
   const { appearance } = useConnectComponents();
@@ -96,12 +104,14 @@ export function ConnectAccountOnboarding({
       setRecipientTermsOfServiceUrl: recipientTermsOfServiceUrl,
       setPrivacyPolicyUrl: privacyPolicyUrl,
       setCollectionOptions: collectionOptions,
+      setKycRecipientAccountId: kycRecipientAccountId,
     };
   }, [
     fullTermsOfServiceUrl,
     recipientTermsOfServiceUrl,
     privacyPolicyUrl,
     collectionOptions,
+    kycRecipientAccountId,
   ]);
 
   const onExitCallback = useCallback(() => {


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

Expose an internal-only prop `kycRecipientAccountId` on the [AccountOnboarding](https://docs.stripe.com/connect/supported-embedded-components/account-onboarding?platform=react-native) component that allows us to onboard recipients for money-movement actions initiated between accounts.

This property shouldn't be available for external customers, so I've marked it with `@internal` as I've observed it being used to annotate other properties in the codebase.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a link to the relevant issue, a code snippet, or an example project that demonstrates the bug. -->

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [ ] I tested this manually
- [ ] I added automated tests
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
