### PR TITLE
fix(ios): use stripe-connect callback scheme for authenticated web view

### DIFF
--- a/ios/StripeSdkImpl.swift
+++ b/ios/StripeSdkImpl.swift
@@ -139,6 +139,8 @@ public class StripeSdkImpl: NSObject, UIAdaptivePresentationControllerDelegate {
     var authenticationSession: ASWebAuthenticationSession?
     var authenticationContextProvider: Any?
 
+    static let authenticatedWebViewReturnURLScheme = "stripe-connect"
+
     @objc public func getConstants() -> [AnyHashable: Any] {
         return [
             "API_VERSIONS": [
@@ -1979,7 +1981,7 @@ public class StripeSdkImpl: NSObject, UIAdaptivePresentationControllerDelegate {
             // Create the authentication session with the configured URL scheme
             self.authenticationSession = ASWebAuthenticationSession(
                 url: url,
-                callbackURLScheme: nil
+                callbackURLScheme: StripeSdkImpl.authenticatedWebViewReturnURLScheme
             ) { callbackURL, error in
                 if let error = error {
                     // User canceled or an error occurred


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
openAuthenticatedWebView created its ASWebAuthenticationSession with callbackURLScheme: nil, so the session could never intercept the redirect back into the app and always completed with no callback URL. Any flow that depends on the returned redirect (e.g. Singpass/MyInfo passing back code/state during Connect embedded onboarding) silently failed.

Use the "stripe-connect" callback scheme, matching the native iOS Connect SDK (StripeConnectConstants.authenticatedWebViewReturnUrlScheme) and the Android SDK's stripe-connect:// deep-link interceptor, so the redirect URL is captured and returned to JS.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a link to the relevant issue, a code snippet, or an example project that demonstrates the bug. -->
RUN_CAX-5271

## Testing
Tested manually

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
