### PR TITLE
GA: Connect embedded components (Payments, Payouts)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * [Breaking] Updated Google Wallet Android Push Provisioning to the Unified Push Provisioning flow. This enables issued cards to be provisioned onto wearable devices via a mobile phone. `canAddCardToWallet` now requires `cardBrand`, and now checks if the card can be provisioned onto the mobile device or any connected wearable devices. See [documentation](https://docs.stripe.com/issuing/cards/digital-wallets?platform=react-native#push-provisioning) for integration guide.
 
 **Features**
+* [GA] Connect embedded components — `ConnectAccountOnboarding`, `ConnectPayments`, and `ConnectPayouts` — are now generally available. No API changes; existing integrations continue to work without modification.
 * [Added] Added Issuing support for Google Wallet Bounce Provisioning via the `isBounceProvisioned` parameter on `AddToWalletButton`. See [documentation](https://docs.stripe.com/issuing/cards/digital-wallets?platform=react-native#push-provisioning) for integration guide.
 
 **Fixes**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 * [Breaking] Updated Google Wallet Android Push Provisioning to the Unified Push Provisioning flow. This enables issued cards to be provisioned onto wearable devices via a mobile phone. `canAddCardToWallet` now requires `cardBrand`, and now checks if the card can be provisioned onto the mobile device or any connected wearable devices. See [documentation](https://docs.stripe.com/issuing/cards/digital-wallets?platform=react-native#push-provisioning) for integration guide.
 
 **Features**
-* [GA] Connect embedded components — `ConnectAccountOnboarding`, `ConnectPayments`, and `ConnectPayouts` — are now generally available. No API changes; existing integrations continue to work without modification.
+* [Added] Connect embedded components — `ConnectAccountOnboarding`, `ConnectPayments`, and `ConnectPayouts` — are now generally available. No API changes; existing integrations continue to work without modification.
 * [Added] Added Issuing support for Google Wallet Bounce Provisioning via the `isBounceProvisioned` parameter on `AddToWalletButton`. See [documentation](https://docs.stripe.com/issuing/cards/digital-wallets?platform=react-native#push-provisioning) for integration guide.
 
 **Fixes**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 **Changes**
 * Updated Stripe iOS SDK from 26.0.0 to 26.1.0.
+* [Changed] Connect embedded components — `ConnectAccountOnboarding`, `ConnectPayments`, and `ConnectPayouts` — are now generally available. No API changes; existing integrations continue to work without modification.
 
 ## 0.68.0 - 2026-06-29
 **Changes**
@@ -12,7 +13,6 @@
 * [Breaking] Updated Google Wallet Android Push Provisioning to the Unified Push Provisioning flow. This enables issued cards to be provisioned onto wearable devices via a mobile phone. `canAddCardToWallet` now requires `cardBrand`, and now checks if the card can be provisioned onto the mobile device or any connected wearable devices. See [documentation](https://docs.stripe.com/issuing/cards/digital-wallets?platform=react-native#push-provisioning) for integration guide.
 
 **Features**
-* [Added] Connect embedded components — `ConnectAccountOnboarding`, `ConnectPayments`, and `ConnectPayouts` — are now generally available. No API changes; existing integrations continue to work without modification.
 * [Added] Added Issuing support for Google Wallet Bounce Provisioning via the `isBounceProvisioned` parameter on `AddToWalletButton`. See [documentation](https://docs.stripe.com/issuing/cards/digital-wallets?platform=react-native#push-provisioning) for integration guide.
 
 **Fixes**

--- a/example-stripe-connect/README.md
+++ b/example-stripe-connect/README.md
@@ -6,8 +6,8 @@ This is an Expo application demonstrating Stripe Connect embedded components usi
 
 ### Stripe Connect Embedded Components
 - **Account Onboarding** - Localized onboarding form with data validation and configurable collection options
-- **Payouts (Beta)** - View and perform payouts with embedded component
-- **Payments (Beta)** - View payment details, manage disputes, and filter payments by amount, date, status, and payment method
+- **Payouts** - View and perform payouts with embedded component
+- **Payments** - View payment details, manage disputes, and filter payments by amount, date, status, and payment method
 
 ### Configuration & Customization
 - **Demo Account Management** - Switch between multiple pre-configured accounts or use custom account IDs
@@ -52,7 +52,7 @@ example-stripe-connect/
 │   ├── index.tsx                  # Home screen
 │   ├── account-onboarding.tsx     # Account onboarding component
 │   ├── payments.tsx               # Payments component
-│   ├── payouts.tsx                # Payouts component (Beta)
+│   ├── payouts.tsx                # Payouts component
 │   ├── configure-appearance.tsx   # Appearance selector
 │   ├── (tabs)/                    # Tab-based layout group
 │   │   ├── _layout.tsx            # Native tabs configuration
@@ -110,8 +110,8 @@ example-stripe-connect/
 
 The home screen displays three main Connect components:
 - **Account onboarding** - "Show a localized onboarding form that validates data."
-- **Payouts Beta** - "Show payouts and allow your users to perform payouts."
-- **Payments Beta** - "Show payments and allow your users to view payment details and manage disputes."
+- **Payouts** - "Show payouts and allow your users to perform payouts."
+- **Payments** - "Show payments and allow your users to view payment details and manage disputes."
 
 Tap any item to view the embedded component. The navigation bar includes:
 - **Settings icon (⚙️)** - Opens settings modal (left)
@@ -249,7 +249,7 @@ Wrapper around each Connect component that:
 #### Connect Components
 - **ConnectAccountOnboarding** - Full onboarding flow with configurable collection options
 - **ConnectPayments** - Payment management with advanced filtering
-- **ConnectPayouts** - Payout management (Beta)
+- **ConnectPayouts** - Payout management
 
 ## Development
 

--- a/example-stripe-connect/app/index.tsx
+++ b/example-stripe-connect/app/index.tsx
@@ -33,7 +33,6 @@ export default function HomeScreen() {
       },
       {
         title: 'Payouts',
-        badge: 'Beta',
         description: 'Show payouts and allow your users to perform payouts.',
         onPress: () => {
           if (viewControllerSettings.embedInTabBar) {
@@ -45,7 +44,6 @@ export default function HomeScreen() {
       },
       {
         title: 'Payments',
-        badge: 'Beta',
         description:
           'Show payments and allow your users to view payment details and manage disputes.',
         onPress: () => {


### PR DESCRIPTION
## Summary

Mark `ConnectPayments` and `ConnectPayouts` as generally available by removing "Beta" labels from the example app and changelog. `ConnectAccountOnboarding` was already GA. [API Review](https://docs.google.com/document/d/1DLyInRUCd1kPNf42z2N5edLqGSrm2aMjgR69K2S2U-g/edit?tab=t.0#heading=h.wy37pln22zhb)

## Motivation

The Connect embedded components (Account Onboarding, Payments, Payouts) are production-ready and no longer in beta. This change reflects that status publicly — removing `badge: 'Beta'` from the example app's navigation items, updating the example app README, and adding a changelog entry announcing GA. There are no API or code changes; existing integrations continue to work without modification.

## Testing

- [x] I tested this manually
- [ ] I added automated tests

<!-- No functional code changes were made — this is a labeling/release change only. Manual verification: confirm the example app builds and runs with no "Beta" labels displayed on the Payments and Payouts navigation items. -->

## Documentation

Select one:
- [x] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.

<!-- Updated `example-stripe-connect/README.md` to remove "(Beta)" from Payments and Payouts references, and added a `[Changed]` entry to `CHANGELOG.md`. -->
