### PR TITLE
Extract native SDK version bumper

### DIFF
--- a/.github/workflows/bump-native-sdks.yml
+++ b/.github/workflows/bump-native-sdks.yml
@@ -3,7 +3,7 @@ name: Bump native SDK versions
 on:
   schedule:
     - cron: '0 9 * * 1-5'  # 9am UTC, Mon–Fri
-  workflow_dispatch:        # allow manual runs from the Actions UI
+  workflow_dispatch:
 
 jobs:
   bump:
@@ -16,135 +16,20 @@ jobs:
       - uses: actions/checkout@v7
         with:
           # Use a PAT so the resulting PR triggers pull_request CI workflows.
-          # GITHUB_TOKEN-created PRs intentionally don't trigger other workflows.
           token: ${{ secrets.NATIVE_SDK_BUMP_TOKEN }}
 
-      # ── Fetch latest release versions ─────────────────────────────────────
-
-      - name: Fetch latest stripe-ios release
-        id: ios_latest
-        env:
-          GH_TOKEN: ${{ secrets.NATIVE_SDK_BUMP_TOKEN }}
-        run: |
-          VERSION=$(gh api repos/stripe/stripe-ios/releases/latest --jq '.tag_name' | sed 's/^v//')
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-
-      - name: Fetch latest stripe-android release
-        id: android_latest
-        env:
-          GH_TOKEN: ${{ secrets.NATIVE_SDK_BUMP_TOKEN }}
-        run: |
-          VERSION=$(gh api repos/stripe/stripe-android/releases/latest --jq '.tag_name' | sed 's/^v//')
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-
-      # ── Read current pinned versions ───────────────────────────────────────
-
-      - name: Read current pinned versions
-        id: current
-        run: |
-          IOS=$(grep "stripe_version = " stripe-react-native.podspec \
-            | sed "s/.*'\([0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\)'.*/\1/")
-
-          ANDROID=$(grep "^StripeSdk_stripeVersion=" android/gradle.properties \
-            | sed 's/StripeSdk_stripeVersion=//')
-
-          echo "ios=$IOS"         >> $GITHUB_OUTPUT
-          echo "android=$ANDROID" >> $GITHUB_OUTPUT
-
-      # ── Diff ───────────────────────────────────────────────────────────────
-
-      - name: Determine what needs updating
-        id: diff
-        run: |
-          IOS_NEW="${{ steps.ios_latest.outputs.version }}"
-          ANDROID_NEW="${{ steps.android_latest.outputs.version }}"
-
-          IOS_CHANGED=false
-          ANDROID_CHANGED=false
-
-          [ "$IOS_NEW"     != "${{ steps.current.outputs.ios }}"     ] && IOS_CHANGED=true
-          [ "$ANDROID_NEW" != "${{ steps.current.outputs.android }}" ] && ANDROID_CHANGED=true
-
-          echo "ios_changed=$IOS_CHANGED"         >> $GITHUB_OUTPUT
-          echo "android_changed=$ANDROID_CHANGED" >> $GITHUB_OUTPUT
-          echo "ios_new=$IOS_NEW"                 >> $GITHUB_OUTPUT
-          echo "android_new=$ANDROID_NEW"         >> $GITHUB_OUTPUT
-
-      # ── Open PR if anything changed ────────────────────────────────────────
-
       - name: Set up Node.js
-        if: steps.diff.outputs.ios_changed == 'true' || steps.diff.outputs.android_changed == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: 18
           cache: yarn
 
-      - name: Update files and open PR
-        if: steps.diff.outputs.ios_changed == 'true' || steps.diff.outputs.android_changed == 'true'
-        env:
-          GH_TOKEN:        ${{ secrets.NATIVE_SDK_BUMP_TOKEN }}
-          IOS_NEW:         ${{ steps.diff.outputs.ios_new }}
-          ANDROID_NEW:     ${{ steps.diff.outputs.android_new }}
-          IOS_CHANGED:     ${{ steps.diff.outputs.ios_changed }}
-          ANDROID_CHANGED: ${{ steps.diff.outputs.android_changed }}
+      - name: Install dependencies
         run: |
-          # Build a deterministic branch name from the new version(s) so the
-          # workflow is idempotent — re-running when a PR is already open for
-          # the same versions is a no-op.
-          BRANCH="chore/bump-native-sdks"
-          [ "$IOS_CHANGED"     = "true" ] && BRANCH="${BRANCH}-ios-${IOS_NEW}"
-          [ "$ANDROID_CHANGED" = "true" ] && BRANCH="${BRANCH}-android-${ANDROID_NEW}"
+          yarn install --frozen-lockfile
+          yarn --cwd example install --frozen-lockfile
 
-          if gh pr list --state open --head "$BRANCH" --json number --jq '.[0].number' \
-              2>/dev/null | grep -q '[0-9]'; then
-            echo "PR already open for $BRANCH — nothing to do."
-            exit 0
-          fi
-
-          git config user.name  "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git checkout -b "$BRANCH"
-
-          TITLE_PARTS=()
-          BODY_LINES=()
-
-          if [ "$IOS_CHANGED" = "true" ]; then
-            sed -i '' \
-              "s/stripe_version = '[^']*'/stripe_version = '${IOS_NEW}'/" \
-              stripe-react-native.podspec
-            git add stripe-react-native.podspec
-            TITLE_PARTS+=("stripe-ios ${IOS_NEW}")
-            BODY_LINES+=("- \`stripe-react-native.podspec\`: \`stripe_version\` → \`${IOS_NEW}\` ([release notes](https://github.com/stripe/stripe-ios/releases/tag/${IOS_NEW}))")
-          fi
-
-          if [ "$ANDROID_CHANGED" = "true" ]; then
-            sed -i '' \
-              "s/^StripeSdk_stripeVersion=.*/StripeSdk_stripeVersion=${ANDROID_NEW}/" \
-              android/gradle.properties
-            git add android/gradle.properties
-            TITLE_PARTS+=("stripe-android ${ANDROID_NEW}")
-            BODY_LINES+=("- \`android/gradle.properties\`: \`StripeSdk_stripeVersion\` → \`${ANDROID_NEW}\` ([release notes](https://github.com/stripe/stripe-android/releases/tag/v${ANDROID_NEW}))")
-          fi
-
-          TITLE="chore: bump $(IFS=', '; echo "${TITLE_PARTS[*]}")"
-
-          BODY="$(IFS=$'\n'; echo "${BODY_LINES[*]}")
-
-          _Automated by [\`bump-native-sdks\`](.github/workflows/bump-native-sdks.yml)_"
-
-          # Update Podfile.lock so CI runs against the new stripe-ios version
-          if [ "$IOS_CHANGED" = "true" ]; then
-            yarn install
-            yarn --cwd example
-            cd example/ios && pod install --repo-update && cd ../..
-            git add example/ios/Podfile.lock
-          fi
-
-          git commit -m "$TITLE"
-          git push origin "$BRANCH"
-
-          gh pr create \
-            --title "$TITLE" \
-            --body  "$BODY"  \
-            --base  master   \
-            --head  "$BRANCH"
+      - name: Update files and open PR
+        env:
+          GH_TOKEN: ${{ secrets.NATIVE_SDK_BUMP_TOKEN }}
+        run: ./scripts/bump_native_sdks.rb --create-pr

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "lint": "eslint \"**/*.{js,ts,tsx}\" --ignore-pattern \"docs/api-reference/*\" --ignore-path .gitignore",
     "prepare": "bob build && rm -rf lib/*/package.json && husky",
     "propose": "./scripts/propose.rb",
+    "bump-native-sdks": "./scripts/bump_native_sdks.rb",
     "release": "./scripts/publish.rb",
     "example": "yarn --cwd example",
     "pods": "cd example && npx pod-install --quiet",

--- a/scripts/bump_native_sdks.rb
+++ b/scripts/bump_native_sdks.rb
@@ -1,0 +1,87 @@
+#!/usr/bin/env ruby
+
+require 'optparse'
+require 'shellwords'
+require_relative 'helpers'
+require_relative 'native_sdk_versions'
+
+class NativeSdkBumper
+  def initialize(root: Dir.pwd)
+    @root = root
+    @updater = NativeSdkVersions.new(root: root)
+  end
+
+  def update
+    puts "Fetching latest native SDK releases"
+    versions = @updater.latest
+    changes = @updater.apply(versions)
+
+    changes.each do |change|
+      status = change.changed ? "#{change.previous_version} -> #{change.version}" : "already at #{change.version}"
+      puts "#{change.name}: #{status}"
+    end
+
+    [changes, versions]
+  rescue NativeSdkVersions::Error => e
+    abort "Error! #{e.message}"
+  end
+end
+
+def create_pr(changes, versions)
+  changed = changes.select(&:changed)
+  if changed.empty?
+    puts "Native SDK versions are already up to date; no PR needed."
+    return
+  end
+
+  branch = "chore/bump-native-sdks"
+  branch += "-ios-#{versions.fetch(:ios)}" if changes.find { |change| change.name == 'stripe-ios' && change.changed }
+  branch += "-android-#{versions.fetch(:android)}" if changes.find { |change| change.name == 'stripe-android' && change.changed }
+
+  existing_pr = `gh pr list --state open --head #{branch.shellescape} --json number --jq '.[0].number'`.strip
+  abort "A PR is already open for #{branch} (##{existing_pr})." unless existing_pr.empty?
+
+  execute_or_fail("git checkout -b #{branch.shellescape}")
+
+  ios_changed = changed.any? { |change| change.name == 'stripe-ios' }
+  execute_or_fail("yarn update-pods") if ios_changed
+
+  files = changed.map(&:path)
+  files << 'example/ios/Podfile.lock' if ios_changed
+  execute_or_fail("git add #{files.map(&:shellescape).join(' ')}")
+
+  title_parts = changed.map { |change| "#{change.name} #{change.version}" }
+  title = "chore: bump #{title_parts.join(', ')}"
+  body = changed.map do |change|
+    release_tag = change.name == 'stripe-ios' ? change.version : "v#{change.version}"
+    "- `#{change.path}`: `#{change.previous_version}` -> `#{change.version}` (https://github.com/stripe/#{change.name}/releases/tag/#{release_tag})"
+  end.join("\n")
+  body += "\n\n_Automated by [`bump_native_sdks.rb`](scripts/bump_native_sdks.rb)_"
+
+  execute_or_fail("git commit -m #{title.shellescape}")
+  execute_or_fail("git push -u origin #{branch.shellescape}")
+  execute_or_fail("gh pr create --repo stripe/stripe-react-native --base master --head #{branch.shellescape} --title #{title.shellescape} --body #{body.shellescape}")
+end
+
+if __FILE__ == $PROGRAM_NAME
+  create_pr_mode = false
+  OptionParser.new do |opts|
+    opts.banner = <<~BANNER
+      USAGE:
+          ./scripts/bump_native_sdks.rb [--create-pr]
+
+      Updates the stripe-ios and stripe-android pins to their latest GitHub
+      releases. With --create-pr, creates a branch, commits the changes, pushes
+      it, and opens a pull request.
+    BANNER
+
+    opts.on('--create-pr', 'Create and push a native SDK version bump PR') { create_pr_mode = true }
+    opts.on('-h', '--help', 'Show this help message') { puts opts; exit }
+  end.parse!
+
+  Dir.chdir(`git rev-parse --show-toplevel`.strip)
+
+  bumper = NativeSdkBumper.new
+  changes, versions = bumper.update
+  create_pr(changes, versions) if create_pr_mode
+end

--- a/scripts/propose.rb
+++ b/scripts/propose.rb
@@ -5,7 +5,7 @@ require 'date'
 require 'tmpdir'
 require 'shellwords'
 require_relative 'helpers'
-require_relative 'native_sdk_versions'
+require_relative 'bump_native_sdks'
 
 @release_type = nil
 
@@ -42,22 +42,12 @@ def bump_version(version)
   execute_or_fail("yarn version --no-git-tag-version --new-version #{version}")
 end
 
-def create_proposal_pr(version, native_sdk_updater, native_sdk_versions)
+def create_proposal_pr(version, native_sdk_changes, native_sdk_versions)
   branch = "release/propose-#{version}"
   execute_or_fail("git checkout -b #{branch}")
 
   bump_version(version)
   update_changelog(version)
-  begin
-    native_sdk_changes = native_sdk_updater.apply(native_sdk_versions)
-  rescue NativeSdkVersions::Error => e
-    abort "Error! #{e.message}"
-  end
-  native_sdk_changes.each do |change|
-    status = change.changed ? "#{change.previous_version} -> #{change.version}" : "already at #{change.version}"
-    puts "#{change.name}: #{status}"
-  end
-
   ios_changed = native_sdk_changes.any? { |change| change.name == 'stripe-ios' && change.changed }
   execute_or_fail("yarn update-pods") if ios_changed
 
@@ -128,11 +118,5 @@ preflight_checks
 
 version = next_version
 puts "Proposing #{version} (currently #{current_version})"
-native_sdk_updater = NativeSdkVersions.new
-puts "Fetching latest native SDK releases"
-begin
-  native_sdk_versions = native_sdk_updater.latest
-rescue NativeSdkVersions::Error => e
-  abort "Error! #{e.message}"
-end
-create_proposal_pr(version, native_sdk_updater, native_sdk_versions)
+native_sdk_changes, native_sdk_versions = NativeSdkBumper.new.update
+create_proposal_pr(version, native_sdk_changes, native_sdk_versions)


### PR DESCRIPTION
## Summary

- Extract iOS and Android SDK version bumping into a reusable script.
- Keep release proposal deploys running the bumper.
- Add standalone yarn bump-native-sdks --create-pr support and use it from the scheduled workflow.

## Validation

- Ruby syntax checks passed.
- Native SDK version tests passed (6 runs, 15 assertions).
- git diff --check passed.