### PR TITLE
Add Tempo support to Crypto Onramp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Updated Stripe Android SDK from 23.13.1 to 23.14.0.
 * [Added] `useLinkController` (private preview): Added `billingDetailsCollectionConfiguration` to `LinkController.Configuration` to control which billing fields are collected in the Link sheet.
 * [Added] `useLinkController` (private preview): Added `appearance` to `LinkController.Configuration` to customize Link UI colors and styling.
+* [Added] Added Tempo network support to Crypto Onramp.
 
 ## 0.72.0 - 2026-07-27
 **Changes**

--- a/etc/stripe-react-native.api.md
+++ b/etc/stripe-react-native.api.md
@@ -1464,6 +1464,8 @@ enum CryptoNetwork {
     // (undocumented)
     sui = "sui",
     // (undocumented)
+    tempo = "tempo",
+    // (undocumented)
     worldchain = "worldchain",
     // (undocumented)
     xrpl = "xrpl"

--- a/example/src/screens/Onramp/utils.ts
+++ b/example/src/screens/Onramp/utils.ts
@@ -11,6 +11,7 @@ export function getDefaultAddressForNetwork(
     case Onramp.CryptoNetwork.base:
     case Onramp.CryptoNetwork.optimism:
     case Onramp.CryptoNetwork.worldchain:
+    case Onramp.CryptoNetwork.tempo:
       return '0x742d35Cc6634C0532925a3b844Bc454e4438f44e';
     case Onramp.CryptoNetwork.solana:
       return '9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM';
@@ -58,6 +59,8 @@ export function getDestinationParamsForNetwork(network: Onramp.CryptoNetwork): {
       return { destinationNetwork: 'xrpl', destinationCurrency: 'xrp' };
     case Onramp.CryptoNetwork.sui:
       return { destinationNetwork: 'sui', destinationCurrency: 'sui' };
+    case Onramp.CryptoNetwork.tempo:
+      return { destinationNetwork: 'tempo', destinationCurrency: 'usdc' };
     default:
       return { destinationNetwork: 'ethereum', destinationCurrency: 'eth' };
   }

--- a/src/types/Onramp.ts
+++ b/src/types/Onramp.ts
@@ -140,6 +140,7 @@ export enum CryptoNetwork {
   xrpl = 'xrpl',
   sui = 'sui',
   arbitrum = 'arbitrum',
+  tempo = 'tempo',
 }
 
 /**


### PR DESCRIPTION
## Summary

Adds Tempo to the React Native Crypto Onramp network enum now that the native SDK bump in #2556 includes the iOS and Android Tempo support.

This also updates the example onramp helpers so Tempo appears in the wallet registration dropdown and uses Tempo/USDC when creating an onramp session.

Depends on #2556.

## Testing

- `yarn typescript`
- `yarn bob build`
- pre-commit hook ran `yarn typescript` and ESLint on the staged TS files