### PR TITLE
chore: bump stripe-ios 26.1.0

### DIFF
--- a/stripe-react-native.podspec
+++ b/stripe-react-native.podspec
@@ -2,7 +2,7 @@ require 'json'
 
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 # Keep stripe_version in sync with https://github.com/stripe/stripe-identity-react-native/blob/main/stripe-identity-react-native.podspec
-stripe_version = '26.0.0'
+stripe_version = '26.1.0'
 
 fabric_enabled = ENV['RCT_NEW_ARCH_ENABLED'] == '1'
 


### PR DESCRIPTION
- `stripe-react-native.podspec`: `stripe_version` → `26.1.0` ([release notes](https://github.com/stripe/stripe-ios/releases/tag/26.1.0))

_Automated by [`bump-native-sdks`](.github/workflows/bump-native-sdks.yml)_