### PR TITLE
Preserve public repo org in Minion links

### DIFF
--- a/.github/workflows/minion-on-native-sdk-bump-ci-failure.yml
+++ b/.github/workflows/minion-on-native-sdk-bump-ci-failure.yml
@@ -165,7 +165,9 @@ jobs:
                   source_specs: [
                     {
                       org: "stripe",
-                      repo: "stripe-react-native"
+                      repo: "stripe-react-native",
+                      git_ref: "",
+                      new_branch: true
                     }
                   ],
                   agent_task: {


### PR DESCRIPTION
## Summary
- Preserve the public GitHub repo source when users click generated Minion links.
- Add `git_ref: ""` and `new_branch: true` to the generated `source_specs` entry.

## Issue
#2529 added `org: "stripe"`, but clicking the link still produced a devbox URL with:

```json
{"org":"stripe-internal","repo":"stripe-react-native"}
```

That happens in the devbox `NewAgentForm`: it normalizes the first `source_spec` whenever `current.new_branch !== true`, and that normalization path hard-codes `org: "stripe-internal"`.

The workflow-generated source spec had `org: "stripe"`, but did not include `new_branch: true`, so the confirmation page rewrote the source back to `stripe-internal/stripe-react-native` before devbox creation.

## Fix
Generate the source spec with the fields the NewAgent page expects:

```json
{
  "org": "stripe",
  "repo": "stripe-react-native",
  "git_ref": "",
  "new_branch": true
}
```

`new_branch: true` prevents the normalization effect from overwriting the org. `git_ref: ""` lets devbox derive the normal user branch name while preserving `org: "stripe"`.

## Verification
- Parsed workflow YAML locally.
- Extracted workflow shell script and ran `bash -n`.
- Ran `shellcheck -s bash` on the extracted script.
- Generated and decoded a sample Minion URL locally; it contains `source=stripe/stripe-react-native`, `git_ref=""`, and `new_branch=true`.
- Simulated the relevant NewAgentForm normalization condition locally; `needsUpdate=false`, so `org` remains `stripe`, and branch canonicalization preserves it.
