### PR TITLE
fix(connect): use exact hostname matching in Connect WebView allowlist

### DIFF
--- a/src/connect/EmbeddedComponent.tsx
+++ b/src/connect/EmbeddedComponent.tsx
@@ -754,7 +754,7 @@ export function EmbeddedComponent(props: EmbeddedComponentProps) {
       if (navigationType !== 'click') return true;
 
       // Allow navigation within allowed Stripe domains (matching iOS SDK behavior)
-      if (ALLOWED_STRIPE_HOSTS.some((host) => url.includes(host))) {
+      if (isAllowedStripeHost(url)) {
         return true; // Allow in-WebView navigation
       }
 
@@ -865,12 +865,24 @@ function isValidUrl(url: string): boolean {
   }
 }
 
+export function isAllowedStripeHost(url: string): boolean {
+  try {
+    const parsedUrl = new URL(url);
+    return ALLOWED_STRIPE_HOSTS.some(
+      (host) => parsedUrl.hostname === host || parsedUrl.host === host
+    );
+  } catch {
+    return false;
+  }
+}
+
 // Detects Stripe CSV export URLs
 function isCsvExportUrl(url: string): boolean {
   try {
     const parsedUrl = new URL(url);
     return (
-      parsedUrl.hostname.includes('stripe-data-exports') ||
+      parsedUrl.hostname === 'stripe-data-exports.com' ||
+      parsedUrl.hostname.endsWith('.stripe-data-exports.com') ||
       parsedUrl.pathname.includes('stripe-data-exports')
     );
   } catch {

--- a/src/connect/__tests__/EmbeddedComponent.test.tsx
+++ b/src/connect/__tests__/EmbeddedComponent.test.tsx
@@ -25,6 +25,7 @@ import { render, waitFor, act } from '@testing-library/react-native';
 import { Platform, AppState } from 'react-native';
 import {
   EmbeddedComponent,
+  isAllowedStripeHost,
   toStripeJsBankAccountToken,
 } from '../EmbeddedComponent';
 import {
@@ -438,6 +439,42 @@ describe('EmbeddedComponent', () => {
         routing_number: null,
         status: null,
       });
+    });
+  });
+
+  describe('isAllowedStripeHost', () => {
+    it('allows exact Stripe hosts', () => {
+      expect(
+        isAllowedStripeHost(
+          'https://connect-js.stripe.com/v1.0/react_native_webview.html'
+        )
+      ).toBe(true);
+      expect(isAllowedStripeHost('https://connect.stripe.com/path')).toBe(true);
+      expect(isAllowedStripeHost('https://verify.stripe.com/verify')).toBe(
+        true
+      );
+    });
+
+    it('rejects non-Stripe hosts, including those containing Stripe hostnames in path or query', () => {
+      expect(
+        isAllowedStripeHost(
+          'https://example.com/connect-bridge?next=https%3A%2F%2Fconnect-js.stripe.com'
+        )
+      ).toBe(false);
+      expect(
+        isAllowedStripeHost('https://connect-js.stripe.com.example.com/path')
+      ).toBe(false);
+      expect(
+        isAllowedStripeHost('https://example.com/?redirect=connect.stripe.com')
+      ).toBe(false);
+      expect(
+        isAllowedStripeHost('https://example.com/connect-js.stripe.com/payload')
+      ).toBe(false);
+    });
+
+    it('rejects malformed or empty URLs', () => {
+      expect(isAllowedStripeHost('not-a-url')).toBe(false);
+      expect(isAllowedStripeHost('')).toBe(false);
     });
   });
 });


### PR DESCRIPTION
## Summary
Replace raw string matching (`url.includes(host)`) with parsed-hostname comparison (`new URL(url).hostname`) when deciding whether a clicked URL should stay in the Connect embedded WebView. 

Also tightens `isCsvExportUrl` from a hostname substring check to exact/suffix domain matching.

## Motivation
The previous check tested whether the raw URL string contained an allowlisted hostname, which passes for URLs that merely include a Stripe hostname anywhere in their path or query string. P

arsing the URL and comparing `hostname` (or `host` for port-bearing dev-mode entries) ensures only URLs whose actual origin matches `ALLOWED_STRIPE_HOSTS` are kept in the privileged WebView. This aligns with how the iOS SDK handles the same decision via `allowedHosts.contains(url.host)`.

## Testing
- [ ] I tested this manually
- [x] I added automated tests

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
