### PR TITLE
Bump Stripe iOS to 26.3.0 and Android to 23.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Unreleased
 **Changes**
-* Updated Stripe iOS SDK from 26.0.0 to 26.1.0.
+* Updated Stripe iOS SDK from 26.0.0 to 26.3.0.
+* Updated Stripe Android SDK from 23.11.0 to 23.12.0.
 * [Changed] Connect embedded components — `ConnectAccountOnboarding`, `ConnectPayments`, and `ConnectPayouts` — are now generally available. No API changes; existing integrations continue to work without modification.
 
 ## 0.68.0 - 2026-06-29

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -3,4 +3,4 @@ StripeSdk_compileSdkVersion=36
 StripeSdk_targetSdkVersion=36
 StripeSdk_minSdkVersion=23
 # Keep StripeSdk_stripeVersion in sync with https://github.com/stripe/stripe-identity-react-native/blob/main/android/gradle.properties
-StripeSdk_stripeVersion=23.11.0
+StripeSdk_stripeVersion=23.12.0

--- a/android/src/onramp/java/com/reactnativestripesdk/OnrampErrors.kt
+++ b/android/src/onramp/java/com/reactnativestripesdk/OnrampErrors.kt
@@ -3,14 +3,12 @@
 package com.reactnativestripesdk
 
 import com.facebook.react.bridge.Arguments
-import com.facebook.react.bridge.WritableArray
 import com.facebook.react.bridge.WritableMap
 import com.reactnativestripesdk.utils.ErrorType
 import com.stripe.android.core.exception.StripeException
 import com.stripe.android.crypto.onramp.ExperimentalCryptoOnramp
 import com.stripe.android.crypto.onramp.exception.AppAttestationException
 import com.stripe.android.crypto.onramp.exception.CryptoOnrampApiException
-import com.stripe.android.crypto.onramp.exception.SDKVersion
 import com.stripe.android.crypto.onramp.exception.StripeCryptoOnrampError
 
 internal fun createOnrampFailedError(error: Throwable): WritableMap =
@@ -32,29 +30,26 @@ private fun createOnrampError(
 
   val stripeError = apiException.stripeError
   val onrampErrorType = apiException.toOnrampErrorType()
+  val apiErrorContext = apiException.apiErrorContext
 
   return createOnrampErrorMap(
     code = code,
     message = apiException.userMessage,
     localizedMessage = apiException.localizedMessage,
     declineCode = stripeError?.declineCode,
-    type = apiException.context.apiErrorType ?: stripeError?.type,
+    type = apiErrorContext.apiErrorType ?: stripeError?.type,
     stripeErrorCode = apiException.code,
   ) {
     putString("onrampErrorType", onrampErrorType)
     putString("developerMessage", apiException.developerMessage)
     putString("userMessage", apiException.userMessage)
-    putString("reason", apiException.context.reason)
-    putString("operation", apiException.context.operation)
-    putString("appPackageName", apiException.context.appPackageName)
-    putString("mode", apiException.context.mode)
-    putArray("sdkVersions", mapFromSdkVersions(apiException.sdkVersions))
-    putString("requestId", apiException.context.requestId)
-    putString("apiErrorCode", apiException.context.apiErrorCode)
-    putString("apiErrorType", apiException.context.apiErrorType)
-    putString("apiErrorMessage", apiException.context.apiErrorMessage)
-    putString("apiUserMessage", apiException.context.apiUserMessage)
-    putString("docUrl", apiException.context.docUrl)
+    putString("reason", apiErrorContext.reason)
+    putString("requestId", apiErrorContext.requestId)
+    putString("apiErrorCode", apiErrorContext.apiErrorCode)
+    putString("apiErrorType", apiErrorContext.apiErrorType)
+    putString("apiErrorMessage", apiErrorContext.apiErrorMessage)
+    putString("apiUserMessage", apiErrorContext.apiUserMessage)
+    putString("docUrl", apiErrorContext.docUrl)
   }
 }
 
@@ -129,17 +124,3 @@ private fun createOnrampErrorMap(
   map.putMap("error", details)
   return map
 }
-
-private fun mapFromSdkVersions(
-  sdkVersions: List<SDKVersion>,
-): WritableArray =
-  Arguments.createArray().apply {
-    sdkVersions.forEach { sdkVersion ->
-      pushMap(
-        Arguments.createMap().apply {
-          putString("name", sdkVersion.name)
-          putString("version", sdkVersion.version)
-        },
-      )
-    }
-  }

--- a/android/src/onramp/java/com/reactnativestripesdk/OnrampSdkModule.kt
+++ b/android/src/onramp/java/com/reactnativestripesdk/OnrampSdkModule.kt
@@ -1,4 +1,4 @@
-@file:OptIn(ExperimentalCryptoOnramp::class)
+@file:OptIn(ExperimentalCryptoOnramp::class, LinkControllerPreview::class)
 
 package com.reactnativestripesdk
 
@@ -52,6 +52,7 @@ import com.stripe.android.crypto.onramp.model.OnrampVerifyIdentityResult
 import com.stripe.android.crypto.onramp.model.OnrampVerifyKycInfoResult
 import com.stripe.android.crypto.onramp.model.PaymentMethodSelection
 import com.stripe.android.link.LinkController.PaymentMethodPreview
+import com.stripe.android.link.LinkControllerPreview
 import com.stripe.android.link.PaymentMethodPreviewDetails
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.DateOfBirth
@@ -65,7 +66,7 @@ import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 
 @SuppressLint("RestrictedApi")
-@OptIn(ExperimentalCryptoOnramp::class)
+@OptIn(ExperimentalCryptoOnramp::class, LinkControllerPreview::class)
 @ReactModule(name = NativeOnrampSdkModuleSpec.NAME)
 class OnrampSdkModule(
   reactContext: ReactApplicationContext,

--- a/android/src/test/java/com/reactnativestripesdk/OnrampErrorsTest.kt
+++ b/android/src/test/java/com/reactnativestripesdk/OnrampErrorsTest.kt
@@ -52,17 +52,6 @@ class OnrampErrorsTest {
     assertEquals("api_error", details.getString("type"))
     assertEquals("api_error", details.getString("apiErrorType"))
     assertEquals("android_package_name_mismatch", details.getString("reason"))
-    assertEquals("configure", details.getString("operation"))
-    assertEquals("com.example.app", details.getString("appPackageName"))
-    assertEquals("test", details.getString("mode"))
-    val sdkVersions = details.getArray("sdkVersions")
-    assertNotNull(sdkVersions)
-    val stripeAndroidVersion = sdkVersions!!.getMap(0)
-    assertEquals("stripe-android", stripeAndroidVersion!!.getString("name"))
-    assertEquals("23.9.1", stripeAndroidVersion.getString("version"))
-    val reactNativeVersion = sdkVersions.getMap(1)
-    assertEquals("stripe-react-native", reactNativeVersion!!.getString("name"))
-    assertEquals("0.66.0", reactNativeVersion.getString("version"))
     assertEquals("req_attestation", details.getString("requestId"))
     assertEquals(
       "Attestation request could not be verified.",
@@ -81,7 +70,7 @@ class OnrampErrorsTest {
   fun createOnrampFailedError_withUncategorizedApiError_preservesStripeCodes() {
     val error =
       createOnrampException(
-        className = "com.stripe.android.crypto.onramp.exception.UncategorizedApiErrorException",
+        className = "com.stripe.android.crypto.onramp.exception.UncategorizedException",
         reason = "consumer_session_expired",
         operation = "authorize",
         appPackageName = "com.example.app",
@@ -104,7 +93,6 @@ class OnrampErrorsTest {
     assertEquals("authentication_error", details.getString("type"))
     assertEquals("Session expired. Please sign in again.", details.getString("message"))
     assertEquals("Session expired. Please sign in again.", details.getString("userMessage"))
-    assertEquals("authorize", details.getString("operation"))
     assertEquals("req_auth", details.getString("requestId"))
     assertTrue(details.getString("developerMessage")!!.contains("Code: consumer_session_expired"))
   }
@@ -135,9 +123,6 @@ class OnrampErrorsTest {
     val context =
       APIErrorContext(
         reason = reason,
-        operation = operation,
-        appPackageName = appPackageName,
-        mode = mode,
         apiErrorCode = apiErrorCode,
         apiErrorType = apiErrorType,
         apiErrorMessage = apiErrorMessage,
@@ -145,6 +130,23 @@ class OnrampErrorsTest {
         docUrl = docUrl,
         underlyingError = cause,
       )
+    val diagnosticContextClass =
+      Class.forName("com.stripe.android.crypto.onramp.exception.DiagnosticContext")
+    val diagnosticContext =
+      diagnosticContextClass
+        .getDeclaredConstructor(
+          List::class.java,
+          String::class.java,
+          String::class.java,
+          String::class.java,
+        ).apply {
+          isAccessible = true
+        }.newInstance(
+          sdkVersions,
+          operation,
+          appPackageName,
+          mode,
+        )
 
     // The exception classes in the `com.stripe.android.crypto.onramp.exception` package
     // don't have public constructors, so we use reflection to create instances for testing.
@@ -153,7 +155,7 @@ class OnrampErrorsTest {
         .forName(className)
         .getDeclaredConstructor(
           APIErrorContext::class.java,
-          List::class.java,
+          diagnosticContextClass,
           String::class.java,
         ).apply {
           isAccessible = true
@@ -161,7 +163,7 @@ class OnrampErrorsTest {
 
     return constructor.newInstance(
       context,
-      sdkVersions,
+      diagnosticContext,
       userMessage,
     ) as Exception
   }

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1820,13 +1820,13 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - Stripe (26.2.0):
-    - StripeApplePay (= 26.2.0)
-    - StripeCore (= 26.2.0)
-    - StripeIssuing (= 26.2.0)
-    - StripePayments (= 26.2.0)
-    - StripePaymentsUI (= 26.2.0)
-    - StripeUICore (= 26.2.0)
+  - Stripe (26.3.0):
+    - StripeApplePay (= 26.3.0)
+    - StripeCore (= 26.3.0)
+    - StripeIssuing (= 26.3.0)
+    - StripePayments (= 26.3.0)
+    - StripePaymentsUI (= 26.3.0)
+    - StripeUICore (= 26.3.0)
   - stripe-react-native (0.68.0):
     - hermes-engine
     - RCTRequired
@@ -1872,12 +1872,12 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-    - Stripe (= 26.2.0)
-    - StripeApplePay (= 26.2.0)
-    - StripeFinancialConnections (= 26.2.0)
-    - StripePayments (= 26.2.0)
-    - StripePaymentSheet (= 26.2.0)
-    - StripePaymentsUI (= 26.2.0)
+    - Stripe (= 26.3.0)
+    - StripeApplePay (= 26.3.0)
+    - StripeFinancialConnections (= 26.3.0)
+    - StripePayments (= 26.3.0)
+    - StripePaymentSheet (= 26.3.0)
+    - StripePaymentsUI (= 26.3.0)
     - Yoga
   - stripe-react-native/NewArch (0.68.0):
     - hermes-engine
@@ -1923,7 +1923,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - stripe-react-native/Core
-    - StripeCryptoOnramp (= 26.2.0)
+    - StripeCryptoOnramp (= 26.3.0)
     - Yoga
   - stripe-react-native/Tests (0.68.0):
     - hermes-engine
@@ -1947,46 +1947,46 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - StripeApplePay (26.2.0):
-    - StripeCore (= 26.2.0)
-  - StripeCameraCore (26.2.0):
-    - StripeCore (= 26.2.0)
-  - StripeCore (26.2.0)
-  - StripeCryptoOnramp (26.2.0):
-    - StripeApplePay (= 26.2.0)
-    - StripeCore (= 26.2.0)
-    - StripeIdentity (= 26.2.0)
-    - StripePayments (= 26.2.0)
-    - StripePaymentSheet (= 26.2.0)
-    - StripePaymentsUI (= 26.2.0)
-    - StripeUICore (= 26.2.0)
-  - StripeFinancialConnections (26.2.0):
-    - StripeCore (= 26.2.0)
-    - StripeUICore (= 26.2.0)
-  - StripeIdentity (26.2.0):
-    - StripeCameraCore (= 26.2.0)
-    - StripeCore (= 26.2.0)
-    - StripeUICore (= 26.2.0)
-  - StripeIssuing (26.2.0):
-    - StripeCore (= 26.2.0)
-    - StripePayments (= 26.2.0)
-    - StripePaymentsUI (= 26.2.0)
-  - StripePayments (26.2.0):
-    - StripeCore (= 26.2.0)
-    - StripePayments/Stripe3DS2 (= 26.2.0)
-  - StripePayments/Stripe3DS2 (26.2.0):
-    - StripeCore (= 26.2.0)
-  - StripePaymentSheet (26.2.0):
-    - StripeApplePay (= 26.2.0)
-    - StripeCore (= 26.2.0)
-    - StripePayments (= 26.2.0)
-    - StripePaymentsUI (= 26.2.0)
-  - StripePaymentsUI (26.2.0):
-    - StripeCore (= 26.2.0)
-    - StripePayments (= 26.2.0)
-    - StripeUICore (= 26.2.0)
-  - StripeUICore (26.2.0):
-    - StripeCore (= 26.2.0)
+  - StripeApplePay (26.3.0):
+    - StripeCore (= 26.3.0)
+  - StripeCameraCore (26.3.0):
+    - StripeCore (= 26.3.0)
+  - StripeCore (26.3.0)
+  - StripeCryptoOnramp (26.3.0):
+    - StripeApplePay (= 26.3.0)
+    - StripeCore (= 26.3.0)
+    - StripeIdentity (= 26.3.0)
+    - StripePayments (= 26.3.0)
+    - StripePaymentSheet (= 26.3.0)
+    - StripePaymentsUI (= 26.3.0)
+    - StripeUICore (= 26.3.0)
+  - StripeFinancialConnections (26.3.0):
+    - StripeCore (= 26.3.0)
+    - StripeUICore (= 26.3.0)
+  - StripeIdentity (26.3.0):
+    - StripeCameraCore (= 26.3.0)
+    - StripeCore (= 26.3.0)
+    - StripeUICore (= 26.3.0)
+  - StripeIssuing (26.3.0):
+    - StripeCore (= 26.3.0)
+    - StripePayments (= 26.3.0)
+    - StripePaymentsUI (= 26.3.0)
+  - StripePayments (26.3.0):
+    - StripeCore (= 26.3.0)
+    - StripePayments/Stripe3DS2 (= 26.3.0)
+  - StripePayments/Stripe3DS2 (26.3.0):
+    - StripeCore (= 26.3.0)
+  - StripePaymentSheet (26.3.0):
+    - StripeApplePay (= 26.3.0)
+    - StripeCore (= 26.3.0)
+    - StripePayments (= 26.3.0)
+    - StripePaymentsUI (= 26.3.0)
+  - StripePaymentsUI (26.3.0):
+    - StripeCore (= 26.3.0)
+    - StripePayments (= 26.3.0)
+    - StripeUICore (= 26.3.0)
+  - StripeUICore (26.3.0):
+    - StripeCore (= 26.3.0)
   - Yoga (0.0.0)
 
 DEPENDENCIES:
@@ -2311,19 +2311,19 @@ SPEC CHECKSUMS:
   RNCAsyncStorage: e85a99325df9eb0191a6ee2b2a842644c7eb29f4
   RNCPicker: e0149590451d5eae242cf686014a6f6d808f93c7
   RNScreens: 448161bce0b7d670222bf4ac967b0c3449cdcefa
-  Stripe: edb3b30a2d76b884e8bf891116c12ce036fc8d75
-  stripe-react-native: de21c61abf497618c2bcd1c4769eff236a317456
-  StripeApplePay: e4d3543b3917101dfc12d251db6600bd13fdfedb
-  StripeCameraCore: 245d1cf751869f76fb7e579c38a503ecacf88177
-  StripeCore: 171f996d107b237df43d2c1f8f7545d9778c4bb7
-  StripeCryptoOnramp: e6e4df113eeeb0a5270efa2f86cb8f118e34134a
-  StripeFinancialConnections: 8cbc326c4c423aa00be71b666c43a8317cef12cb
-  StripeIdentity: dbe98a25b4aedba3aa179895c32c7bc5e56582ad
-  StripeIssuing: 2bea926fb7ebae3e5b7b806600f69b98fead3c37
-  StripePayments: 1cdcf7fd22f7663c8e56f51123876713e664a412
-  StripePaymentSheet: c3f57b2d09687fc6a93688d98fbd1cc9d4682864
-  StripePaymentsUI: 321894adcd1d84f1b20e1ff391cac7460b165ba4
-  StripeUICore: 9d45e14fd891d402c841785639e580ee8662394e
+  Stripe: f7091df3d8d2d3914155b46e0aa3bbb1ed1775e5
+  stripe-react-native: 29cd240185c4f41d2cf2cb7262d3370db9bb05ce
+  StripeApplePay: e6feafcfde92bede41fca36a3638910dc05c6d7d
+  StripeCameraCore: 66daa89327562225e203efbbcb3252735a6ad01b
+  StripeCore: 38ffa3e203ed1090f577cd068322c5d23261bec4
+  StripeCryptoOnramp: c5f93b933fdc66b5d4f66b67574b0eeab73976a5
+  StripeFinancialConnections: adb8a411899b89c943cfc138566fc68305f863f3
+  StripeIdentity: 326b27cdbb15968bac2aefd2264d06db8cd61afb
+  StripeIssuing: 1d120024eafa3d4372766cc44db571597d6507af
+  StripePayments: dc15899a649453ab6d377e5fc9369799ba3d3606
+  StripePaymentSheet: 3a8dd413cef611d1e025c772a1dba6535a076d9c
+  StripePaymentsUI: 967de780d7683b51323934d3c1e3406cb65038f1
+  StripeUICore: ed84f5c88d867aaf6da98f49641a4da27dddaab8
   Yoga: 5934998fbeaef7845dbf698f698518695ab4cd1a
 
 PODFILE CHECKSUM: 605f3cad878b7c0eee93ebb4a78a8141d34cd328

--- a/ios/OnrampErrors.swift
+++ b/ios/OnrampErrors.swift
@@ -84,7 +84,7 @@ enum OnrampErrors {
 
     private static func onrampErrorType(for error: StripeCryptoOnrampAPIError) -> String {
         switch error {
-        case is AppAttestationAPIError:
+        case is AppAttestationError:
             return "AppAttestationError"
         default:
             return "UncategorizedApiError"

--- a/ios/StripeSdkImpl+Checkout.swift
+++ b/ios/StripeSdkImpl+Checkout.swift
@@ -21,7 +21,10 @@ extension StripeSdkImpl {
         resolver resolve: @escaping RCTPromiseResolveBlock,
         rejecter reject: @escaping RCTPromiseRejectBlock
     ) {
-        let checkoutConfiguration = buildCheckoutConfiguration(params: configuration)
+        let checkoutConfiguration = buildCheckoutConfiguration(
+            clientSecret: clientSecret,
+            params: configuration
+        )
 
         Task { @MainActor [weak self] in
             guard let self else {
@@ -30,10 +33,7 @@ extension StripeSdkImpl {
             }
 
             do {
-                let checkout = try await Checkout(
-                    clientSecret: clientSecret,
-                    configuration: checkoutConfiguration
-                )
+                let checkout = try await Checkout(configuration: checkoutConfiguration)
                 let sessionKey = UUID().uuidString
 
                 let cancellable = checkout.$isLoading
@@ -209,8 +209,11 @@ extension StripeSdkImpl {
         resolve(nil)
     }
 
-    internal func buildCheckoutConfiguration(params: NSDictionary) -> Checkout.Configuration {
-        var configuration = Checkout.Configuration()
+    internal func buildCheckoutConfiguration(
+        clientSecret: String,
+        params: NSDictionary
+    ) -> Checkout.Configuration {
+        var configuration = Checkout.Configuration(clientSecret: clientSecret)
 
         if let adaptivePricing = params["adaptivePricing"] as? NSDictionary,
            let allowed = adaptivePricing["allowed"] as? Bool {

--- a/stripe-react-native.podspec
+++ b/stripe-react-native.podspec
@@ -2,7 +2,7 @@ require 'json'
 
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 # Keep stripe_version in sync with https://github.com/stripe/stripe-identity-react-native/blob/main/stripe-identity-react-native.podspec
-stripe_version = '26.2.0'
+stripe_version = '26.3.0'
 
 fabric_enabled = ENV['RCT_NEW_ARCH_ENABLED'] == '1'
 


### PR DESCRIPTION
## Summary

- Bumped Android SDK to 23.12.0
- Bumped iOS SDK to 26.3.0
- Regenerated Stripe entries in example/ios/Podfile.lock
- Updated CHANGELOG.md
- Fixed Android compile issues from stripe-android 23.12.0:
    - CryptoOnrampApiException.context -> apiErrorContext
    - Updated Onramp error tests for the new internal DiagnosticContext constructor
    - Added LinkControllerPreview opt-in (which is [now required](https://github.com/stripe/stripe-android/commit/5a9df6b3acf694101f251a1113fde07d4615ebc7#diff-ad1abde595e7635f02dedbe8ca991cf5b95ab546b52968ada0eac0e0a4a80a50R33) for `LinkController`)

## Motivation

Bumping to latest SDK versions

## Testing

Trust CI

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
