### PR TITLE
StripeCryptoOnramp: Implements Samsung Pay

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,10 @@ docs/api-reference/
 # Local stripe-android dependency
 example/android/stripe-android
 
+# Proprietary Samsung Pay SDK used by the Android example
+example/android/libs/*.jar
+!example/android/libs/README.md
+
 # e2e tests
 e2e-artifacts/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Unreleased
+**Features**
+* [Added] Android: Added Crypto Onramp Samsung Pay configuration, availability checks, payment collection, and example integration.
+
 ## 0.74.0 - 2026-08-11
 **Features**
 * [Added] iOS: Added `supportedNetworks` to the Apple Pay params, which restricts the card networks offered in the Apple Pay sheet.

--- a/android/proguard-rules.txt
+++ b/android/proguard-rules.txt
@@ -9,3 +9,6 @@
 # play-services-tapandpay is a private Google SDK that must be provided by the app.
 # Suppress R8 warnings when it is absent (e.g. in the example app build).
 -dontwarn com.google.android.gms.tapandpay.**
+-dontwarn com.samsung.android.sdk.samsungpay.**
+-keep class com.samsung.android.sdk.** { *; }
+-keep interface com.samsung.android.sdk.** { *; }

--- a/android/src/oldarch/java/com/reactnativestripesdk/NativeOnrampSdkModuleSpec.java
+++ b/android/src/oldarch/java/com/reactnativestripesdk/NativeOnrampSdkModuleSpec.java
@@ -45,6 +45,10 @@ public abstract class NativeOnrampSdkModuleSpec extends ReactContextBaseJavaModu
 
   @ReactMethod
   @DoNotStrip
+  public abstract void isSamsungPaySupported(Promise promise);
+
+  @ReactMethod
+  @DoNotStrip
   public abstract void hasLinkAccount(String email, Promise promise);
 
   @ReactMethod

--- a/android/src/onramp/java/com/reactnativestripesdk/OnrampMappers.kt
+++ b/android/src/onramp/java/com/reactnativestripesdk/OnrampMappers.kt
@@ -8,6 +8,8 @@ import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.WritableArray
+import com.reactnativestripesdk.utils.getIntegerList
+import com.reactnativestripesdk.utils.mapToPreferredNetworks
 import com.stripe.android.core.model.CountryCode
 import com.stripe.android.crypto.onramp.ExperimentalCryptoOnramp
 import com.stripe.android.link.LinkControllerPreview
@@ -17,6 +19,7 @@ import com.stripe.android.crypto.onramp.exception.SDKVersion
 import com.stripe.android.crypto.onramp.model.KycInfo
 import com.stripe.android.crypto.onramp.model.OnrampConfiguration
 import com.stripe.android.crypto.onramp.model.PaymentMethodDisplayData
+import com.stripe.android.crypto.onramp.model.PaymentMethodSelection
 import com.stripe.android.crypto.onramp.model.WalletOwnershipChallenge
 import com.stripe.android.crypto.onramp.model.compliance.ComplianceIdentifier
 import com.stripe.android.crypto.onramp.model.compliance.ComplianceIdentifierAlternativeGroup
@@ -51,6 +54,7 @@ internal fun mapConfig(
   val displayName = configMap.getString("merchantDisplayName") ?: ""
   val cryptoCustomerId = configMap.getString("cryptoCustomerId")
   val googlePayConfig = mapGooglePayConfig(configMap.getMap("googlePay"))
+  val samsungPayConfig = mapSamsungPayConfig(configMap.getMap("samsungPay"))
 
   return OnrampConfiguration()
     .merchantDisplayName(displayName)
@@ -58,12 +62,79 @@ internal fun mapConfig(
     .appearance(appearance)
     .cryptoCustomerId(cryptoCustomerId)
     .apply { googlePayConfig?.let { googlePayConfig(it) } }
+    .apply { samsungPayConfig?.let { samsungPayConfig(it) } }
     .apply {
       if (additionalSdkVersions.isNotEmpty()) {
         this.additionalSdkVersions(additionalSdkVersions)
       }
     }
 }
+
+@SuppressLint("RestrictedApi")
+internal fun mapSamsungPayConfig(params: ReadableMap?): OnrampConfiguration.SamsungPayConfig? {
+  if (params == null) return null
+
+  val serviceId = params.getString("serviceId")?.takeIf { it.isNotBlank() } ?: return null
+  val merchantId = params.getString("merchantId")
+  val merchantName = params.getString("merchantName")
+  val allowedCardBrands = params.getIntegerList("allowedCardBrands")
+
+  return if (allowedCardBrands == null) {
+    OnrampConfiguration.SamsungPayConfig(
+      serviceId = serviceId,
+      merchantId = merchantId,
+      merchantName = merchantName,
+    )
+  } else {
+    OnrampConfiguration.SamsungPayConfig(
+      serviceId = serviceId,
+      merchantId = merchantId,
+      merchantName = merchantName,
+      allowedCardBrands = mapToPreferredNetworks(allowedCardBrands),
+    )
+  }
+}
+
+@SuppressLint("RestrictedApi")
+internal fun mapOnrampPaymentMethodSelection(
+  paymentMethod: String,
+  platformPayParams: ReadableMap,
+): PaymentMethodSelection =
+  when (paymentMethod) {
+    "Card" -> PaymentMethodSelection.Card()
+    "BankAccount" -> PaymentMethodSelection.BankAccount()
+    "CardAndBankAccount" -> PaymentMethodSelection.CardAndBankAccount()
+    "PlatformPay" -> {
+      val googlePayParams =
+        platformPayParams.getMap("googlePay")
+          ?: throw IllegalArgumentException("Missing googlePay params in platformPayParams")
+
+      PaymentMethodSelection.GooglePay(
+        currencyCode = googlePayParams.getString("currencyCode") ?: "",
+        amount = googlePayParams.getDouble("amount").toLong(),
+        transactionId = googlePayParams.getString("transactionId"),
+        label = googlePayParams.getString("label"),
+      )
+    }
+    "SamsungPay" -> {
+      val samsungPayParams =
+        platformPayParams.getMap("samsungPay")
+          ?: throw IllegalArgumentException("Missing samsungPay params in platformPayParams")
+      val currencyCode =
+        samsungPayParams.getString("currencyCode")?.takeIf { it.isNotBlank() }
+          ?: throw IllegalArgumentException("Missing currencyCode in samsungPay params")
+      val orderNumber =
+        samsungPayParams.getString("orderNumber")?.takeIf { it.isNotBlank() }
+          ?: throw IllegalArgumentException("Missing orderNumber in samsungPay params")
+
+      PaymentMethodSelection.SamsungPay(
+        currencyCode = currencyCode,
+        amount = samsungPayParams.getDouble("amount").toLong(),
+        orderNumber = orderNumber,
+      )
+    }
+    else -> throw IllegalArgumentException("Unsupported payment method: $paymentMethod")
+  }
 
 @SuppressLint("RestrictedApi")
 internal fun mapGooglePayConfig(params: ReadableMap?): GooglePayPaymentMethodLauncher.Config? {

--- a/android/src/onramp/java/com/reactnativestripesdk/OnrampMappers.kt
+++ b/android/src/onramp/java/com/reactnativestripesdk/OnrampMappers.kt
@@ -79,7 +79,7 @@ internal fun mapSamsungPayConfig(params: ReadableMap?): OnrampConfiguration.Sams
   val merchantName = params.getString("merchantName")
   val allowedCardBrands = params.getIntegerList("allowedCardBrands")
 
-  return if (allowedCardBrands == null) {
+  return if (allowedCardBrands.isNullOrEmpty()) {
     OnrampConfiguration.SamsungPayConfig(
       serviceId = serviceId,
       merchantId = merchantId,

--- a/android/src/onramp/java/com/reactnativestripesdk/OnrampSdkModule.kt
+++ b/android/src/onramp/java/com/reactnativestripesdk/OnrampSdkModule.kt
@@ -88,7 +88,7 @@ class OnrampSdkModule(
   private var checkoutPromise: Promise? = null
   private var verifyKycPromise: Promise? = null
   private var userAttestationPromise: Promise? = null
-  private var samsungPayAvailability = CompletableDeferred<Boolean>()
+  private var samsungPayAvailability = CompletableDeferred(false)
 
   private var checkoutClientSecretDeferred: CompletableDeferred<String>? = null
   private val rnScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)

--- a/android/src/onramp/java/com/reactnativestripesdk/OnrampSdkModule.kt
+++ b/android/src/onramp/java/com/reactnativestripesdk/OnrampSdkModule.kt
@@ -52,7 +52,6 @@ import com.stripe.android.crypto.onramp.model.OnrampTokenAuthenticationResult
 import com.stripe.android.crypto.onramp.model.OnrampUpdatePhoneNumberResult
 import com.stripe.android.crypto.onramp.model.OnrampVerifyIdentityResult
 import com.stripe.android.crypto.onramp.model.OnrampVerifyKycInfoResult
-import com.stripe.android.crypto.onramp.model.PaymentMethodSelection
 import com.stripe.android.link.LinkController.PaymentMethodPreview
 import com.stripe.android.link.LinkControllerPreview
 import com.stripe.android.link.PaymentMethodPreviewDetails
@@ -66,6 +65,7 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.withTimeoutOrNull
 
 @SuppressLint("RestrictedApi")
 @OptIn(ExperimentalCryptoOnramp::class, LinkControllerPreview::class)
@@ -88,6 +88,7 @@ class OnrampSdkModule(
   private var checkoutPromise: Promise? = null
   private var verifyKycPromise: Promise? = null
   private var userAttestationPromise: Promise? = null
+  private var samsungPayAvailability = CompletableDeferred<Boolean>()
 
   private var checkoutClientSecretDeferred: CompletableDeferred<String>? = null
   private val rnScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
@@ -136,6 +137,13 @@ class OnrampSdkModule(
       return
     }
 
+    samsungPayAvailability =
+      if (mapSamsungPayConfig(config.getMap("samsungPay")) == null) {
+        CompletableDeferred(false)
+      } else {
+        CompletableDeferred()
+      }
+
     val application =
       reactApplicationContext.currentActivity?.application ?: (reactApplicationContext.applicationContext as? Application)
     if (application == null) {
@@ -159,6 +167,8 @@ class OnrampSdkModule(
           userAttestationPromise?.let {
             handleUserAttestationResult(result, it)
           }
+        }.samsungPayIsReadyCallback { isReady, _ ->
+          samsungPayAvailability.complete(isReady)
         }.onrampSessionClientSecretProvider { sessionId ->
           checkoutClientSecretDeferred = CompletableDeferred()
 
@@ -190,6 +200,17 @@ class OnrampSdkModule(
           }
         }
       }
+    }
+  }
+
+  @ReactMethod
+  override fun isSamsungPaySupported(promise: Promise) {
+    rnScope.launch {
+      val isSupported =
+        withTimeoutOrNull(15_000L) {
+          samsungPayAvailability.await()
+        } ?: false
+      promise.resolve(isSupported)
     }
   }
 
@@ -557,42 +578,11 @@ class OnrampSdkModule(
       }
 
     val method =
-      when (paymentMethod) {
-        "Card" -> PaymentMethodSelection.Card()
-        "BankAccount" -> PaymentMethodSelection.BankAccount()
-        "CardAndBankAccount" -> PaymentMethodSelection.CardAndBankAccount()
-        "PlatformPay" -> {
-          val googlePayParams =
-            platformPayParams.getMap("googlePay")
-              ?: run {
-                promise.resolve(
-                  createOnrampFailedError(
-                    IllegalArgumentException("Missing googlePay params in platformPayParams"),
-                  ),
-                )
-                return
-              }
-          val currencyCode = googlePayParams.getString("currencyCode") ?: ""
-          val amount = googlePayParams.getDouble("amount").toLong()
-
-          val transactionId = googlePayParams.getString("transactionId")
-          val label = googlePayParams.getString("label")
-
-          PaymentMethodSelection.GooglePay(
-            currencyCode = currencyCode,
-            amount = amount,
-            transactionId = transactionId,
-            label = label,
-          )
-        }
-        else -> {
-          promise.resolve(
-            createOnrampFailedError(
-              IllegalArgumentException("Unsupported payment method: $paymentMethod"),
-            ),
-          )
-          return
-        }
+      try {
+        mapOnrampPaymentMethodSelection(paymentMethod, platformPayParams)
+      } catch (error: IllegalArgumentException) {
+        promise.resolve(createOnrampFailedError(error))
+        return
       }
 
     collectPaymentPromise = promise

--- a/android/src/test/java/com/reactnativestripesdk/mappers/OnrampMappersTest.kt
+++ b/android/src/test/java/com/reactnativestripesdk/mappers/OnrampMappersTest.kt
@@ -12,7 +12,9 @@ import com.reactnativestripesdk.mapFromCryptoConsumerWallet
 import com.reactnativestripesdk.mapFromKycInfo
 import com.reactnativestripesdk.mapFromWalletOwnershipChallenge
 import com.reactnativestripesdk.mapGooglePayConfig
+import com.reactnativestripesdk.mapOnrampPaymentMethodSelection
 import com.reactnativestripesdk.mapPaymentDetailsType
+import com.reactnativestripesdk.mapSamsungPayConfig
 import com.reactnativestripesdk.mapToComplianceIdentifiers
 import com.reactnativestripesdk.utils.readableArrayOf
 import com.reactnativestripesdk.utils.readableMapOf
@@ -21,10 +23,12 @@ import com.stripe.android.crypto.onramp.ExperimentalCryptoOnramp
 import com.stripe.android.crypto.onramp.model.CryptoNetwork
 import com.stripe.android.crypto.onramp.model.KycInfo
 import com.stripe.android.crypto.onramp.model.PaymentMethodDisplayData
+import com.stripe.android.crypto.onramp.model.PaymentMethodSelection
 import com.stripe.android.googlepaylauncher.GooglePayEnvironment
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher
 import com.stripe.android.link.LinkAppearance.Style
 import com.stripe.android.link.LinkControllerPreview
+import com.stripe.android.model.CardBrand
 import com.stripe.android.model.DateOfBirth
 import com.stripe.android.paymentsheet.PaymentSheet
 import org.junit.Assert.assertEquals
@@ -215,6 +219,67 @@ class OnrampMappersTest {
 
     assertNotNull(result)
     assertTrue(result!!.billingAddressConfig.isPhoneNumberRequired)
+  }
+
+  @Test
+  fun mapSamsungPayConfig_NullMap_ReturnsNull() {
+    assertNull(mapSamsungPayConfig(null))
+  }
+
+  @Test
+  fun mapSamsungPayConfig_MissingServiceId_ReturnsNull() {
+    assertNull(mapSamsungPayConfig(readableMapOf("merchantName" to "Test Merchant")))
+  }
+
+  @Test
+  fun mapSamsungPayConfig_DefaultsCardBrands() {
+    val result =
+      mapSamsungPayConfig(
+        readableMapOf(
+          "serviceId" to "service-id",
+          "merchantId" to "merchant-id",
+          "merchantName" to "Test Merchant",
+        ),
+    )
+
+    assertNotNull(result)
+    assertEquals("service-id", result!!.privateField("serviceId"))
+    assertEquals("merchant-id", result.privateField("merchantId"))
+    assertEquals("Test Merchant", result.privateField("merchantName"))
+    assertEquals(
+      listOf(CardBrand.Visa, CardBrand.MasterCard, CardBrand.AmericanExpress, CardBrand.Discover),
+      result.privateField("allowedCardBrands"),
+    )
+  }
+
+  @Test
+  fun mapSamsungPayConfig_MapsAllowedCardBrands() {
+    val result =
+      mapSamsungPayConfig(
+        readableMapOf(
+          "serviceId" to "service-id",
+          "allowedCardBrands" to readableArrayOf(7, 5),
+        ),
+      )
+
+    assertEquals(
+      listOf(CardBrand.Visa, CardBrand.MasterCard),
+      result!!.privateField("allowedCardBrands"),
+    )
+  }
+
+  @Test
+  fun mapConfig_WithSamsungPayConfig() {
+    val config =
+      readableMapOf(
+        "merchantDisplayName" to "Test",
+        "samsungPay" to readableMapOf("serviceId" to "service-id"),
+      )
+
+    val result = mapConfig(config, "pk_test_123")
+    val samsungPayConfig = result.privateField("samsungPayConfig")!!
+
+    assertEquals("service-id", samsungPayConfig.privateField("serviceId"))
   }
 
   @Test
@@ -453,6 +518,42 @@ class OnrampMappersTest {
     assertEquals("BankAccount", mapPaymentDetailsType(PaymentMethodDisplayData.Type.BankAccount))
     assertEquals("GooglePay", mapPaymentDetailsType(PaymentMethodDisplayData.Type.GooglePay))
     assertEquals("SamsungPay", mapPaymentDetailsType(PaymentMethodDisplayData.Type.SamsungPay))
+  }
+
+  @Test
+  fun mapOnrampPaymentMethodSelection_MapsSamsungPayParams() {
+    val params =
+      readableMapOf(
+        "samsungPay" to
+          readableMapOf(
+            "currencyCode" to "USD",
+            "amount" to 100,
+            "orderNumber" to "order-123",
+          ),
+      )
+
+    val result = mapOnrampPaymentMethodSelection("SamsungPay", params)
+
+    assertTrue(result is PaymentMethodSelection.SamsungPay)
+    assertEquals("USD", result.privateField("currencyCode"))
+    assertEquals(100L, result.privateField("amount"))
+    assertEquals("order-123", result.privateField("orderNumber"))
+  }
+
+  private fun Any.privateField(name: String): Any? =
+    javaClass.getDeclaredField(name).let { field ->
+      field.isAccessible = true
+      field.get(this)
+    }
+
+  @Test
+  fun mapOnrampPaymentMethodSelection_SamsungPayRequiresParams() {
+    val error =
+      assertThrows(IllegalArgumentException::class.java) {
+        mapOnrampPaymentMethodSelection("SamsungPay", readableMapOf())
+      }
+
+    assertEquals("Missing samsungPay params in platformPayParams", error.message)
   }
 
   @Test

--- a/android/src/test/java/com/reactnativestripesdk/mappers/OnrampMappersTest.kt
+++ b/android/src/test/java/com/reactnativestripesdk/mappers/OnrampMappersTest.kt
@@ -253,6 +253,22 @@ class OnrampMappersTest {
   }
 
   @Test
+  fun mapSamsungPayConfig_EmptyAllowedCardBrands_DefaultsCardBrands() {
+    val result =
+      mapSamsungPayConfig(
+        readableMapOf(
+          "serviceId" to "service-id",
+          "allowedCardBrands" to readableArrayOf(),
+        ),
+      )
+
+    assertEquals(
+      listOf(CardBrand.Visa, CardBrand.MasterCard, CardBrand.AmericanExpress, CardBrand.Discover),
+      result!!.privateField("allowedCardBrands"),
+    )
+  }
+
+  @Test
   fun mapSamsungPayConfig_MapsAllowedCardBrands() {
     val result =
       mapSamsungPayConfig(

--- a/etc/stripe-react-native.api.md
+++ b/etc/stripe-react-native.api.md
@@ -1089,6 +1089,7 @@ type Configuration = {
     appearance: LinkAppearance;
     cryptoCustomerId?: string;
     googlePay?: GooglePayConfig;
+    samsungPay?: SamsungPayConfig;
 };
 
 // @public
@@ -2667,7 +2668,9 @@ declare namespace Onramp {
         Configuration,
         GooglePayConfig,
         GooglePayBillingAddressConfig,
+        SamsungPayConfig,
         OnrampGooglePayParams,
+        OnrampSamsungPayParams,
         OnrampPlatformPayParams,
         LinkUserInfo,
         CryptoNetwork,
@@ -2746,7 +2749,15 @@ type OnrampGooglePayParams = {
 // @public
 type OnrampPlatformPayParams = {
     googlePay?: OnrampGooglePayParams;
+    samsungPay?: OnrampSamsungPayParams;
     applePay?: ApplePayBaseParams & ApplePayPaymentMethodParams;
+};
+
+// @public
+type OnrampSamsungPayParams = {
+    currencyCode: string;
+    amount: number;
+    orderNumber: string;
 };
 
 // @public
@@ -2922,7 +2933,7 @@ type PaymentMethodDisplayData = {
     icon: string;
     label: string;
     sublabel?: string;
-    type: 'Card' | 'BankAccount' | 'ApplePay' | 'GooglePay';
+    type: 'Card' | 'BankAccount' | 'ApplePay' | 'GooglePay' | 'SamsungPay';
 };
 
 // @public (undocumented)
@@ -3591,6 +3602,14 @@ export enum RowStyle {
     FloatingButton = "floatingButton"
 }
 
+// @public
+type SamsungPayConfig = {
+    serviceId: string;
+    merchantId?: string;
+    merchantName?: string;
+    allowedCardBrands?: CardBrand[];
+};
+
 // @public (undocumented)
 interface SepaDebitResult {
     // (undocumented)
@@ -4180,6 +4199,7 @@ export function useOnramp(): {
     configure: (config: Onramp.Configuration) => Promise<{
         error?: Onramp.CryptoOnrampError;
     }>;
+    isSamsungPaySupported: () => Promise<boolean>;
     hasLinkAccount: (email: string) => Promise<Onramp.HasLinkAccountResult>;
     registerLinkUser: (info: Onramp.LinkUserInfo) => Promise<Onramp.RegisterLinkUserResult>;
     registerWalletAddress: (walletAddress: string, network: Onramp.CryptoNetwork) => Promise<{
@@ -4206,6 +4226,7 @@ export function useOnramp(): {
     collectPaymentMethod: {
         (paymentMethod: "Card" | "BankAccount" | "CardAndBankAccount", platformPayParams?: undefined): Promise<Onramp.CollectPaymentMethodResult>;
         (paymentMethod: "PlatformPay", platformPayParams: Onramp.OnrampPlatformPayParams): Promise<Onramp.CollectPaymentMethodResult>;
+        (paymentMethod: "SamsungPay", platformPayParams: Onramp.OnrampPlatformPayParams): Promise<Onramp.CollectPaymentMethodResult>;
     };
     createCryptoPaymentToken: () => Promise<Onramp.CreateCryptoPaymentTokenResult>;
     performCheckout: (onrampSessionId: string, provideCheckoutClientSecret: () => Promise<string | null>) => Promise<{

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -62,6 +62,18 @@ subprojects { subproject ->
                 if (manifestFile.exists()) {
                     def manifest = manifestFile.text
 
+                    // Samsung Pay status checks require package visibility on Android 11+.
+                    if (!manifest.contains('com.samsung.android.spay')) {
+                        manifest = manifest.replace(
+                            '<application',
+                            '''<queries>
+        <package android:name="com.samsung.android.spay" />
+        <package android:name="com.samsung.android.samsungpay.gear" />
+    </queries>
+    <application'''
+                        )
+                    }
+
                     // Add launchMode="singleTask"
                     manifest = manifest.replace(
                         '<activity android:name="com.microsoft.reacttestapp.MainActivity" android:exported="true">',

--- a/example/android/libs/README.md
+++ b/example/android/libs/README.md
@@ -1,0 +1,9 @@
+# Samsung Pay SDK
+
+To exercise Samsung Pay in the Crypto Onramp example:
+
+1. Download Samsung Pay SDK 2.22.00 from the Samsung Pay developer portal.
+2. Copy its Java library here as `samsungpay_2.22.00.jar`.
+3. Build and run the example on a supported Samsung device with Samsung Wallet configured.
+
+The SDK is proprietary and is intentionally not committed to this repository. The example continues to build without it; its Samsung Pay button remains disabled when the SDK, service configuration, or device support is unavailable.

--- a/example/app.json
+++ b/example/app.json
@@ -24,7 +24,9 @@
   "ios": {
     "bundleIdentifier": "com.stripe.react.native",
     "codeSignEntitlements": {
-      "com.apple.developer.in-app-payments": ["merchant.com.stripe.react.native"]
+      "com.apple.developer.in-app-payments": [
+        "merchant.com.stripe.react.native"
+      ]
     },
     "urlTypes": [
       {
@@ -34,17 +36,23 @@
   },
   "android": {
     "package": "com.stripe.react.native",
-    "versionCode": 4, 
+    "versionCode": 4,
     "permissions": [
       {
         "android:name": "android.permission.CAMERA",
         "android:maxSdkVersion": "34"
       }
     ],
-    "metaData": [{
-      "android:name": "com.google.android.gms.wallet.api.enabled",
-      "android:value": "true"
-    }],
+    "metaData": [
+      {
+        "android:name": "com.google.android.gms.wallet.api.enabled",
+        "android:value": "true"
+      },
+      {
+        "android:name": "spay_sdk_api_level",
+        "android:value": "2.22"
+      }
+    ],
     "signingConfigs": {
       "debug": {
         "keyAlias": "androiddebugkey",

--- a/example/rnt-package/android/build.gradle
+++ b/example/rnt-package/android/build.gradle
@@ -43,4 +43,11 @@ dependencies {
   implementation 'com.facebook.react:react-native:+'
   implementation 'com.stripe:stripe-android-issuing-push-provisioning:1.3.0'
   implementation 'com.tencent.mm.opensdk:wechat-sdk-android-without-mta:6.7.0'
+
+  // Samsung Pay is distributed directly by Samsung and cannot be pulled from Maven.
+  // The Onramp example detects it at runtime, so ordinary builds still work without it.
+  def samsungPaySdkJar = rootProject.file('libs/samsungpay_2.22.00.jar')
+  if (samsungPaySdkJar.exists()) {
+    implementation files(samsungPaySdkJar)
+  }
 }

--- a/example/src/Config.ts
+++ b/example/src/Config.ts
@@ -2,6 +2,11 @@
 export const API_URL =
   'https://rigorous-heartbreaking-cephalopod.stripedemos.com';
 
+// To test Samsung Pay in the Crypto Onramp example, register the Android app
+// with Samsung Pay and replace this value with the assigned in-app service ID.
+// Samsung Pay SDK 2.22.00 must also be installed in example/android/libs.
+export const SAMSUNG_PAY_SERVICE_ID = 'a38b24ecbba94a3c8bfbfe';
+
 /*
 🛠️ To use Custom Backend:
 

--- a/example/src/screens/HomeScreen.tsx
+++ b/example/src/screens/HomeScreen.tsx
@@ -19,6 +19,7 @@ import { colors } from '../colors';
 import Button from '../components/Button';
 import { Collapse } from '../components/Collapse';
 import { Onramp } from '@stripe/stripe-react-native';
+import { SAMSUNG_PAY_SERVICE_ID } from '../Config';
 
 export default function HomeScreen() {
   const navigation = useNavigation();
@@ -88,6 +89,14 @@ export default function HomeScreen() {
           isPhoneNumberRequired: false,
         },
       },
+      ...(Platform.OS === 'android' && SAMSUNG_PAY_SERVICE_ID
+        ? {
+            samsungPay: {
+              serviceId: SAMSUNG_PAY_SERVICE_ID,
+              merchantName: 'Onramp Example',
+            },
+          }
+        : {}),
     };
 
     configure(config)

--- a/example/src/screens/Onramp/CryptoOnrampFlow.tsx
+++ b/example/src/screens/Onramp/CryptoOnrampFlow.tsx
@@ -698,12 +698,19 @@ export default function CryptoOnrampFlow() {
 
   const handleCollectPaymentMethod = useCallback(
     async (request: CollectPaymentRequest) => {
-      const result = await withReauth(
-        () =>
-          request.type === 'PlatformPay' || request.type === 'SamsungPay'
-            ? collectPaymentMethod(request.type, request.params)
-            : collectPaymentMethod(request.type),
-        () => authorize(linkAuthIntentId)
+      const collectPayment = () => {
+        switch (request.type) {
+          case 'PlatformPay':
+            return collectPaymentMethod('PlatformPay', request.params);
+          case 'SamsungPay':
+            return collectPaymentMethod('SamsungPay', request.params);
+          default:
+            return collectPaymentMethod(request.type);
+        }
+      };
+
+      const result = await withReauth(collectPayment, () =>
+        authorize(linkAuthIntentId)
       );
 
       if (result?.error) {

--- a/example/src/screens/Onramp/CryptoOnrampFlow.tsx
+++ b/example/src/screens/Onramp/CryptoOnrampFlow.tsx
@@ -103,6 +103,7 @@ export default function CryptoOnrampFlow() {
     getCryptoTokenDisplayData,
     logOut,
     isAuthError,
+    isSamsungPaySupported,
     authenticateUserWithToken,
   } = useOnramp();
   const { isPlatformPaySupported } = useStripe();
@@ -148,13 +149,19 @@ export default function CryptoOnrampFlow() {
   );
 
   const [isPlatformPayAvailable, setIsPlatformPayAvailable] = useState(false);
+  const [isSamsungPayAvailable, setIsSamsungPayAvailable] = useState(false);
   const [authInProgress, setAuthInProgress] = useState<
     null | 'login' | 'signup'
   >(null);
 
   // Payment method state used to help determine ACH settlement speed segmented control visibility (only available for bank account payments).
   const [selectedPaymentMethod, setSelectedPaymentMethod] = useState<
-    'Card' | 'BankAccount' | 'CardAndBankAccount' | 'PlatformPay' | null
+    | 'Card'
+    | 'BankAccount'
+    | 'CardAndBankAccount'
+    | 'PlatformPay'
+    | 'SamsungPay'
+    | null
   >(null);
 
   // ACH settlement speed state
@@ -686,13 +693,14 @@ export default function CryptoOnrampFlow() {
     | { type: 'Card' }
     | { type: 'BankAccount' }
     | { type: 'CardAndBankAccount' }
-    | { type: 'PlatformPay'; params: Onramp.OnrampPlatformPayParams };
+    | { type: 'PlatformPay'; params: Onramp.OnrampPlatformPayParams }
+    | { type: 'SamsungPay'; params: Onramp.OnrampPlatformPayParams };
 
   const handleCollectPaymentMethod = useCallback(
     async (request: CollectPaymentRequest) => {
       const result = await withReauth(
         () =>
-          request.type === 'PlatformPay'
+          request.type === 'PlatformPay' || request.type === 'SamsungPay'
             ? collectPaymentMethod(request.type, request.params)
             : collectPaymentMethod(request.type),
         () => authorize(linkAuthIntentId)
@@ -774,6 +782,21 @@ export default function CryptoOnrampFlow() {
     handleCollectPaymentMethod({
       type: 'PlatformPay',
       params: googlePayParams,
+    });
+  }, [handleCollectPaymentMethod, sourceCurrency]);
+
+  const handleCollectSamsungPayPayment = useCallback(async () => {
+    const samsungPayParams: Onramp.OnrampPlatformPayParams = {
+      samsungPay: {
+        currencyCode: sourceCurrency.toUpperCase(),
+        amount: 100,
+        orderNumber: `rn-onramp-${Date.now()}`,
+      },
+    };
+
+    handleCollectPaymentMethod({
+      type: 'SamsungPay',
+      params: samsungPayParams,
     });
   }, [handleCollectPaymentMethod, sourceCurrency]);
 
@@ -955,7 +978,8 @@ export default function CryptoOnrampFlow() {
 
   useEffect(() => {
     let mounted = true;
-    (async () => {
+
+    const checkPlatformPaySupport = async () => {
       try {
         const params =
           Platform.OS === 'android'
@@ -966,11 +990,26 @@ export default function CryptoOnrampFlow() {
       } catch {
         if (mounted) setIsPlatformPayAvailable(false);
       }
-    })();
+    };
+
+    const checkSamsungPaySupport = async () => {
+      if (Platform.OS !== 'android') return;
+
+      try {
+        const supported = await isSamsungPaySupported();
+        if (mounted) setIsSamsungPayAvailable(supported);
+      } catch {
+        if (mounted) setIsSamsungPayAvailable(false);
+      }
+    };
+
+    checkPlatformPaySupport();
+    checkSamsungPaySupport();
+
     return () => {
       mounted = false;
     };
-  }, [isPlatformPaySupported]);
+  }, [isPlatformPaySupported, isSamsungPaySupported]);
 
   // Load persisted demo auth for seamless sign-in
   useEffect(() => {
@@ -1178,6 +1217,7 @@ export default function CryptoOnrampFlow() {
           />
           <PaymentCollectionSection
             isPlatformPaySupported={isPlatformPayAvailable}
+            isSamsungPaySupported={isSamsungPayAvailable}
             sourceCurrency={sourceCurrency}
             onSourceCurrencyChange={handleSourceCurrencyChange}
             handleCollectPlatformPayPayment={
@@ -1185,6 +1225,7 @@ export default function CryptoOnrampFlow() {
                 ? handleCollectApplePayPayment
                 : handleCollectGooglePayPayment
             }
+            handleCollectSamsungPayPayment={handleCollectSamsungPayPayment}
             handleCollectCardPayment={handleCollectCardPayment}
             handleCollectBankAccountPayment={handleCollectBankAccountPayment}
             handleCollectCardAndBankAccountPayment={

--- a/example/src/screens/Onramp/sections/PaymentCollectionSection.tsx
+++ b/example/src/screens/Onramp/sections/PaymentCollectionSection.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Collapse } from '../../../components/Collapse';
 import Button from '../../../components/Button';
-import { StyleSheet, Text, View } from 'react-native';
+import { Platform, StyleSheet, Text, View } from 'react-native';
 import { PlatformPayButton } from '@stripe/stripe-react-native';
 import { colors } from '../../../colors';
 import { SegmentedControl } from '../../../components/SegmentedControl';
@@ -10,9 +10,11 @@ export type SourceCurrency = 'usd' | 'eur';
 
 interface PaymentCollectionSectionProps {
   isPlatformPaySupported: boolean;
+  isSamsungPaySupported: boolean;
   sourceCurrency: SourceCurrency;
   onSourceCurrencyChange: (currency: SourceCurrency) => void;
   handleCollectPlatformPayPayment: () => void;
+  handleCollectSamsungPayPayment: () => void;
   handleCollectCardPayment: () => void;
   handleCollectBankAccountPayment: () => void;
   handleCollectCardAndBankAccountPayment: () => void;
@@ -20,9 +22,11 @@ interface PaymentCollectionSectionProps {
 
 export function PaymentCollectionSection({
   isPlatformPaySupported,
+  isSamsungPaySupported,
   sourceCurrency,
   onSourceCurrencyChange,
   handleCollectPlatformPayPayment,
+  handleCollectSamsungPayPayment,
   handleCollectCardPayment,
   handleCollectBankAccountPayment,
   handleCollectCardAndBankAccountPayment,
@@ -46,6 +50,23 @@ export function PaymentCollectionSection({
             onPress={handleCollectPlatformPayPayment}
             style={{ width: '100%', height: 44 }}
           />
+        </View>
+      )}
+      {Platform.OS === 'android' && (
+        <View style={styles.samsungPayContainer}>
+          <Button
+            title="Pay with Samsung Pay"
+            onPress={handleCollectSamsungPayPayment}
+            variant="primary"
+            disabled={!isSamsungPaySupported}
+            accessibilityLabel="Pay with Samsung Pay"
+          />
+          {!isSamsungPaySupported && (
+            <Text style={styles.walletUnavailableText}>
+              Samsung Pay requires a supported Samsung device, a configured
+              service ID, and Samsung Pay SDK 2.22.00.
+            </Text>
+          )}
         </View>
       )}
       <Button
@@ -77,5 +98,14 @@ const styles = StyleSheet.create({
   },
   sourceCurrencyOptions: {
     marginBottom: 12,
+  },
+  samsungPayContainer: {
+    marginBottom: 8,
+  },
+  walletUnavailableText: {
+    color: colors.slate,
+    fontSize: 12,
+    marginBottom: 8,
+    opacity: 0.7,
   },
 });

--- a/ios/StripeOnrampSdk.mm
+++ b/ios/StripeOnrampSdk.mm
@@ -29,6 +29,12 @@ RCT_EXPORT_METHOD(configureOnramp:(nonnull NSDictionary *)config
   [StripeSdkImpl.shared configureOnramp:config resolver:resolve rejecter:reject];
 }
 
+RCT_EXPORT_METHOD(isSamsungPaySupported:(nonnull RCTPromiseResolveBlock)resolve
+                                reject:(nonnull RCTPromiseRejectBlock)reject)
+{
+  resolve(@NO);
+}
+
 RCT_EXPORT_METHOD(hasLinkAccount:(nonnull NSString *)email
                          resolve:(nonnull RCTPromiseResolveBlock)resolve
                           reject:(nonnull RCTPromiseRejectBlock)reject)

--- a/src/hooks/useOnramp.tsx
+++ b/src/hooks/useOnramp.tsx
@@ -44,6 +44,10 @@ export function useOnramp() {
     []
   );
 
+  const _isSamsungPaySupported = useCallback(async (): Promise<boolean> => {
+    return requireOnrampModule().isSamsungPaySupported();
+  }, []);
+
   const _registerLinkUser = useCallback(
     async (
       info: Onramp.LinkUserInfo
@@ -155,12 +159,14 @@ export function useOnramp() {
    * The set of payment methods supported by crypto onramp collection.
    * - 'Card', 'BankAccount', 'CardAndBankAccount' present Link for collection.
    * - 'PlatformPay' presents Apple Pay / Google Pay using provided params.
+   * - 'SamsungPay' presents Samsung Pay using provided params on Android.
    */
   type OnrampPaymentMethod =
     | 'Card'
     | 'BankAccount'
     | 'CardAndBankAccount'
-    | 'PlatformPay';
+    | 'PlatformPay'
+    | 'SamsungPay';
 
   // Overloads for stronger type-safety at call-sites
   const _collectPaymentMethod: {
@@ -170,6 +176,10 @@ export function useOnramp() {
     ): Promise<Onramp.CollectPaymentMethodResult>;
     (
       paymentMethod: 'PlatformPay',
+      platformPayParams: Onramp.OnrampPlatformPayParams
+    ): Promise<Onramp.CollectPaymentMethodResult>;
+    (
+      paymentMethod: 'SamsungPay',
       platformPayParams: Onramp.OnrampPlatformPayParams
     ): Promise<Onramp.CollectPaymentMethodResult>;
   } = useCallback(
@@ -258,6 +268,13 @@ export function useOnramp() {
      * @returns Promise that resolves to an object with an optional error property
      */
     configure: _configure,
+
+    /**
+     * Checks whether Samsung Pay is ready for Onramp payment collection.
+     * Returns false on non-Android platforms, when Samsung Pay is not configured,
+     * or when Samsung Pay SDK 2.22.00 is unavailable on the device.
+     */
+    isSamsungPaySupported: _isSamsungPaySupported,
 
     /**
      * Whether or not the provided email is associated with an existing Link consumer.
@@ -380,9 +397,11 @@ export function useOnramp() {
      * @param paymentMethod The payment method type to collect.
      *  - 'Card' and 'BankAccount' present Link for collection.
      *  - 'PlatformPay' presents Apple Pay / Google Pay using the provided parameters.
-     * @param platformPayParams Platform-specific parameters (required when `paymentMethod` is 'PlatformPay').
+     *  - 'SamsungPay' presents Samsung Pay on Android.
+     * @param platformPayParams Platform-specific parameters (required when `paymentMethod` is 'PlatformPay' or 'SamsungPay').
      *  - iOS: provide `applePay` params
      *  - Android: provide `googlePay` params
+     *  - Samsung Pay: provide `samsungPay` params
      *  - To receive Apple Pay billing details back as `kycInfo`, request `.name` and/or `.postalAddress`
      *    in `applePay.requiredBillingContactFields`
      *  - To receive Google Pay billing details back as `kycInfo`, ensure that the `GooglePayConfig`

--- a/src/specs/NativeOnrampSdkModule.ts
+++ b/src/specs/NativeOnrampSdkModule.ts
@@ -8,6 +8,7 @@ export interface Spec extends TurboModule {
   configureOnramp(
     config: UnsafeObject<Onramp.Configuration>
   ): Promise<Onramp.VoidResult>;
+  isSamsungPaySupported(): Promise<boolean>;
   hasLinkAccount(email: string): Promise<Onramp.HasLinkAccountResult>;
   registerLinkUser(
     info: UnsafeObject<Onramp.LinkUserInfo>

--- a/src/types/Onramp.ts
+++ b/src/types/Onramp.ts
@@ -1,4 +1,4 @@
-import type { Address } from './Common';
+import type { Address, CardBrand } from './Common';
 import type { StripeError } from './Errors';
 import type {
   ApplePayBaseParams,
@@ -37,6 +37,8 @@ export type Configuration = {
   cryptoCustomerId?: string;
   /** Google Pay configuration. Required on Android to enable Google Pay as a payment method. */
   googlePay?: GooglePayConfig;
+  /** Samsung Pay configuration. Required on Android to enable Samsung Pay as a payment method. */
+  samsungPay?: SamsungPayConfig;
 };
 
 /**
@@ -72,6 +74,23 @@ export type GooglePayBillingAddressConfig = {
 };
 
 /**
+ * Configuration for Samsung Pay within the onramp flow.
+ *
+ * The Android application must include Samsung Pay SDK 2.22.00 at runtime.
+ * Stripe Android does not package the Samsung Pay SDK transitively.
+ */
+export type SamsungPayConfig = {
+  /** Samsung Pay in-app service ID assigned to the merchant. */
+  serviceId: string;
+  /** Optional merchant identifier supplied to Samsung Pay. */
+  merchantId?: string;
+  /** Optional merchant name supplied to Samsung Pay. */
+  merchantName?: string;
+  /** Card brands customers may select in Samsung Pay. */
+  allowedCardBrands?: CardBrand[];
+};
+
+/**
  * Google Pay parameters for the onramp collectPaymentMethod call.
  * Only includes the fields passed to GooglePayPaymentMethodLauncher.present().
  * Google Pay config (merchantCountryCode, testEnv, etc.) belongs in GooglePayConfig
@@ -89,6 +108,18 @@ export type OnrampGooglePayParams = {
 };
 
 /**
+ * Samsung Pay parameters for the onramp collectPaymentMethod call.
+ */
+export type OnrampSamsungPayParams = {
+  /** ISO 4217 alphabetic currency code (e.g. "USD"). */
+  currencyCode: string;
+  /** Amount in the currency's smallest unit. */
+  amount: number;
+  /** Unique order number for this transaction. */
+  orderNumber: string;
+};
+
+/**
  * Platform Pay parameters for the onramp collectPaymentMethod call.
  */
 export type OnrampPlatformPayParams = {
@@ -96,6 +127,10 @@ export type OnrampPlatformPayParams = {
    * Google Pay parameters. Android only.
    */
   googlePay?: OnrampGooglePayParams;
+  /**
+   * Samsung Pay parameters. Android only.
+   */
+  samsungPay?: OnrampSamsungPayParams;
   /**
    * Apple Pay parameters. iOS only.
    * To receive `kycInfo` back from `collectPaymentMethod`, request Apple Pay billing
@@ -526,7 +561,7 @@ export type PaymentMethodDisplayData = {
   /** Details about the underlying payment method, e.g., "Visa Credit •••• 4242". */
   sublabel?: string;
   /** The type of payment method */
-  type: 'Card' | 'BankAccount' | 'ApplePay' | 'GooglePay';
+  type: 'Card' | 'BankAccount' | 'ApplePay' | 'GooglePay' | 'SamsungPay';
 };
 
 /**

--- a/src/types/Onramp.ts
+++ b/src/types/Onramp.ts
@@ -86,7 +86,10 @@ export type SamsungPayConfig = {
   merchantId?: string;
   /** Optional merchant name supplied to Samsung Pay. */
   merchantName?: string;
-  /** Card brands customers may select in Samsung Pay. */
+  /**
+   * Card brands customers may select in Samsung Pay.
+   * Omitting this or passing an empty array uses the SDK defaults.
+   */
   allowedCardBrands?: CardBrand[];
 };
 


### PR DESCRIPTION
## Summary
Adds SamsungPay implementation to the SDK and the example app.

## Motivation
Updates the RN library to contain Samsung Pay, as the Android SDK now contains it.

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [x] I added automated tests
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

You can follow the instructions in the libs/README.md for testing.

## Documentation

Select one: 
- [x] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
