### PR TITLE
Add headless React Native proposal mode

### DIFF
--- a/scripts/helpers.rb
+++ b/scripts/helpers.rb
@@ -70,12 +70,14 @@ def ensure_gh_authenticated
   end
 end
 
-def preflight_checks(is_dry_run: false)
+def preflight_checks(is_dry_run: false, require_gh: true)
   puts "Fetching git remotes"
   execute_or_fail("git fetch")
   ensure_on_master(is_dry_run: is_dry_run)
   ensure_up_to_date(is_dry_run: is_dry_run)
   ensure_clean_repo(is_dry_run: is_dry_run)
-  ensure_gh_installed
-  ensure_gh_authenticated
+  if require_gh
+    ensure_gh_installed
+    ensure_gh_authenticated
+  end
 end

--- a/scripts/propose.rb
+++ b/scripts/propose.rb
@@ -7,6 +7,7 @@ require 'shellwords'
 require_relative 'helpers'
 
 @release_type = nil
+@headless = false
 
 VALID_RELEASE_TYPES = %w[patch minor major].freeze
 
@@ -41,27 +42,71 @@ def bump_version(version)
   execute_or_fail("yarn version --no-git-tag-version --new-version #{version}")
 end
 
-def create_proposal_pr(version)
-  branch = "release/propose-#{version}"
-  execute_or_fail("git checkout -b #{branch}")
+def proposal_branch(version)
+  "release/propose-#{version}"
+end
 
-  bump_version(version)
-  update_changelog(version)
+def proposal_pr_title(version)
+  "Propose #{version}"
+end
 
-  execute_or_fail("git add package.json CHANGELOG.md")
-  execute_or_fail("git commit -m 'Propose #{version}'")
-  execute_or_fail("git push -u origin #{branch}")
-
-  pr_message_file = File.join(Dir.tmpdir, "propose-#{version}-pr-body.md")
-  File.write(pr_message_file, <<~BODY)
+def proposal_pr_body
+  <<~BODY
     - [x] Ensure the CHANGELOG is up to date with all relevant commits since the last release
     - [x] Add the version number for this release & the date to the CHANGELOG, underneath "## Unreleased"
       - e.g. "## 1.2.3 - 2022-02-14"
     - [x] Update the README if necessary (this is only required when there are breaking changes in the release, such as dropping support for an iOS || Android version)
   BODY
+end
+
+def proposal_pr_url(branch)
+  "https://github.com/stripe/stripe-react-native/compare/#{branch}?expand=1"
+end
+
+def print_headless_summary(version, branch)
+  puts ""
+  puts "Headless proposal branch pushed."
+  puts ""
+  puts "PR title:"
+  puts proposal_pr_title(version)
+  puts ""
+  puts "PR body:"
+  puts proposal_pr_body
+  puts "Create PR:"
+  puts proposal_pr_url(branch)
+end
+
+def create_proposal_branch(version, headless:)
+  branch = proposal_branch(version)
+  if headless
+    execute_or_fail("git checkout -B #{branch}")
+  else
+    execute_or_fail("git checkout -b #{branch}")
+  end
+
+  bump_version(version)
+  update_changelog(version)
+
+  execute_or_fail("git add package.json CHANGELOG.md")
+  execute_or_fail("git commit -m #{proposal_pr_title(version).shellescape}")
+
+  if headless
+    execute_or_fail("git push --force-with-lease -u origin #{branch}")
+    print_headless_summary(version, branch)
+  else
+    execute_or_fail("git push -u origin #{branch}")
+  end
+
+  branch
+end
+
+def create_proposal_pr(version)
+  branch = create_proposal_branch(version, headless: false)
+  pr_message_file = File.join(Dir.tmpdir, "propose-#{version}-pr-body.md")
+  File.write(pr_message_file, proposal_pr_body)
 
   puts ""
-  pr_url = `GH_HOST=github.com gh pr create --repo stripe/stripe-react-native --base master --head #{branch} --title "Propose #{version}" --body-file #{pr_message_file.shellescape}`.strip
+  pr_url = `GH_HOST=github.com gh pr create --repo stripe/stripe-react-native --base master --head #{branch} --title #{proposal_pr_title(version).shellescape} --body-file #{pr_message_file.shellescape}`.strip
   File.delete(pr_message_file) if File.exist?(pr_message_file)
 
   if $?.success?
@@ -69,23 +114,28 @@ def create_proposal_pr(version)
     system("open", pr_url)
   else
     rputs "Could not create PR via gh. Create it manually:"
-    url = "https://github.com/stripe/stripe-react-native/compare/#{branch}?expand=1"
-    puts "  #{url}"
-    system("open", url)
+    puts "  #{proposal_pr_url(branch)}"
+    system("open", proposal_pr_url(branch))
   end
 end
 
 OptionParser.new do |opts|
   opts.banner = <<~BANNER
     USAGE:
-        ./scripts/propose.rb <release_type>
+        ./scripts/propose.rb [--headless] <release_type>
 
     Creates a proposal PR for the next release. Replaces the '## Unreleased'
     header in CHANGELOG.md with the new version and today's date, then opens a PR.
+    In headless mode, creates and pushes the proposal branch, then prints PR
+    details without creating a PR, opening a browser, or requiring gh auth.
 
     ARGS:
         <release_type>    "patch", "minor", or "major"
   BANNER
+
+  opts.on("--headless", "Create and push the proposal branch, then print PR details without using gh") do
+    @headless = true
+  end
 
   opts.on("-h", "--help", "Show this help message") do
     puts opts
@@ -105,8 +155,12 @@ end
 
 Dir.chdir(`git rev-parse --show-toplevel`.strip)
 
-preflight_checks
+preflight_checks(require_gh: !@headless)
 
 version = next_version
 puts "Proposing #{version} (currently #{current_version})"
-create_proposal_pr(version)
+if @headless
+  create_proposal_branch(version, headless: true)
+else
+  create_proposal_pr(version)
+end


### PR DESCRIPTION
## Summary
- Add `--headless` to `scripts/propose.rb`
- In headless mode, create/update and push the proposal branch, then print PR title/body/create URL instead of invoking `gh pr create`
- Skip `gh` install/auth checks in headless mode while preserving existing interactive behavior by default

## Validation
- `ruby -c scripts/propose.rb`
- `ruby -c scripts/helpers.rb`
- `./scripts/propose.rb --help`
- `git diff --check -- scripts/propose.rb scripts/helpers.rb`

Did not run the full proposer because it would create and push a real release proposal branch.