### PR TITLE
Use bump PAT for Minion workflow comments

### DIFF
--- a/.github/workflows/minion-on-native-sdk-bump-ci-failure.yml
+++ b/.github/workflows/minion-on-native-sdk-bump-ci-failure.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GH_HOST: github.com
-      GH_TOKEN: ${{ github.token }}
+      GH_TOKEN: ${{ secrets.NATIVE_SDK_BUMP_TOKEN }}
       REPO: stripe/stripe-react-native
       TARGET_PR_NUMBER: ${{ inputs.pr_number || '' }}
       BUMP_BRANCH_PREFIX: chore/bump-native-sdks


### PR DESCRIPTION
## Summary
- Use the existing `NATIVE_SDK_BUMP_TOKEN` PAT for the Minion-on-native-SDK-bump workflow.
- This keeps the REST issue-comments fix from #2527, but avoids the repo/org restriction that prevents `GITHUB_TOKEN` from posting comments.

## Issue
The workflow now detects failing bump PRs correctly and uses the REST issue-comments endpoint, but the default Actions token still cannot create the PR comment:

```text
gh: Resource not accessible by integration (HTTP 403)
```

Failed run: https://github.com/stripe/stripe-react-native/actions/runs/29103904602/job/86399462854

The run was on `master`, targeting a same-repo bump PR, and Actions reported `Issues: write` for `GITHUB_TOKEN`. So this is not a fork-context issue; the integration token is still blocked from creating comments in this repo.

## Fix
Use `secrets.NATIVE_SDK_BUMP_TOKEN` as `GH_TOKEN`, matching the existing native SDK bump automation. That PAT is already the repo pattern for automation that needs to interact with PRs on public GitHub.

## Verification
- Parsed workflow YAML locally.
- Extracted workflow shell script and ran `bash -n`.
- Ran `shellcheck -s bash` on the extracted script.
