### PR TITLE
Update native SDKs when proposing a release

### DIFF
--- a/scripts/native_sdk_versions.rb
+++ b/scripts/native_sdk_versions.rb
@@ -1,0 +1,116 @@
+require 'json'
+require 'net/http'
+require 'uri'
+
+class NativeSdkVersions
+  class Error < StandardError; end
+
+  Change = Struct.new(:name, :path, :previous_version, :version, :changed, keyword_init: true)
+
+  SDK_CONFIG = {
+    ios: {
+      name: 'stripe-ios',
+      repo: 'stripe/stripe-ios',
+      path: 'stripe-react-native.podspec',
+      pattern: /^stripe_version = '([^']+)'$/,
+      replacement: ->(version) { "stripe_version = '#{version}'" },
+    },
+    android: {
+      name: 'stripe-android',
+      repo: 'stripe/stripe-android',
+      path: 'android/gradle.properties',
+      pattern: /^StripeSdk_stripeVersion=(\S+)$/,
+      replacement: ->(version) { "StripeSdk_stripeVersion=#{version}" },
+    },
+  }.freeze
+
+  VERSION_PATTERN = /\A\d+\.\d+\.\d+\z/
+
+  def initialize(root: Dir.pwd, token: ENV['GITHUB_TOKEN'] || ENV['GH_TOKEN'], http_get: nil)
+    @root = root
+    @token = token
+    @http_get = http_get || method(:get)
+  end
+
+  def latest
+    SDK_CONFIG.to_h do |key, config|
+      [key, latest_for(config)]
+    end
+  end
+
+  def apply(versions)
+    plans = SDK_CONFIG.map do |key, config|
+      version = versions.fetch(key)
+      validate_version!(version, config[:name])
+
+      path = File.join(@root, config[:path])
+      contents = File.read(path)
+      matches = contents.scan(config[:pattern])
+      unless matches.length == 1
+        raise Error, "Expected exactly one #{config[:name]} version in #{config[:path]}"
+      end
+
+      previous_version = matches.first.first
+      updated_contents = contents.sub(config[:pattern], config[:replacement].call(version))
+      change = Change.new(
+        name: config[:name],
+        path: config[:path],
+        previous_version: previous_version,
+        version: version,
+        changed: previous_version != version,
+      )
+      [path, updated_contents, change]
+    end
+
+    plans.each do |path, updated_contents, change|
+      File.write(path, updated_contents) if change.changed
+    end
+
+    plans.map(&:last)
+  rescue KeyError => e
+    raise Error, "Missing native SDK version: #{e.message}"
+  end
+
+  private
+
+  def latest_for(config)
+    uri = URI("https://api.github.com/repos/#{config[:repo]}/releases/latest")
+    response = @http_get.call(uri, request_headers)
+    unless response.code.to_i == 200
+      raise Error, "GitHub returned HTTP #{response.code} for #{config[:repo]} releases/latest"
+    end
+
+    tag = JSON.parse(response.body).fetch('tag_name')
+    unless tag.is_a?(String)
+      raise Error, "Invalid GitHub release response for #{config[:repo]}: tag_name must be a string"
+    end
+
+    version = tag.delete_prefix('v')
+    validate_version!(version, config[:name])
+    version
+  rescue JSON::ParserError, KeyError => e
+    raise Error, "Invalid GitHub release response for #{config[:repo]}: #{e.message}"
+  end
+
+  def request_headers
+    headers = {
+      'Accept' => 'application/vnd.github+json',
+      'User-Agent' => 'stripe-react-native-release-proposer',
+      'X-GitHub-Api-Version' => '2022-11-28',
+    }
+    headers['Authorization'] = "Bearer #{@token}" unless @token.nil? || @token.empty?
+    headers
+  end
+
+  def get(uri, headers)
+    Net::HTTP.get_response(uri, headers)
+  rescue SocketError, SystemCallError, Timeout::Error => e
+    raise Error, "Could not reach GitHub Releases: #{e.message}"
+  end
+
+  def validate_version!(version, name)
+    return if version.is_a?(String) && version.match?(VERSION_PATTERN)
+
+    raise Error, "Invalid #{name} release version: #{version.inspect}"
+  end
+end

--- a/scripts/native_sdk_versions.rb
+++ b/scripts/native_sdk_versions.rb
@@ -103,7 +103,11 @@ class NativeSdkVersions
   end
 
   def get(uri, headers)
-    Net::HTTP.get_response(uri, headers)
+    request = Net::HTTP::Get.new(uri)
+    headers.each { |name, value| request[name] = value }
+    Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https') do |http|
+      http.request(request)
+    end
   rescue SocketError, SystemCallError, Timeout::Error => e
     raise Error, "Could not reach GitHub Releases: #{e.message}"
   end

--- a/scripts/propose.rb
+++ b/scripts/propose.rb
@@ -5,6 +5,7 @@ require 'date'
 require 'tmpdir'
 require 'shellwords'
 require_relative 'helpers'
+require_relative 'native_sdk_versions'
 
 @release_type = nil
 
@@ -41,14 +42,29 @@ def bump_version(version)
   execute_or_fail("yarn version --no-git-tag-version --new-version #{version}")
 end
 
-def create_proposal_pr(version)
+def create_proposal_pr(version, native_sdk_updater, native_sdk_versions)
   branch = "release/propose-#{version}"
   execute_or_fail("git checkout -b #{branch}")
 
   bump_version(version)
   update_changelog(version)
+  begin
+    native_sdk_changes = native_sdk_updater.apply(native_sdk_versions)
+  rescue NativeSdkVersions::Error => e
+    abort "Error! #{e.message}"
+  end
+  native_sdk_changes.each do |change|
+    status = change.changed ? "#{change.previous_version} -> #{change.version}" : "already at #{change.version}"
+    puts "#{change.name}: #{status}"
+  end
 
-  execute_or_fail("git add package.json CHANGELOG.md")
+  ios_changed = native_sdk_changes.any? { |change| change.name == 'stripe-ios' && change.changed }
+  execute_or_fail("yarn update-pods") if ios_changed
+
+  files_to_add = ['package.json', 'CHANGELOG.md']
+  files_to_add.concat(native_sdk_changes.select(&:changed).map(&:path))
+  files_to_add << 'example/ios/Podfile.lock' if ios_changed
+  execute_or_fail("git add #{files_to_add.map(&:shellescape).join(' ')}")
   execute_or_fail("git commit -m 'Propose #{version}'")
   execute_or_fail("git push -u origin #{branch}")
 
@@ -57,6 +73,8 @@ def create_proposal_pr(version)
     - [x] Ensure the CHANGELOG is up to date with all relevant commits since the last release
     - [x] Add the version number for this release & the date to the CHANGELOG, underneath "## Unreleased"
       - e.g. "## 1.2.3 - 2022-02-14"
+    - [x] Update stripe-ios to the latest GitHub release (#{native_sdk_versions.fetch(:ios)})
+    - [x] Update stripe-android to the latest GitHub release (#{native_sdk_versions.fetch(:android)})
     - [x] Update the README if necessary (this is only required when there are breaking changes in the release, such as dropping support for an iOS || Android version)
   BODY
 
@@ -81,7 +99,8 @@ OptionParser.new do |opts|
         ./scripts/propose.rb <release_type>
 
     Creates a proposal PR for the next release. Replaces the '## Unreleased'
-    header in CHANGELOG.md with the new version and today's date, then opens a PR.
+    header in CHANGELOG.md with the new version and today's date, updates the
+    native SDK pins to the latest GitHub releases, then opens a PR.
 
     ARGS:
         <release_type>    "patch", "minor", or "major"
@@ -109,4 +128,11 @@ preflight_checks
 
 version = next_version
 puts "Proposing #{version} (currently #{current_version})"
-create_proposal_pr(version)
+native_sdk_updater = NativeSdkVersions.new
+puts "Fetching latest native SDK releases"
+begin
+  native_sdk_versions = native_sdk_updater.latest
+rescue NativeSdkVersions::Error => e
+  abort "Error! #{e.message}"
+end
+create_proposal_pr(version, native_sdk_updater, native_sdk_versions)

--- a/scripts/test/native_sdk_versions_test.rb
+++ b/scripts/test/native_sdk_versions_test.rb
@@ -1,0 +1,81 @@
+require 'fileutils'
+require 'minitest/autorun'
+require 'tmpdir'
+require_relative '../native_sdk_versions'
+
+class NativeSdkVersionsTest < Minitest::Test
+  Response = Struct.new(:code, :body)
+
+  def setup
+    @root = Dir.mktmpdir
+    FileUtils.mkdir_p(File.join(@root, 'android'))
+    File.write(File.join(@root, 'stripe-react-native.podspec'), "stripe_version = '26.4.0'\n")
+    File.write(File.join(@root, 'android/gradle.properties'), "StripeSdk_stripeVersion=23.13.0\n")
+  end
+
+  def teardown
+    FileUtils.remove_entry(@root)
+  end
+
+  def test_fetches_and_normalizes_latest_release_versions
+    requests = []
+    responses = {
+      '/repos/stripe/stripe-ios/releases/latest' => Response.new('200', '{"tag_name":"26.5.0"}'),
+      '/repos/stripe/stripe-android/releases/latest' => Response.new('200', '{"tag_name":"v23.14.0"}'),
+    }
+    http_get = lambda do |uri, headers|
+      requests << [uri, headers]
+      responses.fetch(uri.path)
+    end
+
+    versions = NativeSdkVersions.new(root: @root, token: 'token', http_get: http_get).latest
+
+    assert_equal({ios: '26.5.0', android: '23.14.0'}, versions)
+    assert_equal(2, requests.length)
+    assert(requests.all? { |_, headers| headers['Authorization'] == 'Bearer token' })
+  end
+
+  def test_rejects_an_invalid_release_tag
+    response = Response.new('200', '{"tag_name":"latest"}')
+    updater = NativeSdkVersions.new(root: @root, http_get: ->(_, _) { response })
+
+    error = assert_raises(NativeSdkVersions::Error) { updater.latest }
+
+    assert_includes(error.message, 'Invalid stripe-ios release version')
+  end
+
+  def test_rejects_a_non_string_release_tag
+    response = Response.new('200', '{"tag_name":null}')
+    updater = NativeSdkVersions.new(root: @root, http_get: ->(_, _) { response })
+
+    error = assert_raises(NativeSdkVersions::Error) { updater.latest }
+
+    assert_includes(error.message, 'tag_name must be a string')
+  end
+
+  def test_applies_both_versions
+    changes = NativeSdkVersions.new(root: @root).apply(ios: '26.5.0', android: '23.14.0')
+
+    assert_equal("stripe_version = '26.5.0'\n", File.read(File.join(@root, 'stripe-react-native.podspec')))
+    assert_equal("StripeSdk_stripeVersion=23.14.0\n", File.read(File.join(@root, 'android/gradle.properties')))
+    assert(changes.all?(&:changed))
+  end
+
+  def test_validates_every_file_before_writing
+    File.write(File.join(@root, 'android/gradle.properties'), "unrelated=true\n")
+    updater = NativeSdkVersions.new(root: @root)
+
+    assert_raises(NativeSdkVersions::Error) do
+      updater.apply(ios: '26.5.0', android: '23.14.0')
+    end
+
+    assert_equal("stripe_version = '26.4.0'\n", File.read(File.join(@root, 'stripe-react-native.podspec')))
+  end
+
+  def test_reports_versions_that_are_already_current_as_unchanged
+    updater = NativeSdkVersions.new(root: @root)
+    changes = updater.apply(ios: '26.4.0', android: '23.13.0')
+
+    refute(changes.any?(&:changed))
+  end
+end


### PR DESCRIPTION
## Summary
Bump the stripe-ios and stripe-android versions when proposing a new release, pulling the latest versions from GitHub. Update `stripe-react-native.podspec` and `android/gradle.properties` and run `yarn update-pods`.

## Validation
Ran through Codex's tests, manually rolled back the iOS/Android SDK versions, then ran a full pass up until just before proposing the release.