### PR TITLE
Update to use actions@v7

### DIFF
--- a/.github/workflows/bump-native-sdks.yml
+++ b/.github/workflows/bump-native-sdks.yml
@@ -13,7 +13,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           # Use a PAT so the resulting PR triggers pull_request CI workflows.
           # GITHUB_TOKEN-created PRs intentionally don't trigger other workflows.

--- a/.github/workflows/update-podfile-lock.yml
+++ b/.github/workflows/update-podfile-lock.yml
@@ -17,7 +17,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           # Always run against master. For release events the tag is already
           # cut, so updating master keeps it current for the next release.
@@ -25,7 +25,7 @@ jobs:
           token: ${{ secrets.NATIVE_SDK_BUMP_TOKEN }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: '.node-version'
 


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
Update to `actions/checkout@v7` and `actions/setup-node@v6`

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a link to the relevant issue, a code snippet, or an example project that demonstrates the bug. -->
Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@v4

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [ ] I tested this manually
- [ ] I added automated tests
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
