### PR TITLE
chore: bump stripe-ios 26.1.0,stripe-android 23.11.1

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -3,4 +3,4 @@ StripeSdk_compileSdkVersion=36
 StripeSdk_targetSdkVersion=36
 StripeSdk_minSdkVersion=23
 # Keep StripeSdk_stripeVersion in sync with https://github.com/stripe/stripe-identity-react-native/blob/main/android/gradle.properties
-StripeSdk_stripeVersion=23.11.0
+StripeSdk_stripeVersion=23.11.1

--- a/ios/StripeSdkImpl.swift
+++ b/ios/StripeSdkImpl.swift
@@ -1518,7 +1518,7 @@ public class StripeSdkImpl: NSObject, UIAdaptivePresentationControllerDelegate {
                 let presentingViewController = await MainActor.run {
                     findViewControllerPresenter(from: RCTKeyWindow()?.rootViewController ?? UIViewController())
                 }
-                let result = try await coordinator.presentCRSCARFDeclaration(from: presentingViewController)
+                let result = try await coordinator.presentUserAttestation(from: presentingViewController)
                 switch result {
                 case .confirmed:
                     resolve(["status": "Confirmed"])

--- a/stripe-react-native.podspec
+++ b/stripe-react-native.podspec
@@ -2,7 +2,7 @@ require 'json'
 
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 # Keep stripe_version in sync with https://github.com/stripe/stripe-identity-react-native/blob/main/stripe-identity-react-native.podspec
-stripe_version = '26.0.0'
+stripe_version = '26.1.0'
 
 fabric_enabled = ENV['RCT_NEW_ARCH_ENABLED'] == '1'
 


### PR DESCRIPTION
- `stripe-react-native.podspec`: `stripe_version` → `26.1.0` ([release notes](https://github.com/stripe/stripe-ios/releases/tag/26.1.0))
- `android/gradle.properties`: `StripeSdk_stripeVersion` → `23.11.1` ([release notes](https://github.com/stripe/stripe-android/releases/tag/v23.11.1))

_Automated by [`bump-native-sdks`](.github/workflows/bump-native-sdks.yml)_