### PR TITLE
Remove updateBillingAddress from Checkout SDK

### DIFF
--- a/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
+++ b/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
@@ -1798,30 +1798,6 @@ class StripeSdkModule(
     }
   }
 
-  override fun checkoutUpdateBillingAddress(
-    sessionKey: String,
-    address: ReadableMap,
-    name: String?,
-    phone: String?,
-    promise: Promise,
-  ) {
-    val addressUpdate = buildCheckoutAddressUpdate(name, phone, address) ?: run {
-      promise.reject(ErrorType.Failed.toString(), "A billing address country is required.")
-      return
-    }
-
-    performCheckoutMutation(
-      sessionKey = sessionKey,
-      promise = promise,
-    ) { checkout ->
-      checkout.updateBillingAddress(
-        name = addressUpdate.name,
-        phoneNumber = addressUpdate.phone,
-        address = addressUpdate.toCheckoutAddress(),
-      )
-    }
-  }
-
   override fun checkoutApplyPromotionCode(
     sessionKey: String,
     code: String,

--- a/android/src/oldarch/java/com/reactnativestripesdk/NativeStripeSdkModuleSpec.java
+++ b/android/src/oldarch/java/com/reactnativestripesdk/NativeStripeSdkModuleSpec.java
@@ -307,10 +307,6 @@ public abstract class NativeStripeSdkModuleSpec extends ReactContextBaseJavaModu
 
   @ReactMethod
   @DoNotStrip
-  public abstract void checkoutUpdateBillingAddress(String sessionKey, ReadableMap address, @Nullable String name, @Nullable String phone, Promise promise);
-
-  @ReactMethod
-  @DoNotStrip
   public abstract void checkoutApplyPromotionCode(String sessionKey, String code, Promise promise);
 
   @ReactMethod

--- a/example/src/checkoutPlayground/CheckoutPlaygroundCartView.tsx
+++ b/example/src/checkoutPlayground/CheckoutPlaygroundCartView.tsx
@@ -128,7 +128,6 @@ export function CheckoutPlaygroundCartView({
   const [embeddedModalVisible, setEmbeddedModalVisible] = useState(false);
   const [showShippingAddressSheet, setShowShippingAddressSheet] =
     useState(false);
-  const [showBillingAddressSheet, setShowBillingAddressSheet] = useState(false);
   const [selectedShippingOptionId, setSelectedShippingOptionId] = useState<
     string | null
   >(null);
@@ -165,9 +164,6 @@ export function CheckoutPlaygroundCartView({
   const shouldShowShippingAddressSection = Boolean(
     session && (config.shippingAddressCollection || session.shippingAddress)
   );
-  const shouldShowBillingAddressSection = Boolean(
-    session && (config.billingAddressCollection || session.billingAddress)
-  );
 
   const displayedSelectedShippingOptionId = useMemo(() => {
     if (
@@ -184,10 +180,6 @@ export function CheckoutPlaygroundCartView({
   const shippingAddressLines = useMemo(
     () => getAddressLines(session?.shippingAddress),
     [session?.shippingAddress]
-  );
-  const billingAddressLines = useMemo(
-    () => getAddressLines(session?.billingAddress),
-    [session?.billingAddress]
   );
   const orderSummaryRows = useMemo(
     () => buildOrderSummaryRows(session?.total),
@@ -618,22 +610,6 @@ export function CheckoutPlaygroundCartView({
           />
         ) : null}
 
-        {shouldShowBillingAddressSection ? (
-          <AddressSection
-            actionLabel={
-              session.billingAddress
-                ? 'Edit billing address'
-                : 'Add billing address'
-            }
-            badge="B"
-            disabled={disableActions}
-            emptyMessage="No billing address has been collected yet."
-            lines={billingAddressLines}
-            onPress={() => setShowBillingAddressSheet(true)}
-            title="Billing address"
-          />
-        ) : null}
-
         {shouldShowPromotionSection ? (
           <PromotionSection
             disableActions={disableActions}
@@ -694,36 +670,6 @@ export function CheckoutPlaygroundCartView({
               message:
                 addressError.localizedMessage ||
                 'Unable to collect the shipping address.',
-            });
-          }
-        }}
-      />
-
-      <AddressSheet
-        visible={showBillingAddressSheet}
-        sheetTitle="Billing address"
-        primaryButtonTitle="Use billing address"
-        additionalFields={{ phoneNumber: 'optional' }}
-        defaultValues={toAddressSheetDefaultValues(session.billingAddress)}
-        onSubmit={async (result) => {
-          setShowBillingAddressSheet(false);
-          await runCheckoutAction('Billing address', async () => {
-            await checkout.updateBillingAddress(
-              toCheckoutAddress(result.address),
-              result.name,
-              result.phone
-            );
-          });
-        }}
-        onError={(addressError) => {
-          setShowBillingAddressSheet(false);
-          if (addressError.code === AddressSheetError.Failed) {
-            setFeedback({
-              tone: 'error',
-              title: 'Address collection failed',
-              message:
-                addressError.localizedMessage ||
-                'Unable to collect the billing address.',
             });
           }
         }}

--- a/ios/StripeSdk.mm
+++ b/ios/StripeSdk.mm
@@ -289,21 +289,6 @@ RCT_EXPORT_METHOD(checkoutUpdateShippingAddress:(nonnull NSString *)sessionKey
                                              rejecter:reject];
 }
 
-RCT_EXPORT_METHOD(checkoutUpdateBillingAddress:(nonnull NSString *)sessionKey
-                                       address:(nonnull NSDictionary *)address
-                                          name:(NSString *_Nullable)name
-                                         phone:(NSString *_Nullable)phone
-                                       resolve:(nonnull RCTPromiseResolveBlock)resolve
-                                        reject:(nonnull RCTPromiseRejectBlock)reject)
-{
-  [StripeSdkImpl.shared checkoutUpdateBillingAddress:sessionKey
-                                             address:address
-                                                name:name
-                                               phone:phone
-                                            resolver:resolve
-                                            rejecter:reject];
-}
-
 RCT_EXPORT_METHOD(checkoutApplyPromotionCode:(nonnull NSString *)sessionKey
                                         code:(nonnull NSString *)code
                                      resolve:(nonnull RCTPromiseResolveBlock)resolve

--- a/ios/StripeSdkImpl+Checkout.swift
+++ b/ios/StripeSdkImpl+Checkout.swift
@@ -85,32 +85,6 @@ extension StripeSdkImpl {
         }
     }
 
-    @objc(checkoutUpdateBillingAddress:address:name:phone:resolver:rejecter:)
-    public func checkoutUpdateBillingAddress(
-        sessionKey: String,
-        address: NSDictionary,
-        name: String?,
-        phone: String?,
-        resolver resolve: @escaping RCTPromiseResolveBlock,
-        rejecter reject: @escaping RCTPromiseRejectBlock
-    ) {
-        performCheckoutAddressMutation(
-            sessionKey: sessionKey,
-            address: address,
-            name: name,
-            phone: phone,
-            missingCountryMessage: "A billing address country is required.",
-            resolver: resolve,
-            rejecter: reject
-        ) { checkout, addressUpdate in
-            try await checkout.updateBillingAddress(
-                name: addressUpdate.name,
-                phone: addressUpdate.phone,
-                address: addressUpdate.address
-            )
-        }
-    }
-
     @objc(checkoutApplyPromotionCode:code:resolver:rejecter:)
     public func checkoutApplyPromotionCode(
         sessionKey: String,

--- a/src/hooks/useCheckout.tsx
+++ b/src/hooks/useCheckout.tsx
@@ -114,18 +114,6 @@ export function useCheckout(
       ),
     [withLoading]
   );
-  const updateBillingAddress = useCallback<Checkout['updateBillingAddress']>(
-    (address, name, phone) =>
-      withLoading((key) =>
-        NativeStripeSdk.checkoutUpdateBillingAddress(
-          key,
-          address,
-          name ?? null,
-          phone ?? null
-        )
-      ),
-    [withLoading]
-  );
   const applyPromotionCode = useCallback<Checkout['applyPromotionCode']>(
     (code) =>
       withLoading((key) =>
@@ -192,7 +180,6 @@ export function useCheckout(
         return sessionKeyRef.current;
       },
       updateShippingAddress,
-      updateBillingAddress,
       applyPromotionCode,
       removePromotionCode,
       updateLineItemQuantity,
@@ -201,7 +188,6 @@ export function useCheckout(
     }),
     [
       updateShippingAddress,
-      updateBillingAddress,
       applyPromotionCode,
       removePromotionCode,
       updateLineItemQuantity,

--- a/src/specs/NativeStripeSdkModule.ts
+++ b/src/specs/NativeStripeSdkModule.ts
@@ -226,13 +226,6 @@ export interface Spec extends TurboModule {
     phone: string | null
   ): Promise<UnsafeObject<Checkout.State>>;
 
-  checkoutUpdateBillingAddress(
-    sessionKey: string,
-    address: UnsafeObject<Checkout.Address>,
-    name: string | null,
-    phone: string | null
-  ): Promise<UnsafeObject<Checkout.State>>;
-
   checkoutApplyPromotionCode(
     sessionKey: string,
     code: string

--- a/src/types/Checkout.ts
+++ b/src/types/Checkout.ts
@@ -103,7 +103,7 @@ export namespace Checkout {
     tax: Tax;
     /** Tax and discount details for the computed total amount. */
     total?: Total;
-    /** The billing address set via `updateBillingAddress`, if any. */
+    /** The billing address for this session, if any. */
     billingAddress?: ContactAddress;
   }
 
@@ -502,24 +502,6 @@ export interface Checkout {
    * @param phone - The recipient's phone number.
    */
   updateShippingAddress(
-    address: Checkout.Address,
-    name?: string,
-    phone?: string
-  ): Promise<void>;
-
-  /**
-   * Sets the billing address for this checkout.
-   *
-   * The address is stored locally and merged into PaymentSheet configuration
-   * when presenting payment UI. If automatic tax is enabled and the tax
-   * address source is "billing", the address is also sent to the server to
-   * compute updated tax amounts.
-   *
-   * @param address - The billing address to set.
-   * @param name - The customer's name.
-   * @param phone - The customer's phone number.
-   */
-  updateBillingAddress(
     address: Checkout.Address,
     name?: string,
     phone?: string


### PR DESCRIPTION
Removes the updateBillingAddress mutation from the Checkout SDK public API, the iOS and Android native bridge layers, and the example app's billing address collection flow.

