### PR TITLE
fix(ios): read captureMethod from nested mode params in deferred flows 🪿✨

### DIFF
--- a/ios/StripeSdkImpl+Embedded.swift
+++ b/ios/StripeSdkImpl+Embedded.swift
@@ -37,7 +37,7 @@ extension StripeSdkImpl {
       resolve(nil)
       return
     }
-    let captureMethodString = intentConfig["captureMethod"] as? String
+    let captureMethodString = modeParams["captureMethod"] as? String
     let intentConfig = buildIntentConfiguration(
       modeParams: modeParams,
       paymentMethodTypes: intentConfig["paymentMethodTypes"] as? [String],
@@ -191,7 +191,7 @@ extension StripeSdkImpl {
       resolve(Errors.createError(ErrorType.Failed, "You must provide either `confirmHandler` or `confirmationTokenConfirmHandler`, but not both"))
       return
     }
-    let captureMethodString = intentConfig["captureMethod"] as? String
+    let captureMethodString = modeParams["captureMethod"] as? String
     let intentConfiguration = buildIntentConfiguration(
       modeParams: modeParams,
       paymentMethodTypes: intentConfig["paymentMethodTypes"] as? [String],

--- a/ios/StripeSdkImpl+PaymentSheet.swift
+++ b/ios/StripeSdkImpl+PaymentSheet.swift
@@ -249,7 +249,7 @@ extension StripeSdkImpl {
                 resolve(Errors.createError(ErrorType.Failed, "You must provide either `confirmHandler` or `confirmationTokenConfirmHandler`, but not both"))
                 return
             }
-            let captureMethodString = intentConfiguration["captureMethod"] as? String
+            let captureMethodString = modeParams["captureMethod"] as? String
             let intentConfig = buildIntentConfiguration(
                 modeParams: modeParams,
                 paymentMethodTypes: intentConfiguration["paymentMethodTypes"] as? [String],

--- a/ios/Tests/PaymentSheetUtilsTests.swift
+++ b/ios/Tests/PaymentSheetUtilsTests.swift
@@ -523,6 +523,98 @@ class PaymentSheetUtilsTests: XCTestCase {
         XCTAssertEqual(result[1].id, "cpmt_valid2")
     }
 
+    // MARK: - buildIntentConfiguration captureMethod Tests
+
+    func test_buildIntentConfiguration_manualCaptureMethod() {
+        let modeParams: NSDictionary = [
+            "amount": 1099,
+            "currencyCode": "usd",
+            "captureMethod": "Manual",
+        ]
+
+        let config = StripeSdkImpl.shared.buildIntentConfiguration(
+            modeParams: modeParams,
+            paymentMethodTypes: nil,
+            onBehalfOf: nil,
+            captureMethod: StripeSdkImpl.mapCaptureMethod(modeParams["captureMethod"] as? String),
+            useConfirmationTokenCallback: false
+        )
+
+        if case .payment(let amount, let currency, _, let captureMethod, _) = config.mode {
+            XCTAssertEqual(amount, 1099)
+            XCTAssertEqual(currency, "usd")
+            XCTAssertEqual(captureMethod, .manual)
+        } else {
+            XCTFail("Expected payment mode")
+        }
+    }
+
+    func test_buildIntentConfiguration_automaticAsyncCaptureMethod() {
+        let modeParams: NSDictionary = [
+            "amount": 2000,
+            "currencyCode": "eur",
+            "captureMethod": "AutomaticAsync",
+        ]
+
+        let config = StripeSdkImpl.shared.buildIntentConfiguration(
+            modeParams: modeParams,
+            paymentMethodTypes: nil,
+            onBehalfOf: nil,
+            captureMethod: StripeSdkImpl.mapCaptureMethod(modeParams["captureMethod"] as? String),
+            useConfirmationTokenCallback: false
+        )
+
+        if case .payment(_, _, _, let captureMethod, _) = config.mode {
+            XCTAssertEqual(captureMethod, .automaticAsync)
+        } else {
+            XCTFail("Expected payment mode")
+        }
+    }
+
+    func test_buildIntentConfiguration_missingCaptureMethod_defaultsToAutomatic() {
+        let modeParams: NSDictionary = [
+            "amount": 500,
+            "currencyCode": "usd",
+        ]
+
+        let config = StripeSdkImpl.shared.buildIntentConfiguration(
+            modeParams: modeParams,
+            paymentMethodTypes: nil,
+            onBehalfOf: nil,
+            captureMethod: StripeSdkImpl.mapCaptureMethod(modeParams["captureMethod"] as? String),
+            useConfirmationTokenCallback: false
+        )
+
+        if case .payment(_, _, _, let captureMethod, _) = config.mode {
+            XCTAssertEqual(captureMethod, .automatic)
+        } else {
+            XCTFail("Expected payment mode")
+        }
+    }
+
+    func test_buildIntentConfiguration_captureMethodFromNestedMode_notTopLevel() {
+        // Regression test: captureMethod must be read from mode params,
+        // not from the top-level intentConfiguration dictionary.
+        let topLevelIntentConfig: NSDictionary = [
+            "captureMethod": "Manual",
+            "mode": [
+                "amount": 1099,
+                "currencyCode": "usd",
+                // captureMethod intentionally absent from mode
+            ],
+        ]
+
+        let modeParams = topLevelIntentConfig["mode"] as! NSDictionary
+        // Reading from modeParams (correct behavior) should yield nil/automatic
+        let captureMethodString = modeParams["captureMethod"] as? String
+        XCTAssertNil(captureMethodString)
+        XCTAssertEqual(StripeSdkImpl.mapCaptureMethod(captureMethodString), .automatic)
+
+        // Reading from top-level (old incorrect behavior) would have yielded "Manual"
+        let topLevelCaptureMethod = topLevelIntentConfig["captureMethod"] as? String
+        XCTAssertEqual(topLevelCaptureMethod, "Manual")
+    }
+
     // MARK: - computeAllowedCardFundingTypes Tests
 
     func test_computeAllowedCardFundingTypes_nilParams_returnsNil() {


### PR DESCRIPTION
[Minion run](https://agents.corp.stripe.com/sessions/f06e8cd2-adc5-4566-bde9-ecce711877f6)

## Summary

The iOS bridge read `captureMethod` from the top-level `intentConfiguration` dictionary instead of from the nested `mode` params where the TypeScript API defines it. This caused `mapCaptureMethod(nil)` to always fall back to `.automatic`, ignoring any configured value. Fixed in all three affected call sites: PaymentSheet/FlowController init, EmbeddedPaymentElement create, and EmbeddedPaymentElement update.

## Motivation

In deferred PaymentIntent flows on iOS, setting `intentConfiguration.mode.captureMethod` to `Manual` or `AutomaticAsync` had no effect — the value was silently dropped. This caused incorrect payment method filtering in Elements Sessions (e.g. showing BNPL methods incompatible with manual capture) and `capture_method` mismatches when confirming PaymentIntents, particularly on accounts where `automatic_async` is the default.

Android already reads from the nested mode dictionary and is unaffected.

## Testing

- [ ] I tested this manually
- [x] I added automated tests
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.