### PR TITLE
Propose 0.71.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## Unreleased
+## 0.71.0 - 2026-07-22
 **Features**
 * [Added] Added support for the Pay by Bank payment method (`paymentMethodType: 'PayByBank'`) in `confirmPayment` and `confirmSetupIntent`.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stripe/stripe-react-native",
-  "version": "0.70.0",
+  "version": "0.71.0",
   "author": "Stripe",
   "description": "Stripe SDK for React Native",
   "main": "lib/commonjs/index",


### PR DESCRIPTION
- [x] Ensure the CHANGELOG is up to date with all relevant commits since the last release
- [x] Add the version number for this release & the date to the CHANGELOG, underneath "## Unreleased"
  - e.g. "## 1.2.3 - 2022-02-14"
- [x] Update the README if necessary (this is only required when there are breaking changes in the release, such as dropping support for an iOS || Android version)
