### PR TITLE
Add workflow to close GitHub issues on Jira resolution

### DIFF
--- a/.github/workflows/close-resolved-issues.yml
+++ b/.github/workflows/close-resolved-issues.yml
@@ -1,0 +1,34 @@
+name: Close GitHub Issue on Jira Resolution
+on:
+  repository_dispatch:
+    types: [jira-issue-resolved]
+
+jobs:
+  close-issue:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Close GitHub Issue
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const issueNumber = parseInt(context.payload.client_payload.issue_number, 10);
+            const jiraKey    = context.payload.client_payload.jira_key;
+            const jiraUrl    = `https://jira.corp.stripe.com/browse/${jiraKey}`;
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo:  context.repo.repo,
+              issue_number: issueNumber,
+              body: `This issue has been resolved internally ([${jiraKey}](${jiraUrl})). Closing — please reopen if you're still experiencing this or have follow-up questions!`
+            });
+
+            await github.rest.issues.update({
+              owner: context.repo.owner,
+              repo:  context.repo.repo,
+              issue_number: issueNumber,
+              state: 'closed',
+              state_reason: 'completed'
+            });


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
Workflow to close GitHub issues when corresponding Jira closed using [this automation](https://jira.corp.stripe.com/secure/AutomationProjectAdminAction!default.jspa?projectKey=RUN_MOBILESDK#/rule/8759)
## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a link to the relevant issue, a code snippet, or an example project that demonstrates the bug. -->
https://jira.corp.stripe.com/browse/RUN_MOBILESDK-5342
## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [ ] I tested this manually
- [ ] I added automated tests
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->
https://github.com/stripe/stripe-ios/issues/6843
## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [X] This PR does not result in any developer-facing changes.
