### PR TITLE
Fix Minion workflow PR commenting

### DIFF
--- a/.github/workflows/minion-on-native-sdk-bump-ci-failure.yml
+++ b/.github/workflows/minion-on-native-sdk-bump-ci-failure.yml
@@ -185,8 +185,14 @@ jobs:
               printf '%s\n' "$failed_check_summary"
             } > "$comment_file"
 
-            gh pr comment "$pr_number" --repo "$REPO" --body-file "$comment_file"
-            rm -f "$comment_file"
+            comment_payload="$(mktemp)"
+            jq -Rs '{body: .}' < "$comment_file" > "$comment_payload"
+            gh api \
+              --method POST \
+              "repos/${REPO}/issues/${pr_number}/comments" \
+              --input "$comment_payload" \
+              >/dev/null
+            rm -f "$comment_file" "$comment_payload"
 
             echo "Posted Minion task link on PR #$pr_number for $head_sha."
           done < <(printf '%s' "$prs_json" | jq -c '.[]')


### PR DESCRIPTION
## Summary
- Fix the merged Minion-on-native-SDK-bump workflow so it can actually post PR comments.
- Use the existing `NATIVE_SDK_BUMP_TOKEN` PAT for GitHub API calls instead of `GITHUB_TOKEN`.
- Keep the direct REST issue-comments API call instead of `gh pr comment`.

## Issue
The workflow added in #2524 successfully detected failing native SDK bump PRs, but failed when it tried to post the Minion task comment.

First failure, from `gh pr comment`:

```text
GraphQL: Resource not accessible by integration (addComment)
```

Failed run: https://github.com/stripe/stripe-react-native/actions/runs/29066446673/job/86278886052

`gh pr comment` uses GitHub GraphQL `addComment` against the PR subject. The workflow token only had `pull-requests: read` and `issues: write`, so that GraphQL mutation was rejected.

After switching to the REST issue-comments endpoint, the workflow still failed with `GITHUB_TOKEN`:

```text
gh: Resource not accessible by integration (HTTP 403)
```

Failed run: https://github.com/stripe/stripe-react-native/actions/runs/29103904602/job/86399462854

That run was on `master`, targeting a same-repo bump PR, and Actions printed `Issues: write` for `GITHUB_TOKEN`, so this appears to be a repo/org integration-token restriction rather than a fork or event-context issue.

## Fix
This PR now uses the same `NATIVE_SDK_BUMP_TOKEN` PAT already used by the native SDK bump workflow. That token is the existing repo pattern for automation that needs to interact with PRs on public GitHub.

The comment creation path remains the REST issue-comments endpoint:

```text
POST /repos/stripe/stripe-react-native/issues/<pr-number>/comments
```

## Verification
- Parsed the workflow YAML locally.
- Extracted the workflow shell script and ran `bash -n`.
- Ran `shellcheck -s bash` on the extracted script.
