### PR TITLE
Notify Slack for failed SDK bump CI

### DIFF
--- a/.github/workflows/minion-on-native-sdk-bump-ci-failure.yml
+++ b/.github/workflows/minion-on-native-sdk-bump-ci-failure.yml
@@ -35,6 +35,7 @@ jobs:
       BUMP_BRANCH_PREFIX: chore/bump-native-sdks
       MINION_SOURCE_REFERENCE: stripe-react-native-native-sdk-bump-ci-fixer
       MINION_URL_PREFIX: 'https://devboxproxy.qa.corp.stripe.com/new-agent#'
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_RUN_CHANNEL_WEBHOOK_URL }}
 
     steps:
       - name: Find failing native SDK bump PRs and comment with Minion link
@@ -196,4 +197,40 @@ jobs:
             rm -f "$comment_file" "$comment_payload"
 
             echo "Posted Minion task link on PR #$pr_number for $head_sha."
+
+            if [ -n "$SLACK_WEBHOOK_URL" ]; then
+              slack_payload="$(mktemp)"
+              jq -n \
+                --arg pr_number "$pr_number" \
+                --arg pr_title "$pr_title" \
+                --arg pr_url "$pr_url" \
+                --arg branch "$branch" \
+                --arg head_sha "$head_sha" \
+                --arg minion_url "$minion_url" \
+                --arg failed_check_summary "$failed_check_summary" \
+                '{
+                  text: (
+                    ":warning: CI is failing on automated native SDK bump PR <" + $pr_url + "|#" + $pr_number + ">.\n" +
+                    "Branch: `" + $branch + "`\n" +
+                    "Head SHA: `" + $head_sha + "`\n" +
+                    "Title: " + $pr_title + "\n\n" +
+                    "Failed checks:\n" + $failed_check_summary + "\n\n" +
+                    "<" + $minion_url + "|Create Minion task>"
+                  )
+                }' > "$slack_payload"
+
+              if curl -fsS \
+                -X POST \
+                -H 'Content-type: application/json' \
+                --data @"$slack_payload" \
+                "$SLACK_WEBHOOK_URL" \
+                >/dev/null; then
+                echo "Posted Minion task link to Slack."
+              else
+                echo "Failed to post Minion task link to Slack." >&2
+              fi
+              rm -f "$slack_payload"
+            else
+              echo "SLACK_RUN_CHANNEL_WEBHOOK_URL is not configured; skipping Slack notification."
+            fi
           done < <(printf '%s' "$prs_json" | jq -c '.[]')


### PR DESCRIPTION
## Summary
- Post the generated Minion task link to Slack when automated native SDK bump CI fails.
- Use the existing `SLACK_RUN_CHANNEL_WEBHOOK_URL` repo secret for the run channel (`ocs-mobile-run`).
- Send Slack only after a new PR comment is posted, so the existing per-SHA marker dedupe also prevents duplicate Slack notifications.

## Behavior
When the workflow finds failed checks on a `chore/bump-native-sdks*` PR and posts the PR comment, it also posts a Slack message containing:

- PR number, title, branch, and head SHA
- failed check summary
- Minion task launch link

Slack post failures are logged but do not fail the workflow after the PR comment has already been created.

## Verification
- Parsed workflow YAML locally.
- Extracted the workflow shell script and ran `bash -n`.
- Ran `shellcheck -s bash` on the extracted script.
- Built a sample Slack JSON payload with `jq` locally.
