### PR TITLE
CryptoOnramp SDK: Wallet Address Deletion + Android Version Bump (23.16.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Unreleased
+**Features**
+* [Added] Added `deleteWalletAddress` to Crypto Onramp for deleting a registered wallet from the current Link account.
+
 ## 0.74.0 - 2026-08-11
 **Features**
 * [Added] iOS: Added `supportedNetworks` to the Apple Pay params, which restricts the card networks offered in the Apple Pay sheet.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # CHANGELOG
 
 ## Unreleased
+**Changes**
+* Updated Stripe Android SDK from 23.15.0 to 23.16.0.
+
 **Features**
 * [Added] Added `deleteWalletAddress` to Crypto Onramp for deleting a registered wallet from the current Link account.
 * [Added] Added typed Crypto Onramp error coverage for wallet ownership verification failures.

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -3,4 +3,4 @@ StripeSdk_compileSdkVersion=36
 StripeSdk_targetSdkVersion=36
 StripeSdk_minSdkVersion=23
 # Keep StripeSdk_stripeVersion in sync with https://github.com/stripe/stripe-identity-react-native/blob/main/android/gradle.properties
-StripeSdk_stripeVersion=23.15.0
+StripeSdk_stripeVersion=23.16.0

--- a/android/src/oldarch/java/com/reactnativestripesdk/NativeOnrampSdkModuleSpec.java
+++ b/android/src/oldarch/java/com/reactnativestripesdk/NativeOnrampSdkModuleSpec.java
@@ -57,6 +57,10 @@ public abstract class NativeOnrampSdkModuleSpec extends ReactContextBaseJavaModu
 
   @ReactMethod
   @DoNotStrip
+  public abstract void deleteWalletAddress(String walletId, Promise promise);
+
+  @ReactMethod
+  @DoNotStrip
   public abstract void getWalletOwnershipChallenge(String walletAddress, String network, Promise promise);
 
   @ReactMethod

--- a/android/src/onramp/java/com/reactnativestripesdk/OnrampSdkModule.kt
+++ b/android/src/onramp/java/com/reactnativestripesdk/OnrampSdkModule.kt
@@ -39,6 +39,7 @@ import com.stripe.android.crypto.onramp.model.OnrampCheckoutResult
 import com.stripe.android.crypto.onramp.model.OnrampCollectPaymentMethodResult
 import com.stripe.android.crypto.onramp.model.OnrampConfigurationResult
 import com.stripe.android.crypto.onramp.model.OnrampCreateCryptoPaymentTokenResult
+import com.stripe.android.crypto.onramp.model.OnrampDeleteWalletAddressResult
 import com.stripe.android.crypto.onramp.model.OnrampGetWalletOwnershipChallengeResult
 import com.stripe.android.crypto.onramp.model.OnrampUserAttestationResult
 import com.stripe.android.crypto.onramp.model.OnrampHasLinkAccountResult
@@ -293,6 +294,28 @@ class OnrampSdkModule(
           promise.resolveVoid()
         }
         is OnrampRegisterWalletAddressResult.Failed -> {
+          promise.resolve(createOnrampFailedError(result.error))
+        }
+      }
+    }
+  }
+
+  @ReactMethod
+  override fun deleteWalletAddress(
+    walletId: String,
+    promise: Promise,
+  ) {
+    val coordinator =
+      onrampCoordinator ?: run {
+        promise.resolve(createOnrampNotConfiguredError())
+        return
+      }
+    CoroutineScope(Dispatchers.IO).launch {
+      when (val result = coordinator.deleteWalletAddress(walletId)) {
+        is OnrampDeleteWalletAddressResult.Completed -> {
+          promise.resolveVoid()
+        }
+        is OnrampDeleteWalletAddressResult.Failed -> {
           promise.resolve(createOnrampFailedError(result.error))
         }
       }

--- a/etc/stripe-react-native.api.md
+++ b/etc/stripe-react-native.api.md
@@ -4185,6 +4185,9 @@ export function useOnramp(): {
     registerWalletAddress: (walletAddress: string, network: Onramp.CryptoNetwork) => Promise<{
         error?: Onramp.CryptoOnrampError;
     }>;
+    deleteWalletAddress: (walletId: string) => Promise<{
+        error?: Onramp.CryptoOnrampError;
+    }>;
     getWalletOwnershipChallenge: (walletAddress: string, network: Onramp.CryptoNetwork) => Promise<Onramp.GetWalletOwnershipChallengeResult>;
     submitWalletOwnershipSignature: (challengeId: string, signature: string) => Promise<Onramp.SubmitWalletOwnershipSignatureResult>;
     attachKycInfo: (kycInfo: Onramp.KycInfo) => Promise<{

--- a/example/src/api/onrampBackend.ts
+++ b/example/src/api/onrampBackend.ts
@@ -54,6 +54,25 @@ interface GetCryptoCustomerResponse {
   crypto_customer_id: string;
 }
 
+interface CustomerWallet {
+  id: string;
+  network: string;
+  walletAddress: string;
+  verifiedOwnership: boolean;
+}
+
+interface CustomerWalletsResponse {
+  count: number;
+  data: CustomerWallet[];
+}
+
+interface CustomerWalletApiResponse {
+  id: string;
+  network: string;
+  wallet_address: string;
+  verified_ownership: boolean;
+}
+
 interface CreateOnrampSessionRequest {
   ui_mode: string;
   payment_token: string;
@@ -403,6 +422,32 @@ export class OnrampBackend {
       }
     );
   }
+
+  /**
+   * Retrieves the registered wallets for the currently authenticated user
+   * @param authToken Authorization token
+   */
+  async fetchCustomerWallets(
+    authToken: string
+  ): Promise<ApiResult<CustomerWalletsResponse>> {
+    return this.makeRequest<CustomerWalletsResponse>(
+      '/v1/customer_wallets?limit=50',
+      null,
+      {
+        authToken,
+        method: 'GET',
+        transformResponse: (data) => ({
+          count: data.count,
+          data: data.data.map((wallet: CustomerWalletApiResponse) => ({
+            id: wallet.id,
+            network: wallet.network,
+            walletAddress: wallet.wallet_address,
+            verifiedOwnership: wallet.verified_ownership,
+          })),
+        }),
+      }
+    );
+  }
 }
 
 const defaultClient = new OnrampBackend();
@@ -459,6 +504,12 @@ export const getCryptoCustomerId = async (
   return defaultClient.getCryptoCustomerId(authToken);
 };
 
+export const fetchCustomerWallets = async (
+  authToken: string
+): Promise<ApiResult<CustomerWalletsResponse>> => {
+  return defaultClient.fetchCustomerWallets(authToken);
+};
+
 export const saveUser = async (
   cryptoCustomerId: string,
   authToken: string
@@ -487,6 +538,8 @@ export type {
   CreateAuthIntentResponse,
   CreateLinkAuthTokenResponse,
   GetCryptoCustomerResponse,
+  CustomerWallet,
+  CustomerWalletsResponse,
   SaveUserRequest,
   SaveUserResponse,
   SignupRequest,

--- a/example/src/screens/Onramp/CryptoOnrampFlow.tsx
+++ b/example/src/screens/Onramp/CryptoOnrampFlow.tsx
@@ -634,7 +634,7 @@ export default function CryptoOnrampFlow() {
         );
 
         if (
-          wallet.walletAddress === walletAddress &&
+          wallet.walletAddress.toLowerCase() === walletAddress?.toLowerCase() &&
           wallet.network === walletNetwork
         ) {
           setWalletAddress(null);

--- a/example/src/screens/Onramp/CryptoOnrampFlow.tsx
+++ b/example/src/screens/Onramp/CryptoOnrampFlow.tsx
@@ -28,7 +28,9 @@ import {
   saveUser,
   createLinkAuthToken,
   getCryptoCustomerId,
+  fetchCustomerWallets,
 } from '../../api/onrampBackend';
+import type { CustomerWallet } from '../../api/onrampBackend';
 import {
   getDestinationParamsForNetwork,
   formatIdentifierRequirements,
@@ -91,6 +93,7 @@ export default function CryptoOnrampFlow() {
     attachKycInfo,
     retrieveMissingIdentifiers,
     submitIdentifiers,
+    deleteWalletAddress,
     getWalletOwnershipChallenge,
     submitWalletOwnershipSignature,
     presentUserAttestation,
@@ -180,6 +183,8 @@ export default function CryptoOnrampFlow() {
   const [walletAddress, setWalletAddress] = useState<string | null>(null);
   const [walletNetwork, setWalletNetwork] =
     useState<Onramp.CryptoNetwork | null>(null);
+  const [wallets, setWallets] = useState<CustomerWallet[]>([]);
+  const [isWalletsLoading, setIsWalletsLoading] = useState(false);
   const [walletOwnershipChallenge, setWalletOwnershipChallenge] =
     useState<Onramp.WalletOwnershipChallenge | null>(null);
   const [walletOwnershipVerified, setWalletOwnershipVerified] = useState<
@@ -584,6 +589,75 @@ export default function CryptoOnrampFlow() {
     }
   }, [userInfo.phoneNumber, updatePhoneNumber]);
 
+  const handleRefreshWallets = useCallback(async () => {
+    if (!authToken) {
+      showError('Please log in to the demo backend first.');
+      return;
+    }
+
+    setIsWalletsLoading(true);
+
+    try {
+      const result = await fetchCustomerWallets(authToken);
+      if (!result.success) {
+        showError(
+          `Failed to fetch wallets: ${result.error.code} - ${result.error.message}`
+        );
+        return;
+      }
+
+      setWallets(result.data.data);
+    } finally {
+      setIsWalletsLoading(false);
+    }
+  }, [authToken]);
+
+  const handleDeleteWallet = useCallback(
+    async (wallet: CustomerWallet) => {
+      setIsWalletsLoading(true);
+
+      try {
+        const result = await withReauth(
+          () => deleteWalletAddress(wallet.id),
+          () => authorize(linkAuthIntentId)
+        );
+
+        if (result.error) {
+          showError(`Failed to delete wallet: ${result.error.message}.`);
+          return;
+        }
+
+        setWallets((currentWallets) =>
+          currentWallets.filter(
+            (currentWallet) => currentWallet.id !== wallet.id
+          )
+        );
+
+        if (
+          wallet.walletAddress === walletAddress &&
+          wallet.network === walletNetwork
+        ) {
+          setWalletAddress(null);
+          setWalletNetwork(null);
+          setWalletOwnershipChallenge(null);
+          setWalletOwnershipVerified(null);
+        }
+
+        showSuccess('Wallet deleted successfully!');
+      } finally {
+        setIsWalletsLoading(false);
+      }
+    },
+    [
+      authorize,
+      deleteWalletAddress,
+      linkAuthIntentId,
+      walletAddress,
+      walletNetwork,
+      withReauth,
+    ]
+  );
+
   const handleGetWalletOwnershipChallenge = useCallback(async () => {
     const address = walletAddress?.trim();
     const network = walletNetwork;
@@ -944,6 +1018,7 @@ export default function CryptoOnrampFlow() {
       setStoredDemoAuth(null);
       setWalletAddress(null);
       setWalletNetwork(null);
+      setWallets([]);
       setWalletOwnershipChallenge(null);
       setWalletOwnershipVerified(null);
       setOnrampSessionId(null);
@@ -952,6 +1027,12 @@ export default function CryptoOnrampFlow() {
       setAchSettlementSpeed('instant');
     }
   }, [logOut]);
+
+  useEffect(() => {
+    if (isLinkUser && customerId && authToken) {
+      handleRefreshWallets();
+    }
+  }, [authToken, customerId, handleRefreshWallets, isLinkUser]);
 
   useEffect(() => {
     let mounted = true;
@@ -1211,11 +1292,16 @@ export default function CryptoOnrampFlow() {
             handleCreateCryptoPaymentToken={handleCreateCryptoPaymentToken}
           />
           <RegisterWalletAddressSection
+            wallets={wallets}
+            isWalletsLoading={isWalletsLoading}
+            onDeleteWallet={handleDeleteWallet}
+            onRefreshWallets={handleRefreshWallets}
             onWalletRegistered={(address, network) => {
               setWalletAddress(address);
               setWalletNetwork(network);
               setWalletOwnershipChallenge(null);
               setWalletOwnershipVerified(null);
+              handleRefreshWallets();
             }}
           />
           <WalletOwnershipSection

--- a/example/src/screens/Onramp/sections/RegisterWalletAddressSection.tsx
+++ b/example/src/screens/Onramp/sections/RegisterWalletAddressSection.tsx
@@ -1,17 +1,34 @@
 import React, { useCallback, useState } from 'react';
-import { View, Text, Alert } from 'react-native';
+import {
+  ActivityIndicator,
+  Alert,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
 import { Picker } from '@react-native-picker/picker';
 import { Collapse } from '../../../components/Collapse';
 import Button from '../../../components/Button';
 import { FormField } from '../FormField';
 import { useOnramp, Onramp } from '@stripe/stripe-react-native';
 import { getDefaultAddressForNetwork } from '../utils';
+import { colors } from '../../../colors';
+import type { CustomerWallet } from '../../../api/onrampBackend';
 
 interface RegisterWalletAddressSectionProps {
+  wallets: CustomerWallet[];
+  isWalletsLoading: boolean;
+  onDeleteWallet: (wallet: CustomerWallet) => void;
+  onRefreshWallets: () => void;
   onWalletRegistered?: (address: string, network: Onramp.CryptoNetwork) => void;
 }
 
 export function RegisterWalletAddressSection({
+  wallets,
+  isWalletsLoading,
+  onDeleteWallet,
+  onRefreshWallets,
   onWalletRegistered,
 }: RegisterWalletAddressSectionProps) {
   const { registerWalletAddress } = useOnramp();
@@ -53,7 +70,57 @@ export function RegisterWalletAddressSection({
 
   return (
     <Collapse title="Wallet Registration" initialExpanded={true}>
-      <View style={{ paddingVertical: 16, gap: 4 }}>
+      <View style={styles.container}>
+        <View style={styles.walletsHeader}>
+          <Text style={styles.walletsTitle}>Registered Wallets</Text>
+          <View style={styles.refreshContainer}>
+            {isWalletsLoading && <ActivityIndicator size="small" />}
+            <TouchableOpacity
+              accessibilityRole="button"
+              disabled={isWalletsLoading}
+              onPress={onRefreshWallets}
+              style={isWalletsLoading && styles.disabled}
+            >
+              <Text style={styles.refreshText}>Refresh</Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+
+        {wallets.length === 0 && !isWalletsLoading && (
+          <Text style={styles.emptyWalletsText}>No registered wallets</Text>
+        )}
+
+        {wallets.map((wallet) => (
+          <View key={wallet.id} style={styles.walletRow}>
+            <View style={styles.walletDetails}>
+              <Text style={styles.walletNetwork}>
+                {wallet.network.charAt(0).toUpperCase() +
+                  wallet.network.slice(1)}
+              </Text>
+              <Text selectable style={styles.walletAddress}>
+                {wallet.walletAddress}
+              </Text>
+              <Text selectable style={styles.walletId}>
+                ID: {wallet.id}
+              </Text>
+              {wallet.verifiedOwnership && (
+                <Text style={styles.verifiedWallet}>Verified</Text>
+              )}
+            </View>
+            <TouchableOpacity
+              accessibilityLabel={`Delete ${wallet.network} wallet`}
+              accessibilityRole="button"
+              disabled={isWalletsLoading}
+              onPress={() => onDeleteWallet(wallet)}
+              style={isWalletsLoading && styles.disabled}
+            >
+              <Text style={styles.deleteText}>Delete</Text>
+            </TouchableOpacity>
+          </View>
+        ))}
+
+        <View style={styles.separator} />
+
         <Text style={{ marginBottom: 8 }}>Wallet Address:</Text>
         <FormField
           label="Wallet Address"
@@ -92,6 +159,7 @@ export function RegisterWalletAddressSection({
           title="Register Wallet Address"
           onPress={handleRegisterWallet}
           variant="primary"
+          disabled={isWalletsLoading}
         />
         {response && (
           <Text style={{ marginTop: 12, fontSize: 12, color: '#333' }}>
@@ -102,3 +170,73 @@ export function RegisterWalletAddressSection({
     </Collapse>
   );
 }
+
+const styles = StyleSheet.create({
+  container: {
+    paddingVertical: 16,
+    gap: 4,
+  },
+  walletsHeader: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+  },
+  walletsTitle: {
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  refreshContainer: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    gap: 12,
+  },
+  refreshText: {
+    color: colors.blurple,
+    fontSize: 16,
+    fontWeight: '600',
+    padding: 8,
+  },
+  emptyWalletsText: {
+    color: colors.dark_gray,
+    marginBottom: 16,
+  },
+  walletRow: {
+    alignItems: 'center',
+    backgroundColor: colors.light_gray,
+    borderRadius: 8,
+    flexDirection: 'row',
+    marginBottom: 8,
+    padding: 12,
+  },
+  walletDetails: {
+    flex: 1,
+  },
+  walletNetwork: {
+    fontWeight: '500',
+  },
+  walletAddress: {
+    fontFamily: 'monospace',
+    fontSize: 12,
+  },
+  walletId: {
+    color: colors.dark_gray,
+    fontFamily: 'monospace',
+    fontSize: 12,
+  },
+  verifiedWallet: {
+    color: '#2E7D32',
+    fontSize: 12,
+  },
+  deleteText: {
+    color: '#B00020',
+    fontSize: 16,
+    fontWeight: '600',
+    padding: 8,
+  },
+  separator: {
+    height: 12,
+  },
+  disabled: {
+    opacity: 0.3,
+  },
+});

--- a/ios/StripeOnrampSdk.mm
+++ b/ios/StripeOnrampSdk.mm
@@ -58,6 +58,13 @@ RCT_EXPORT_METHOD(registerWalletAddress:(nonnull NSString *)address
   [StripeSdkImpl.shared registerWalletAddress:address network:network resolver:resolve rejecter:reject];
 }
 
+RCT_EXPORT_METHOD(deleteWalletAddress:(nonnull NSString *)walletId
+                              resolve:(nonnull RCTPromiseResolveBlock)resolve
+                               reject:(nonnull RCTPromiseRejectBlock)reject)
+{
+  [StripeSdkImpl.shared deleteWalletAddress:walletId resolver:resolve rejecter:reject];
+}
+
 RCT_EXPORT_METHOD(getWalletOwnershipChallenge:(nonnull NSString *)walletAddress
                                       network:(nonnull NSString *)network
                                       resolve:(nonnull RCTPromiseResolveBlock)resolve

--- a/ios/StripeSdkImpl.swift
+++ b/ios/StripeSdkImpl.swift
@@ -1423,6 +1423,27 @@ public class StripeSdkImpl: NSObject, UIAdaptivePresentationControllerDelegate {
         }
     }
 
+    @objc(deleteWalletAddress:resolver:rejecter:)
+    public func deleteWalletAddress(
+        walletId: String,
+        resolver resolve: @escaping RCTPromiseResolveBlock,
+        rejecter reject: @escaping RCTPromiseRejectBlock
+    ) {
+        guard isPublishableKeyAvailable(resolve), let coordinator = requireOnrampCoordinator(resolve) else {
+            return
+        }
+
+        Task {
+            do {
+                try await coordinator.deleteWalletAddress(walletId: walletId)
+                resolve([:])  // Return empty object on success
+            } catch {
+                let errorResult = OnrampErrors.createFailedError(error)
+                resolve(["error": errorResult["error"]!])
+            }
+        }
+    }
+
     @objc(getWalletOwnershipChallenge:network:resolver:rejecter:)
     public func getWalletOwnershipChallenge(
         walletAddress: String,

--- a/jest/setup.js
+++ b/jest/setup.js
@@ -12,6 +12,7 @@ jest.mock('../src/specs/NativeOnrampSdkModule', () => ({
     hasLinkAccount: jest.fn(),
     registerLinkUser: jest.fn(),
     registerWalletAddress: jest.fn(),
+    deleteWalletAddress: jest.fn(),
     getWalletOwnershipChallenge: jest.fn(),
     submitWalletOwnershipSignature: jest.fn(),
     attachKycInfo: jest.fn(),

--- a/src/hooks/useOnramp.tsx
+++ b/src/hooks/useOnramp.tsx
@@ -66,6 +66,13 @@ export function useOnramp() {
     []
   );
 
+  const _deleteWalletAddress = useCallback(
+    async (walletId: string): Promise<{ error?: Onramp.CryptoOnrampError }> => {
+      return requireOnrampModule().deleteWalletAddress(walletId);
+    },
+    []
+  );
+
   const _getWalletOwnershipChallenge = useCallback(
     async (
       walletAddress: string,
@@ -284,6 +291,15 @@ export function useOnramp() {
      * @returns Promise that resolves to an object with an optional error property
      */
     registerWalletAddress: _registerWalletAddress,
+
+    /**
+     * Deletes the given crypto wallet from the current Link account.
+     * Requires an authenticated Link user.
+     *
+     * @param walletId The ID of the crypto wallet to delete
+     * @returns Promise that resolves to an object with an optional error property
+     */
+    deleteWalletAddress: _deleteWalletAddress,
 
     /**
      * Creates a short-lived challenge for proving ownership of a registered wallet.

--- a/src/specs/NativeOnrampSdkModule.ts
+++ b/src/specs/NativeOnrampSdkModule.ts
@@ -16,6 +16,7 @@ export interface Spec extends TurboModule {
     walletAddress: string,
     network: string
   ): Promise<Onramp.VoidResult>;
+  deleteWalletAddress(walletId: string): Promise<Onramp.VoidResult>;
   getWalletOwnershipChallenge(
     walletAddress: string,
     network: string


### PR DESCRIPTION
## Summary
- This adds the wallet address deletion bindings to the CryptoOnramp SDK.
- For the example app, it also adds demo backend support for fetching and listing wallets, and the ability to delete those wallet from the user's account.

## Motivation
To keep parity with the native SDKs.

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [ ] I added automated tests
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

| Wallet List | Wallet Deletion |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/77cebcfb-55ca-4b6b-95d2-ac26e549fcf3" width="300" /> | <img src="https://github.com/user-attachments/assets/388b71de-95fb-4b7c-b448-53091af65076" width="300" /> |

## Documentation

Select one: 
- [x] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
