### PR TITLE
Fix Minion source org for React Native

### DIFF
--- a/.github/workflows/minion-on-native-sdk-bump-ci-failure.yml
+++ b/.github/workflows/minion-on-native-sdk-bump-ci-failure.yml
@@ -35,6 +35,7 @@ jobs:
       BUMP_BRANCH_PREFIX: chore/bump-native-sdks
       MINION_SOURCE_REFERENCE: stripe-react-native-native-sdk-bump-ci-fixer
       MINION_URL_PREFIX: 'https://devboxproxy.qa.corp.stripe.com/new-agent#'
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_RUN_CHANNEL_WEBHOOK_URL }}
 
     steps:
       - name: Find failing native SDK bump PRs and comment with Minion link
@@ -196,4 +197,40 @@ jobs:
             rm -f "$comment_file" "$comment_payload"
 
             echo "Posted Minion task link on PR #$pr_number for $head_sha."
+
+            if [ -n "$SLACK_WEBHOOK_URL" ]; then
+              slack_payload="$(mktemp)"
+              jq -n \
+                --arg pr_number "$pr_number" \
+                --arg pr_title "$pr_title" \
+                --arg pr_url "$pr_url" \
+                --arg branch "$branch" \
+                --arg head_sha "$head_sha" \
+                --arg minion_url "$minion_url" \
+                --arg failed_check_summary "$failed_check_summary" \
+                '{
+                  text: (
+                    ":warning: CI is failing on automated native SDK bump PR <" + $pr_url + "|#" + $pr_number + ">.\n" +
+                    "Branch: `" + $branch + "`\n" +
+                    "Head SHA: `" + $head_sha + "`\n" +
+                    "Title: " + $pr_title + "\n\n" +
+                    "Failed checks:\n" + $failed_check_summary + "\n\n" +
+                    "<" + $minion_url + "|Create Minion task>"
+                  )
+                }' > "$slack_payload"
+
+              if curl -fsS \
+                -X POST \
+                -H 'Content-type: application/json' \
+                --data @"$slack_payload" \
+                "$SLACK_WEBHOOK_URL" \
+                >/dev/null; then
+                echo "Posted Minion task link to Slack."
+              else
+                echo "Failed to post Minion task link to Slack." >&2
+              fi
+              rm -f "$slack_payload"
+            else
+              echo "SLACK_RUN_CHANNEL_WEBHOOK_URL is not configured; skipping Slack notification."
+            fi
           done < <(printf '%s' "$prs_json" | jq -c '.[]')

--- a/.github/workflows/minion-on-native-sdk-bump-ci-failure.yml
+++ b/.github/workflows/minion-on-native-sdk-bump-ci-failure.yml
@@ -164,6 +164,7 @@ jobs:
                 spec: {
                   source_specs: [
                     {
+                      org: "stripe",
                       repo: "stripe-react-native"
                     }
                   ],

--- a/.github/workflows/minion-on-native-sdk-bump-ci-failure.yml
+++ b/.github/workflows/minion-on-native-sdk-bump-ci-failure.yml
@@ -35,7 +35,6 @@ jobs:
       BUMP_BRANCH_PREFIX: chore/bump-native-sdks
       MINION_SOURCE_REFERENCE: stripe-react-native-native-sdk-bump-ci-fixer
       MINION_URL_PREFIX: 'https://devboxproxy.qa.corp.stripe.com/new-agent#'
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_RUN_CHANNEL_WEBHOOK_URL }}
 
     steps:
       - name: Find failing native SDK bump PRs and comment with Minion link
@@ -197,40 +196,4 @@ jobs:
             rm -f "$comment_file" "$comment_payload"
 
             echo "Posted Minion task link on PR #$pr_number for $head_sha."
-
-            if [ -n "$SLACK_WEBHOOK_URL" ]; then
-              slack_payload="$(mktemp)"
-              jq -n \
-                --arg pr_number "$pr_number" \
-                --arg pr_title "$pr_title" \
-                --arg pr_url "$pr_url" \
-                --arg branch "$branch" \
-                --arg head_sha "$head_sha" \
-                --arg minion_url "$minion_url" \
-                --arg failed_check_summary "$failed_check_summary" \
-                '{
-                  text: (
-                    ":warning: CI is failing on automated native SDK bump PR <" + $pr_url + "|#" + $pr_number + ">.\n" +
-                    "Branch: `" + $branch + "`\n" +
-                    "Head SHA: `" + $head_sha + "`\n" +
-                    "Title: " + $pr_title + "\n\n" +
-                    "Failed checks:\n" + $failed_check_summary + "\n\n" +
-                    "<" + $minion_url + "|Create Minion task>"
-                  )
-                }' > "$slack_payload"
-
-              if curl -fsS \
-                -X POST \
-                -H 'Content-type: application/json' \
-                --data @"$slack_payload" \
-                "$SLACK_WEBHOOK_URL" \
-                >/dev/null; then
-                echo "Posted Minion task link to Slack."
-              else
-                echo "Failed to post Minion task link to Slack." >&2
-              fi
-              rm -f "$slack_payload"
-            else
-              echo "SLACK_RUN_CHANNEL_WEBHOOK_URL is not configured; skipping Slack notification."
-            fi
           done < <(printf '%s' "$prs_json" | jq -c '.[]')


### PR DESCRIPTION
## Summary
- Fix the generated Minion launch config for the public React Native repo.
- Add `org: "stripe"` to the Minion `source_specs` entry.

## Issue
Clicking a generated Minion link failed with:

```text
Failed to create devbox: {"error":{"message":"Unknown repo `stripe-internal/stripe-react-native`. Only repos registered in Opus::Dev::Sources are supported."}}
```

The generated payload only set:

```json
{"repo":"stripe-react-native"}
```

Without an explicit org, devbox resolves the source as `stripe-internal/stripe-react-native`. The real repo is the public GitHub repo:

```text
stripe/stripe-react-native
```

`Opus::Dev::Sources` has the registered source as `DefaultSource.new(name: "stripe-react-native", org: "stripe", origin: "github.com")`.

## Fix
Generate the Minion source spec as:

```json
{"org":"stripe","repo":"stripe-react-native"}
```

The agent task repo remains `stripe-react-native`, matching the registered source name.

## Verification
- Parsed workflow YAML locally.
- Extracted the workflow shell script and ran `bash -n`.
- Ran `shellcheck -s bash` on the extracted script.
