### PR TITLE
Propose 0.74.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## Unreleased
+## 0.74.0 - 2026-08-11
 **Features**
 * [Added] iOS: Added `supportedNetworks` to the Apple Pay params, which restricts the card networks offered in the Apple Pay sheet.
 

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -3,4 +3,4 @@ StripeSdk_compileSdkVersion=36
 StripeSdk_targetSdkVersion=36
 StripeSdk_minSdkVersion=23
 # Keep StripeSdk_stripeVersion in sync with https://github.com/stripe/stripe-identity-react-native/blob/main/android/gradle.properties
-StripeSdk_stripeVersion=23.14.0
+StripeSdk_stripeVersion=23.15.0

--- a/android/src/onramp/java/com/reactnativestripesdk/OnrampMappers.kt
+++ b/android/src/onramp/java/com/reactnativestripesdk/OnrampMappers.kt
@@ -186,6 +186,7 @@ internal fun mapPaymentDetailsType(type: PaymentMethodDisplayData.Type): String 
     PaymentMethodDisplayData.Type.Card -> "Card"
     PaymentMethodDisplayData.Type.BankAccount -> "BankAccount"
     PaymentMethodDisplayData.Type.GooglePay -> "GooglePay"
+    PaymentMethodDisplayData.Type.SamsungPay -> "SamsungPay"
   }
 
 @OptIn(ExperimentalCryptoOnramp::class)

--- a/android/src/test/java/com/reactnativestripesdk/mappers/OnrampMappersTest.kt
+++ b/android/src/test/java/com/reactnativestripesdk/mappers/OnrampMappersTest.kt
@@ -452,6 +452,7 @@ class OnrampMappersTest {
     assertEquals("Card", mapPaymentDetailsType(PaymentMethodDisplayData.Type.Card))
     assertEquals("BankAccount", mapPaymentDetailsType(PaymentMethodDisplayData.Type.BankAccount))
     assertEquals("GooglePay", mapPaymentDetailsType(PaymentMethodDisplayData.Type.GooglePay))
+    assertEquals("SamsungPay", mapPaymentDetailsType(PaymentMethodDisplayData.Type.SamsungPay))
   }
 
   @Test

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1820,14 +1820,14 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - Stripe (26.5.0):
-    - StripeApplePay (= 26.5.0)
-    - StripeCore (= 26.5.0)
-    - StripeIssuing (= 26.5.0)
-    - StripePayments (= 26.5.0)
-    - StripePaymentsUI (= 26.5.0)
-    - StripeUICore (= 26.5.0)
-  - stripe-react-native (0.72.0):
+  - Stripe (26.6.0):
+    - StripeApplePay (= 26.6.0)
+    - StripeCore (= 26.6.0)
+    - StripeIssuing (= 26.6.0)
+    - StripePayments (= 26.6.0)
+    - StripePaymentsUI (= 26.6.0)
+    - StripeUICore (= 26.6.0)
+  - stripe-react-native (0.74.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1848,10 +1848,10 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-    - stripe-react-native/Core (= 0.72.0)
-    - stripe-react-native/NewArch (= 0.72.0)
+    - stripe-react-native/Core (= 0.74.0)
+    - stripe-react-native/NewArch (= 0.74.0)
     - Yoga
-  - stripe-react-native/Core (0.72.0):
+  - stripe-react-native/Core (0.74.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1872,14 +1872,14 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-    - Stripe (= 26.5.0)
-    - StripeApplePay (= 26.5.0)
-    - StripeFinancialConnections (= 26.5.0)
-    - StripePayments (= 26.5.0)
-    - StripePaymentSheet (= 26.5.0)
-    - StripePaymentsUI (= 26.5.0)
+    - Stripe (= 26.6.0)
+    - StripeApplePay (= 26.6.0)
+    - StripeFinancialConnections (= 26.6.0)
+    - StripePayments (= 26.6.0)
+    - StripePaymentSheet (= 26.6.0)
+    - StripePaymentsUI (= 26.6.0)
     - Yoga
-  - stripe-react-native/NewArch (0.72.0):
+  - stripe-react-native/NewArch (0.74.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1901,7 +1901,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - stripe-react-native/Onramp (0.72.0):
+  - stripe-react-native/Onramp (0.74.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1923,9 +1923,9 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - stripe-react-native/Core
-    - StripeCryptoOnramp (= 26.5.0)
+    - StripeCryptoOnramp (= 26.6.0)
     - Yoga
-  - stripe-react-native/Tests (0.72.0):
+  - stripe-react-native/Tests (0.74.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1947,46 +1947,46 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - StripeApplePay (26.5.0):
-    - StripeCore (= 26.5.0)
-  - StripeCameraCore (26.5.0):
-    - StripeCore (= 26.5.0)
-  - StripeCore (26.5.0)
-  - StripeCryptoOnramp (26.5.0):
-    - StripeApplePay (= 26.5.0)
-    - StripeCore (= 26.5.0)
-    - StripeIdentity (= 26.5.0)
-    - StripePayments (= 26.5.0)
-    - StripePaymentSheet (= 26.5.0)
-    - StripePaymentsUI (= 26.5.0)
-    - StripeUICore (= 26.5.0)
-  - StripeFinancialConnections (26.5.0):
-    - StripeCore (= 26.5.0)
-    - StripeUICore (= 26.5.0)
-  - StripeIdentity (26.5.0):
-    - StripeCameraCore (= 26.5.0)
-    - StripeCore (= 26.5.0)
-    - StripeUICore (= 26.5.0)
-  - StripeIssuing (26.5.0):
-    - StripeCore (= 26.5.0)
-    - StripePayments (= 26.5.0)
-    - StripePaymentsUI (= 26.5.0)
-  - StripePayments (26.5.0):
-    - StripeCore (= 26.5.0)
-    - StripePayments/Stripe3DS2 (= 26.5.0)
-  - StripePayments/Stripe3DS2 (26.5.0):
-    - StripeCore (= 26.5.0)
-  - StripePaymentSheet (26.5.0):
-    - StripeApplePay (= 26.5.0)
-    - StripeCore (= 26.5.0)
-    - StripePayments (= 26.5.0)
-    - StripePaymentsUI (= 26.5.0)
-  - StripePaymentsUI (26.5.0):
-    - StripeCore (= 26.5.0)
-    - StripePayments (= 26.5.0)
-    - StripeUICore (= 26.5.0)
-  - StripeUICore (26.5.0):
-    - StripeCore (= 26.5.0)
+  - StripeApplePay (26.6.0):
+    - StripeCore (= 26.6.0)
+  - StripeCameraCore (26.6.0):
+    - StripeCore (= 26.6.0)
+  - StripeCore (26.6.0)
+  - StripeCryptoOnramp (26.6.0):
+    - StripeApplePay (= 26.6.0)
+    - StripeCore (= 26.6.0)
+    - StripeIdentity (= 26.6.0)
+    - StripePayments (= 26.6.0)
+    - StripePaymentSheet (= 26.6.0)
+    - StripePaymentsUI (= 26.6.0)
+    - StripeUICore (= 26.6.0)
+  - StripeFinancialConnections (26.6.0):
+    - StripeCore (= 26.6.0)
+    - StripeUICore (= 26.6.0)
+  - StripeIdentity (26.6.0):
+    - StripeCameraCore (= 26.6.0)
+    - StripeCore (= 26.6.0)
+    - StripeUICore (= 26.6.0)
+  - StripeIssuing (26.6.0):
+    - StripeCore (= 26.6.0)
+    - StripePayments (= 26.6.0)
+    - StripePaymentsUI (= 26.6.0)
+  - StripePayments (26.6.0):
+    - StripeCore (= 26.6.0)
+    - StripePayments/Stripe3DS2 (= 26.6.0)
+  - StripePayments/Stripe3DS2 (26.6.0):
+    - StripeCore (= 26.6.0)
+  - StripePaymentSheet (26.6.0):
+    - StripeApplePay (= 26.6.0)
+    - StripeCore (= 26.6.0)
+    - StripePayments (= 26.6.0)
+    - StripePaymentsUI (= 26.6.0)
+  - StripePaymentsUI (26.6.0):
+    - StripeCore (= 26.6.0)
+    - StripePayments (= 26.6.0)
+    - StripeUICore (= 26.6.0)
+  - StripeUICore (26.6.0):
+    - StripeCore (= 26.6.0)
   - Yoga (0.0.0)
 
 DEPENDENCIES:
@@ -2311,21 +2311,21 @@ SPEC CHECKSUMS:
   RNCAsyncStorage: 3a4f5e2777dae1688b781a487923a08569e27fe4
   RNCPicker: c8a3584b74133464ee926224463fcc54dfdaebca
   RNScreens: 61c18865ab074f4d995ac8d7cf5060522a649d05
-  Stripe: 42c446f3f3ee60c2e96aa27491fd88cb849a3887
-  stripe-react-native: a58169e34430b180e14c015e6c1218475711f5da
-  StripeApplePay: d6e62eb6150d7739e7a6aff99d3ed69905461fc4
-  StripeCameraCore: a404c9e95a0906668f62c40ce6ee15a890e6607f
-  StripeCore: ccde420bc8e878df43d356f8661702b921ace869
-  StripeCryptoOnramp: 8cde3d01016a7d99c0f25e644e3d1c8fe2fd97ae
-  StripeFinancialConnections: fb8e12e36d2e5e79a1b5413c72900a9bf571fbe2
-  StripeIdentity: a773235907c17ae6c4a4b83492bdf365a89dc256
-  StripeIssuing: 104bad01e6a872713b81d44821eebc958a49d6cf
-  StripePayments: 43fb89181afd417966fa1e8bf7b8a0e5c85eb9ac
-  StripePaymentSheet: dbe9a57e2cef4d54630b56511f501d2c355e102d
-  StripePaymentsUI: 71c5666d50b62889d5f935f283ba6afb88135533
-  StripeUICore: aa5d5a1ff0e8a090078303915a5c14a0bce80a01
+  Stripe: 2aa937a5b3dc1db7b42392a70cd4d4534dd2e77b
+  stripe-react-native: b75bf2cb4c4714876b2efd808532d34fa924eae2
+  StripeApplePay: 73d55b6586e0acf7c5897100bf3dc7924488cf2d
+  StripeCameraCore: d3a281318aae77233616ce0336572afe7000db7c
+  StripeCore: 06bafa6087c3fa240460d9feb6729543d1634961
+  StripeCryptoOnramp: 8953cc4ac938ffeedf524f3f9c6bc9d0ecaa9d79
+  StripeFinancialConnections: 648b3cba2b42198fce9c1f3e5f997543031a76f4
+  StripeIdentity: 0ea131379bb6d78c50dfa57861d1ff1d3472d74f
+  StripeIssuing: dfd966fd0c32dc2d38c5cea8f18d88969967eaaf
+  StripePayments: c20f9058b588fb4f677822d6d415d8d59ae21fc3
+  StripePaymentSheet: 87e00057a5867f6a594bd1285494b6efe43639a9
+  StripePaymentsUI: 8af6ccdeea136ef2c8b942b27e6a33c4ff84e877
+  StripeUICore: 500ec9fd1c7c733a33f28c6a4b75423b87496ee4
   Yoga: 5934998fbeaef7845dbf698f698518695ab4cd1a
 
 PODFILE CHECKSUM: 605f3cad878b7c0eee93ebb4a78a8141d34cd328
 
-COCOAPODS: 1.17.0
+COCOAPODS: 1.16.2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stripe/stripe-react-native",
-  "version": "0.73.0",
+  "version": "0.74.0",
   "author": "Stripe",
   "description": "Stripe SDK for React Native",
   "main": "lib/commonjs/index",

--- a/stripe-react-native.podspec
+++ b/stripe-react-native.podspec
@@ -2,7 +2,7 @@ require 'json'
 
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 # Keep stripe_version in sync with https://github.com/stripe/stripe-identity-react-native/blob/main/stripe-identity-react-native.podspec
-stripe_version = '26.5.0'
+stripe_version = '26.6.0'
 
 fabric_enabled = ENV['RCT_NEW_ARCH_ENABLED'] == '1'
 


### PR DESCRIPTION
- [x] Ensure the CHANGELOG is up to date with all relevant commits since the last release
- [x] Add the version number for this release & the date to the CHANGELOG, underneath "## Unreleased"
  - e.g. "## 1.2.3 - 2022-02-14"
- [x] Update stripe-ios to the latest GitHub release (26.6.0)
- [x] Update stripe-android to the latest GitHub release (23.15.0)
- [x] Update the README if necessary (this is only required when there are breaking changes in the release, such as dropping support for an iOS || Android version)
