### PR TITLE
Add supportedNetworks to Apple Pay platform pay params

### DIFF
--- a/ios/ApplePayUtils.swift
+++ b/ios/ApplePayUtils.swift
@@ -67,6 +67,10 @@ class ApplePayUtils {
             }
         }
 
+        if let supportedNetworks = params["supportedNetworks"] as? [String] {
+            paymentRequest.supportedNetworks = ApplePayUtils.mapToArrayOfPaymentNetworks(arrayOfStrings: supportedNetworks)
+        }
+
         paymentRequest.shippingType = ApplePayUtils.getShippingTypeFrom(string: params["shippingType"] as? String)
         if let supportedCountries = params["supportedCountries"] as? Set<String> {
             paymentRequest.supportedCountries = supportedCountries

--- a/ios/Tests/ApplePayUtilsTests.swift
+++ b/ios/Tests/ApplePayUtilsTests.swift
@@ -7,6 +7,7 @@
 //
 
 import PassKit
+import StripePaymentSheet
 @testable import stripe_react_native
 import XCTest
 
@@ -420,6 +421,33 @@ class ApplePayUtilsTests: XCTestCase {
 
         XCTAssertEqual(result.count, 1)
         XCTAssertEqual(result[0].rawValue, "customNetwork")
+    }
+
+    func test_createPaymentRequest_withSupportedNetworks_restrictsNetworks() {
+        let params: NSDictionary = [
+            "merchantCountryCode": TestFixtures.COUNTRY_CODE,
+            "currencyCode": "USD",
+            "cartItems": [TestFixtures.IMMEDIATE_CART_ITEM_DICTIONARY],
+            "supportedNetworks": ["Visa", "MasterCard"],
+        ]
+
+        let (error, paymentRequest) = ApplePayUtils.createPaymentRequest(merchantIdentifier: TestFixtures.MERCHANT_ID, params: params)
+
+        XCTAssertNil(error)
+        XCTAssertEqual(paymentRequest?.supportedNetworks, [.visa, .masterCard])
+    }
+
+    func test_createPaymentRequest_withoutSupportedNetworks_keepsDefaultNetworks() {
+        let params: NSDictionary = [
+            "merchantCountryCode": TestFixtures.COUNTRY_CODE,
+            "currencyCode": "USD",
+            "cartItems": [TestFixtures.IMMEDIATE_CART_ITEM_DICTIONARY],
+        ]
+
+        let (error, paymentRequest) = ApplePayUtils.createPaymentRequest(merchantIdentifier: TestFixtures.MERCHANT_ID, params: params)
+
+        XCTAssertNil(error)
+        XCTAssertEqual(paymentRequest?.supportedNetworks, StripeAPI.supportedPKPaymentNetworks())
     }
 
     private struct TestFixtures {

--- a/src/types/PlatformPay.ts
+++ b/src/types/PlatformPay.ts
@@ -51,6 +51,8 @@ export type ApplePayBaseParams = {
   currencyCode: string;
   /** The SDK accepts Amex, Mastercard, Visa, and Discover for Apple Pay by default. Set this property to enable other card networks, for example: ["JCB", "barcode", "chinaUnionPay"]. A full list of possible networks can be found at https://developer.apple.com/documentation/passkit/pkpaymentnetwork. */
   additionalEnabledNetworks?: Array<string>;
+  /** Restricts the Apple Pay sheet to the given card networks, replacing the default set entirely: cards on any other network are not selectable. Use the raw values of PKPaymentNetwork, for example: ["Visa", "MasterCard"]. A full list of possible networks can be found at https://developer.apple.com/documentation/passkit/pkpaymentnetwork. When omitted, the SDK's default networks (plus `additionalEnabledNetworks`) apply. */
+  supportedNetworks?: Array<string>;
   /** The list of items that describe a purchase. For example: total, tax, discount, and grand total. The final item should represent your company and the total; it'll be prepended with the word "Pay" (for example, "Pay Example Company $50"). */
   cartItems: Array<CartSummaryItem>;
   /** The list of fields that you need for a shipping contact in order to process the transaction. If you include ContactField.PostalAddress in this array, you must implement the PlatformPayButton component's `onShippingContactSelected` callback and call `updatePlatformPaySheet` from there.*/


### PR DESCRIPTION
## Summary

Adds an optional `supportedNetworks` field to `ApplePayBaseParams`. When set, it replaces the default card network set on the `PKPaymentRequest` built by `ApplePayUtils.createPaymentRequest`, so cards on other networks are greyed out in the Apple Pay sheet. When omitted, behavior is unchanged (SDK defaults plus `additionalEnabledNetworks`). Values are `PKPaymentNetwork` raw values, mapped through the existing `mapToArrayOfPaymentNetworks` helper.

## Motivation

The platform-pay flow currently has no way to *restrict* Apple Pay card networks: `additionalEnabledNetworks` is additive on top of the default (Amex, Mastercard, Visa, Discover), and `cardBrandAcceptance` only exists on the PaymentSheet API. A merchant that cannot accept one of the default networks (e.g. Amex) has no client-side option on this path — the card is selectable in the sheet and the payment has to be declined server-side after the customer has already confirmed. PaymentSheet's card brand filtering achieves the greyed-out-in-sheet UX by restricting `PKPaymentRequest.supportedNetworks`; this exposes the same lever to platform-pay integrations.

This also benefits downstream bindings that sync this native code — flutter-stripe/flutter_stripe#2451 is the Flutter side of the same change, held pending this landing here.

Note: AI (Claude Code) was used to draft this change and PR; the diff was reviewed and verified as described below.

## Testing
- [ ] I tested this manually
- [x] I added automated tests

Two XCTest cases in `ApplePayUtilsTests`: `supportedNetworks` restricts `paymentRequest.supportedNetworks` to the mapped list, and omitting it keeps `StripeAPI.supportedPKPaymentNetworks()`. Ran `yarn test` (106 passing) and `tsc --noEmit` locally; iOS unit tests rely on CI (no Xcode toolchain on this machine).

## Documentation

Select one:
- [x] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
