### PR TITLE
CryptoOnramp SDK: Adds Missing Error Types for Wallet Verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Unreleased
+**Features**
+* [Added] Added typed Crypto Onramp error coverage for wallet ownership verification failures.
+
 ## 0.74.0 - 2026-08-11
 **Features**
 * [Added] iOS: Added `supportedNetworks` to the Apple Pay params, which restricts the card networks offered in the Apple Pay sheet.

--- a/android/src/onramp/java/com/reactnativestripesdk/OnrampErrors.kt
+++ b/android/src/onramp/java/com/reactnativestripesdk/OnrampErrors.kt
@@ -86,10 +86,17 @@ private fun createOnrampMessageError(
   createOnrampErrorMap(code = code, message = message)
 
 private fun CryptoOnrampApiException.toOnrampErrorType(): String =
-  if (code == "link_failed_to_attest_request") {
-    "AppAttestationError"
-  } else {
-    "UncategorizedApiError"
+  when (code) {
+    "link_failed_to_attest_request" -> "AppAttestationError"
+    "crypto_onramp_invalid_wallet_ownership_signature" ->
+      "InvalidWalletOwnershipSignatureError"
+    "crypto_onramp_wallet_ownership_challenge_expired" ->
+      "WalletOwnershipChallengeExpiredError"
+    "crypto_onramp_invalid_wallet_ownership_challenge" ->
+      "InvalidWalletOwnershipChallengeError"
+    "crypto_onramp_wallet_not_found" -> "WalletNotFoundError"
+    "crypto_onramp_unsupported_network" -> "UnsupportedNetworkError"
+    else -> "UncategorizedApiError"
   }
 
 private fun StripeCryptoOnrampError.toOnrampErrorType(): String? =

--- a/android/src/test/java/com/reactnativestripesdk/OnrampErrorsTest.kt
+++ b/android/src/test/java/com/reactnativestripesdk/OnrampErrorsTest.kt
@@ -99,6 +99,47 @@ class OnrampErrorsTest {
   }
 
   @Test
+  fun createOnrampFailedError_withWalletOwnershipApiError_mapsSpecificErrorType() {
+    val testCases =
+      mapOf(
+        "crypto_onramp_invalid_wallet_ownership_signature" to
+          "InvalidWalletOwnershipSignatureError",
+        "crypto_onramp_wallet_ownership_challenge_expired" to
+          "WalletOwnershipChallengeExpiredError",
+        "crypto_onramp_invalid_wallet_ownership_challenge" to
+          "InvalidWalletOwnershipChallengeError",
+        "crypto_onramp_wallet_not_found" to "WalletNotFoundError",
+        "crypto_onramp_unsupported_network" to "UnsupportedNetworkError",
+      )
+
+    testCases.forEach { (apiErrorCode, expectedType) ->
+      val error =
+        createApiOnrampException(
+          className = "com.stripe.android.crypto.onramp.exception.UncategorizedException",
+          reason = "wallet_verification_failed",
+          operation = "submitWalletOwnershipSignature",
+          appPackageName = "com.example.app",
+          mode = "test",
+          sdkVersions = listOf(SDKVersion(name = "stripe-android", version = "23.15.0")),
+          userMessage = "Wallet ownership verification failed.",
+          apiErrorCode = apiErrorCode,
+          apiErrorType = "invalid_request_error",
+          apiErrorMessage = "Wallet ownership verification failed.",
+          apiUserMessage = "Please try again.",
+          requestId = "req_wallet_verification",
+        )
+
+      val details = createOnrampFailedError(error).getMap("error")
+
+      assertNotNull(apiErrorCode, details)
+      assertEquals(apiErrorCode, expectedType, details!!.getString("onrampErrorType"))
+      assertEquals(apiErrorCode, apiErrorCode, details.getString("apiErrorCode"))
+      assertEquals(apiErrorCode, "wallet_verification_failed", details.getString("reason"))
+      assertEquals(apiErrorCode, "req_wallet_verification", details.getString("requestId"))
+    }
+  }
+
+  @Test
   fun createOnrampFailedError_withAppAttestationUnavailableException_preservesSdkErrorFields() {
     val underlyingError = IllegalStateException("Native Link is not available")
     val error =
@@ -148,7 +189,7 @@ class OnrampErrorsTest {
     apiErrorType: String,
     apiErrorMessage: String,
     apiUserMessage: String,
-    docUrl: String,
+    docUrl: String? = null,
     requestId: String,
   ): Exception {
     val stripeError =

--- a/etc/stripe-react-native.api.md
+++ b/etc/stripe-react-native.api.md
@@ -1477,7 +1477,7 @@ type CryptoOnrampError = (StripeError<OnrampErrorStatus> & {
     onrampErrorType?: never;
     developerMessage?: never;
     userMessage?: never;
-}) | AppAttestationError | UncategorizedApiError | AppAttestationUnavailableError;
+}) | AppAttestationError | InvalidWalletOwnershipSignatureError | WalletOwnershipChallengeExpiredError | InvalidWalletOwnershipChallengeError | WalletNotFoundError | UnsupportedNetworkError | UncategorizedApiError | AppAttestationUnavailableError;
 
 // @public
 type CryptoPaymentToken = {
@@ -2282,6 +2282,16 @@ enum InvalidShippingField {
     SubLocality = "subLocality"
 }
 
+// @public
+type InvalidWalletOwnershipChallengeError = OnrampApiError & {
+    onrampErrorType: 'InvalidWalletOwnershipChallengeError';
+};
+
+// @public
+type InvalidWalletOwnershipSignatureError = OnrampApiError & {
+    onrampErrorType: 'InvalidWalletOwnershipSignatureError';
+};
+
 // @public (undocumented)
 interface IOSNavigationBarProps {
     // (undocumented)
@@ -2686,6 +2696,11 @@ declare namespace Onramp {
         OnrampSdkError,
         OnrampApiError,
         AppAttestationError,
+        InvalidWalletOwnershipSignatureError,
+        WalletOwnershipChallengeExpiredError,
+        InvalidWalletOwnershipChallengeError,
+        WalletNotFoundError,
+        UnsupportedNetworkError,
         UncategorizedApiError,
         AppAttestationUnavailableError,
         CryptoOnrampError,
@@ -2720,7 +2735,7 @@ type OnrampApiError = OnrampSdkError & {
 };
 
 // @public
-type OnrampApiErrorType = 'AppAttestationError' | 'UncategorizedApiError';
+type OnrampApiErrorType = 'AppAttestationError' | 'InvalidWalletOwnershipSignatureError' | 'WalletOwnershipChallengeExpiredError' | 'InvalidWalletOwnershipChallengeError' | 'WalletNotFoundError' | 'UnsupportedNetworkError' | 'UncategorizedApiError';
 
 // @public
 enum OnrampErrorStatus {
@@ -4076,6 +4091,11 @@ type UncategorizedApiError = OnrampApiError & {
 };
 
 // @public
+type UnsupportedNetworkError = OnrampApiError & {
+    onrampErrorType: 'UnsupportedNetworkError';
+};
+
+// @public
 export const updatePlatformPaySheet: (params: {
     applePay: {
         cartItems: Array<PlatformPay.CartSummaryItem>;
@@ -4378,12 +4398,22 @@ type VoidResult = {
 };
 
 // @public
+type WalletNotFoundError = OnrampApiError & {
+    onrampErrorType: 'WalletNotFoundError';
+};
+
+// @public
 type WalletOwnershipChallenge = {
     challengeId: string;
     walletAddress: string;
     network: CryptoNetwork;
     message: string;
     expiresAt: string;
+};
+
+// @public
+type WalletOwnershipChallengeExpiredError = OnrampApiError & {
+    onrampErrorType: 'WalletOwnershipChallengeExpiredError';
 };
 
 // @public (undocumented)

--- a/ios/OnrampErrors.swift
+++ b/ios/OnrampErrors.swift
@@ -91,11 +91,22 @@ enum OnrampErrors {
     }
 
     private static func onrampErrorType(for error: StripeCryptoOnrampAPIError) -> String {
-        if error.code == "link_failed_to_attest_request" {
+        switch error.code {
+        case "link_failed_to_attest_request":
             return "AppAttestationError"
+        case "crypto_onramp_invalid_wallet_ownership_signature":
+            return "InvalidWalletOwnershipSignatureError"
+        case "crypto_onramp_wallet_ownership_challenge_expired":
+            return "WalletOwnershipChallengeExpiredError"
+        case "crypto_onramp_invalid_wallet_ownership_challenge":
+            return "InvalidWalletOwnershipChallengeError"
+        case "crypto_onramp_wallet_not_found":
+            return "WalletNotFoundError"
+        case "crypto_onramp_unsupported_network":
+            return "UnsupportedNetworkError"
+        default:
+            return "UncategorizedApiError"
         }
-
-        return "UncategorizedApiError"
     }
 
     private static func onrampErrorType(for error: StripeCryptoOnrampError) -> String? {

--- a/ios/Tests/OnrampErrorsTests.swift
+++ b/ios/Tests/OnrampErrorsTests.swift
@@ -76,6 +76,52 @@ class OnrampErrorsTests: XCTestCase {
         XCTAssertEqual(details["docUrl"] as? String, error.docURL?.absoluteString)
     }
 
+    func test_createFailedError_withWalletOwnershipAPIError_mapsSpecificErrorType() throws {
+        let testCases = [
+            (
+                code: "crypto_onramp_invalid_wallet_ownership_signature",
+                expectedType: "InvalidWalletOwnershipSignatureError"
+            ),
+            (
+                code: "crypto_onramp_wallet_ownership_challenge_expired",
+                expectedType: "WalletOwnershipChallengeExpiredError"
+            ),
+            (
+                code: "crypto_onramp_invalid_wallet_ownership_challenge",
+                expectedType: "InvalidWalletOwnershipChallengeError"
+            ),
+            (
+                code: "crypto_onramp_wallet_not_found",
+                expectedType: "WalletNotFoundError"
+            ),
+            (
+                code: "crypto_onramp_unsupported_network",
+                expectedType: "UnsupportedNetworkError"
+            ),
+        ]
+
+        for testCase in testCases {
+            let error = TestStripeCryptoOnrampAPIError(
+                code: testCase.code,
+                userMessage: "Wallet ownership verification failed.",
+                developerMessage: "Developer message.",
+                docURL: nil,
+                reason: "wallet_verification_failed",
+                type: "invalid_request_error",
+                requestID: "req_wallet_verification",
+                apiMessage: "Wallet ownership verification failed.",
+                apiUserMessage: "Please try again."
+            )
+
+            let details = try errorDetails(from: OnrampErrors.createFailedError(error))
+
+            XCTAssertEqual(details["onrampErrorType"] as? String, testCase.expectedType, testCase.code)
+            XCTAssertEqual(details["apiErrorCode"] as? String, testCase.code, testCase.code)
+            XCTAssertEqual(details["reason"] as? String, error.reason, testCase.code)
+            XCTAssertEqual(details["requestId"] as? String, error.requestID, testCase.code)
+        }
+    }
+
     func test_createFailedError_withAppAttestationUnavailableError_preservesSdkErrorFields() throws {
         let error = TestStripeCryptoOnrampError(
             code: "app_attestation_unavailable",

--- a/src/types/Onramp.ts
+++ b/src/types/Onramp.ts
@@ -269,6 +269,11 @@ export type ComplianceIdentifierRequirements = {
  */
 export type OnrampApiErrorType =
   | 'AppAttestationError'
+  | 'InvalidWalletOwnershipSignatureError'
+  | 'WalletOwnershipChallengeExpiredError'
+  | 'InvalidWalletOwnershipChallengeError'
+  | 'WalletNotFoundError'
+  | 'UnsupportedNetworkError'
   | 'UncategorizedApiError';
 
 /**
@@ -309,6 +314,41 @@ export type AppAttestationError = OnrampApiError & {
 };
 
 /**
+ * A typed Crypto Onramp API error for an invalid wallet ownership signature.
+ */
+export type InvalidWalletOwnershipSignatureError = OnrampApiError & {
+  onrampErrorType: 'InvalidWalletOwnershipSignatureError';
+};
+
+/**
+ * A typed Crypto Onramp API error for an expired wallet ownership challenge.
+ */
+export type WalletOwnershipChallengeExpiredError = OnrampApiError & {
+  onrampErrorType: 'WalletOwnershipChallengeExpiredError';
+};
+
+/**
+ * A typed Crypto Onramp API error for an invalid wallet ownership challenge.
+ */
+export type InvalidWalletOwnershipChallengeError = OnrampApiError & {
+  onrampErrorType: 'InvalidWalletOwnershipChallengeError';
+};
+
+/**
+ * A typed Crypto Onramp API error when the requested wallet cannot be found.
+ */
+export type WalletNotFoundError = OnrampApiError & {
+  onrampErrorType: 'WalletNotFoundError';
+};
+
+/**
+ * A typed Crypto Onramp API error for a network unsupported by the operation.
+ */
+export type UnsupportedNetworkError = OnrampApiError & {
+  onrampErrorType: 'UnsupportedNetworkError';
+};
+
+/**
  * A typed Crypto Onramp API error that did not map to a narrower category.
  */
 export type UncategorizedApiError = OnrampApiError & {
@@ -336,6 +376,11 @@ export type CryptoOnrampError =
       userMessage?: never;
     })
   | AppAttestationError
+  | InvalidWalletOwnershipSignatureError
+  | WalletOwnershipChallengeExpiredError
+  | InvalidWalletOwnershipChallengeError
+  | WalletNotFoundError
+  | UnsupportedNetworkError
   | UncategorizedApiError
   | AppAttestationUnavailableError;
 


### PR DESCRIPTION
## Summary
In #2540, we added wallet verification APIs. Currently the related rich errors are miscategorized as UncategorizedApiErrors. This PR adds the appropriate error types such that a merchant could switch over particular errors as needed.

## Motivation
To keep parity with the native SDKs.

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [x] I added automated tests
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

Ensured that the errors were still properly populating. In this example, I supplied an invalid signature.
<img width="300" alt="Simulator Screenshot - iPhone 16 Pro Max - 2026-08-12 at 15 54 29" src="https://github.com/user-attachments/assets/ebe7ca3b-cc54-4cb6-b03f-4131237656f3" />

Made sure that in code, I could check for the specific error type and log details:

```
if (
  result.error.onrampErrorType ===
  'InvalidWalletOwnershipSignatureError'
) {
  console.error(
    'Invalid wallet ownership signature:',
    result.error.developerMessage
  );
}
```

<img width="1326" height="402" alt="CleanShot 2026-08-12 at 16 00 57@2x" src="https://github.com/user-attachments/assets/2bf4f6bb-7e8f-44f5-a519-ccceb590552c" />

## Documentation

Select one: 
- [x] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
