### PR TITLE
feat(ios): support `supportedNetworks` in `ApplePayBaseParams`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Unreleased
+**Features**
+* [Added] iOS: Added `supportedNetworks` to the Apple Pay params, which restricts the card networks offered in the Apple Pay sheet.
+
 ## 0.73.0 - 2026-08-04
 **Changes**
 * Updated Stripe iOS SDK from 26.4.1 to 26.5.0.

--- a/etc/stripe-react-native.api.md
+++ b/etc/stripe-react-native.api.md
@@ -271,6 +271,7 @@ type ApplePayBaseParams = {
     merchantCountryCode: string;
     currencyCode: string;
     additionalEnabledNetworks?: Array<string>;
+    supportedNetworks?: Array<string>;
     cartItems: Array<CartSummaryItem_2>;
     requiredShippingAddressFields?: Array<ContactField>;
     requiredBillingContactFields?: Array<ContactField>;

--- a/ios/ApplePayUtils.swift
+++ b/ios/ApplePayUtils.swift
@@ -40,6 +40,10 @@ class ApplePayUtils {
 
         let paymentRequest = StripeAPI.paymentRequest(withMerchantIdentifier: merchantIdentifier, country: countryCode, currency: currencyCode)
 
+        if let supportedNetworks = params["supportedNetworks"] as? [String] {
+            paymentRequest.supportedNetworks = ApplePayUtils.mapToArrayOfPaymentNetworks(arrayOfStrings: supportedNetworks)
+        }
+
         let requiredShippingAddressFields = params["requiredShippingAddressFields"] as? NSArray ?? NSArray()
         let requiredBillingContactFields = params["requiredBillingContactFields"] as? NSArray ?? NSArray()
         let shippingMethods = params["shippingMethods"] as? NSArray ?? NSArray()

--- a/ios/Tests/ApplePayUtilsTests.swift
+++ b/ios/Tests/ApplePayUtilsTests.swift
@@ -8,10 +8,16 @@
 
 import PassKit
 @testable import stripe_react_native
+import StripePaymentSheet
 import XCTest
 
 @available(iOS 15.0, *)
 class ApplePayUtilsTests: XCTestCase {
+
+    override func tearDown() {
+        StripeAPI.additionalEnabledApplePayNetworks = []
+        super.tearDown()
+    }
 
     func test_buildPaymentSheetApplePayConfig_FailsWithoutMerchantIdentifier() throws {
         XCTAssertThrowsError(
@@ -420,6 +426,55 @@ class ApplePayUtilsTests: XCTestCase {
 
         XCTAssertEqual(result.count, 1)
         XCTAssertEqual(result[0].rawValue, "customNetwork")
+    }
+
+    // MARK: - createPaymentRequest Tests
+
+    func test_createPaymentRequest_supportedNetworksRestrictsNetworks() {
+        let params: NSDictionary = [
+            "merchantCountryCode": TestFixtures.COUNTRY_CODE,
+            "currencyCode": "USD",
+            "cartItems": TestFixtures.CART_ITEM_DICTIONARY,
+            "supportedNetworks": ["Visa", "MasterCard"],
+        ]
+
+        let (error, paymentRequest) = ApplePayUtils.createPaymentRequest(
+            merchantIdentifier: TestFixtures.MERCHANT_ID, params: params)
+
+        XCTAssertNil(error)
+        XCTAssertEqual(paymentRequest?.supportedNetworks, [.visa, .masterCard])
+    }
+
+    func test_createPaymentRequest_withoutSupportedNetworksKeepsDefaults() {
+        let params: NSDictionary = [
+            "merchantCountryCode": TestFixtures.COUNTRY_CODE,
+            "currencyCode": "USD",
+            "cartItems": TestFixtures.CART_ITEM_DICTIONARY,
+        ]
+
+        let (error, paymentRequest) = ApplePayUtils.createPaymentRequest(
+            merchantIdentifier: TestFixtures.MERCHANT_ID, params: params)
+
+        XCTAssertNil(error)
+        // Defaults are left untouched, so the SDK's standard networks still apply.
+        XCTAssertTrue(paymentRequest?.supportedNetworks.contains(.amex) ?? false)
+        XCTAssertTrue(paymentRequest?.supportedNetworks.contains(.visa) ?? false)
+    }
+
+    func test_createPaymentRequest_supportedNetworksOverridesAdditionalEnabledNetworks() {
+        let params: NSDictionary = [
+            "merchantCountryCode": TestFixtures.COUNTRY_CODE,
+            "currencyCode": "USD",
+            "cartItems": TestFixtures.CART_ITEM_DICTIONARY,
+            "additionalEnabledNetworks": ["JCB"],
+            "supportedNetworks": ["Visa"],
+        ]
+
+        let (error, paymentRequest) = ApplePayUtils.createPaymentRequest(
+            merchantIdentifier: TestFixtures.MERCHANT_ID, params: params)
+
+        XCTAssertNil(error)
+        XCTAssertEqual(paymentRequest?.supportedNetworks, [.visa])
     }
 
     private struct TestFixtures {

--- a/src/types/PlatformPay.ts
+++ b/src/types/PlatformPay.ts
@@ -51,6 +51,8 @@ export type ApplePayBaseParams = {
   currencyCode: string;
   /** The SDK accepts Amex, Mastercard, Visa, and Discover for Apple Pay by default. Set this property to enable other card networks, for example: ["JCB", "barcode", "chinaUnionPay"]. A full list of possible networks can be found at https://developer.apple.com/documentation/passkit/pkpaymentnetwork. */
   additionalEnabledNetworks?: Array<string>;
+  /** Set this property to restrict the card networks accepted for this payment, for example: ["Visa", "MasterCard"]. Overrides the default networks, including any set in `additionalEnabledNetworks`. A full list of possible networks can be found at https://developer.apple.com/documentation/passkit/pkpaymentnetwork. */
+  supportedNetworks?: Array<string>;
   /** The list of items that describe a purchase. For example: total, tax, discount, and grand total. The final item should represent your company and the total; it'll be prepended with the word "Pay" (for example, "Pay Example Company $50"). */
   cartItems: Array<CartSummaryItem>;
   /** The list of fields that you need for a shipping contact in order to process the transaction. If you include ContactField.PostalAddress in this array, you must implement the PlatformPayButton component's `onShippingContactSelected` callback and call `updatePlatformPaySheet` from there.*/

--- a/src/types/PlatformPay.ts
+++ b/src/types/PlatformPay.ts
@@ -51,7 +51,7 @@ export type ApplePayBaseParams = {
   currencyCode: string;
   /** The SDK accepts Amex, Mastercard, Visa, and Discover for Apple Pay by default. Set this property to enable other card networks, for example: ["JCB", "barcode", "chinaUnionPay"]. A full list of possible networks can be found at https://developer.apple.com/documentation/passkit/pkpaymentnetwork. */
   additionalEnabledNetworks?: Array<string>;
-  /** Set this property to restrict the card networks accepted for this payment, for example: ["Visa", "MasterCard"]. Overrides the default networks, including any set in `additionalEnabledNetworks`. A full list of possible networks can be found at https://developer.apple.com/documentation/passkit/pkpaymentnetwork. */
+  /** Set this property to only allow specific card networks for this payment, for example: ["Visa", "MasterCard"]. Overrides the default networks, including any set in `additionalEnabledNetworks`. A full list of possible networks can be found at https://developer.apple.com/documentation/passkit/pkpaymentnetwork. */
   supportedNetworks?: Array<string>;
   /** The list of items that describe a purchase. For example: total, tax, discount, and grand total. The final item should represent your company and the total; it'll be prepended with the word "Pay" (for example, "Pay Example Company $50"). */
   cartItems: Array<CartSummaryItem>;


### PR DESCRIPTION
## Summary
This PR adds an optional `supportedNetworks` param to the Apple Pay params, which overrides `PKPaymentRequest.supportedNetworks` on the request built in `ApplePayUtils.createPaymentRequest`.

I have read through the contribution guidelines and done my best to adhere to them. Please let me know if there are any changes you'd like to see.

## Motivation
`additionalEnabledNetworks` is additive only, so on the PlatformPay path there is currently no way to decline a card network that's on by default (in my case, Amex). Setting `supportedNetworks` replaces the default set instead of adding to it.

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [ ] I tested this manually
- [x] I added automated tests
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Documentation

Select one: 
- [x] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
