### PR TITLE
Propose 0.75.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## Unreleased
+## 0.75.0 - 2026-08-18
 **Features**
 * [Added] Added typed Crypto Onramp error coverage for wallet ownership verification failures.
 

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -3,4 +3,4 @@ StripeSdk_compileSdkVersion=36
 StripeSdk_targetSdkVersion=36
 StripeSdk_minSdkVersion=23
 # Keep StripeSdk_stripeVersion in sync with https://github.com/stripe/stripe-identity-react-native/blob/main/android/gradle.properties
-StripeSdk_stripeVersion=23.15.0
+StripeSdk_stripeVersion=23.16.0

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1820,14 +1820,14 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - Stripe (26.6.0):
-    - StripeApplePay (= 26.6.0)
-    - StripeCore (= 26.6.0)
-    - StripeIssuing (= 26.6.0)
-    - StripePayments (= 26.6.0)
-    - StripePaymentsUI (= 26.6.0)
-    - StripeUICore (= 26.6.0)
-  - stripe-react-native (0.74.0):
+  - Stripe (26.7.0):
+    - StripeApplePay (= 26.7.0)
+    - StripeCore (= 26.7.0)
+    - StripeIssuing (= 26.7.0)
+    - StripePayments (= 26.7.0)
+    - StripePaymentsUI (= 26.7.0)
+    - StripeUICore (= 26.7.0)
+  - stripe-react-native (0.75.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1848,10 +1848,10 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-    - stripe-react-native/Core (= 0.74.0)
-    - stripe-react-native/NewArch (= 0.74.0)
+    - stripe-react-native/Core (= 0.75.0)
+    - stripe-react-native/NewArch (= 0.75.0)
     - Yoga
-  - stripe-react-native/Core (0.74.0):
+  - stripe-react-native/Core (0.75.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1872,14 +1872,14 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-    - Stripe (= 26.6.0)
-    - StripeApplePay (= 26.6.0)
-    - StripeFinancialConnections (= 26.6.0)
-    - StripePayments (= 26.6.0)
-    - StripePaymentSheet (= 26.6.0)
-    - StripePaymentsUI (= 26.6.0)
+    - Stripe (= 26.7.0)
+    - StripeApplePay (= 26.7.0)
+    - StripeFinancialConnections (= 26.7.0)
+    - StripePayments (= 26.7.0)
+    - StripePaymentSheet (= 26.7.0)
+    - StripePaymentsUI (= 26.7.0)
     - Yoga
-  - stripe-react-native/NewArch (0.74.0):
+  - stripe-react-native/NewArch (0.75.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1901,7 +1901,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - stripe-react-native/Onramp (0.74.0):
+  - stripe-react-native/Onramp (0.75.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1923,9 +1923,9 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - stripe-react-native/Core
-    - StripeCryptoOnramp (= 26.6.0)
+    - StripeCryptoOnramp (= 26.7.0)
     - Yoga
-  - stripe-react-native/Tests (0.74.0):
+  - stripe-react-native/Tests (0.75.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1947,46 +1947,49 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - StripeApplePay (26.6.0):
-    - StripeCore (= 26.6.0)
-  - StripeCameraCore (26.6.0):
-    - StripeCore (= 26.6.0)
-  - StripeCore (26.6.0)
-  - StripeCryptoOnramp (26.6.0):
-    - StripeApplePay (= 26.6.0)
-    - StripeCore (= 26.6.0)
-    - StripeIdentity (= 26.6.0)
-    - StripePayments (= 26.6.0)
-    - StripePaymentSheet (= 26.6.0)
-    - StripePaymentsUI (= 26.6.0)
-    - StripeUICore (= 26.6.0)
-  - StripeFinancialConnections (26.6.0):
-    - StripeCore (= 26.6.0)
-    - StripeUICore (= 26.6.0)
-  - StripeIdentity (26.6.0):
-    - StripeCameraCore (= 26.6.0)
-    - StripeCore (= 26.6.0)
-    - StripeUICore (= 26.6.0)
-  - StripeIssuing (26.6.0):
-    - StripeCore (= 26.6.0)
-    - StripePayments (= 26.6.0)
-    - StripePaymentsUI (= 26.6.0)
-  - StripePayments (26.6.0):
-    - StripeCore (= 26.6.0)
-    - StripePayments/Stripe3DS2 (= 26.6.0)
-  - StripePayments/Stripe3DS2 (26.6.0):
-    - StripeCore (= 26.6.0)
-  - StripePaymentSheet (26.6.0):
-    - StripeApplePay (= 26.6.0)
-    - StripeCore (= 26.6.0)
-    - StripePayments (= 26.6.0)
-    - StripePaymentsUI (= 26.6.0)
-  - StripePaymentsUI (26.6.0):
-    - StripeCore (= 26.6.0)
-    - StripePayments (= 26.6.0)
-    - StripeUICore (= 26.6.0)
-  - StripeUICore (26.6.0):
-    - StripeCore (= 26.6.0)
+  - StripeApplePay (26.7.0):
+    - StripeCore (= 26.7.0)
+  - StripeCameraCore (26.7.0):
+    - StripeCore (= 26.7.0)
+  - StripeCore (26.7.0)
+  - StripeCryptoOnramp (26.7.0):
+    - StripeApplePay (= 26.7.0)
+    - StripeCore (= 26.7.0)
+    - StripeIdentity (= 26.7.0)
+    - StripePayments (= 26.7.0)
+    - StripePaymentSheet (= 26.7.0)
+    - StripePaymentsUI (= 26.7.0)
+    - StripeUICore (= 26.7.0)
+  - StripeFinancialConnections (26.7.0):
+    - StripeCore (= 26.7.0)
+    - StripeUICore (= 26.7.0)
+  - StripeFinancialConnectionsLite (26.7.0):
+    - StripeCore (= 26.7.0)
+  - StripeIdentity (26.7.0):
+    - StripeCameraCore (= 26.7.0)
+    - StripeCore (= 26.7.0)
+    - StripeUICore (= 26.7.0)
+  - StripeIssuing (26.7.0):
+    - StripeCore (= 26.7.0)
+    - StripePayments (= 26.7.0)
+    - StripePaymentsUI (= 26.7.0)
+  - StripePayments (26.7.0):
+    - StripeCore (= 26.7.0)
+    - StripePayments/Stripe3DS2 (= 26.7.0)
+  - StripePayments/Stripe3DS2 (26.7.0):
+    - StripeCore (= 26.7.0)
+  - StripePaymentSheet (26.7.0):
+    - StripeApplePay (= 26.7.0)
+    - StripeCore (= 26.7.0)
+    - StripeFinancialConnectionsLite (= 26.7.0)
+    - StripePayments (= 26.7.0)
+    - StripePaymentsUI (= 26.7.0)
+  - StripePaymentsUI (26.7.0):
+    - StripeCore (= 26.7.0)
+    - StripePayments (= 26.7.0)
+    - StripeUICore (= 26.7.0)
+  - StripeUICore (26.7.0):
+    - StripeCore (= 26.7.0)
   - Yoga (0.0.0)
 
 DEPENDENCIES:
@@ -2077,6 +2080,7 @@ SPEC REPOS:
     - StripeCore
     - StripeCryptoOnramp
     - StripeFinancialConnections
+    - StripeFinancialConnectionsLite
     - StripeIdentity
     - StripeIssuing
     - StripePayments
@@ -2311,19 +2315,20 @@ SPEC CHECKSUMS:
   RNCAsyncStorage: 3a4f5e2777dae1688b781a487923a08569e27fe4
   RNCPicker: c8a3584b74133464ee926224463fcc54dfdaebca
   RNScreens: 61c18865ab074f4d995ac8d7cf5060522a649d05
-  Stripe: 2aa937a5b3dc1db7b42392a70cd4d4534dd2e77b
-  stripe-react-native: b75bf2cb4c4714876b2efd808532d34fa924eae2
-  StripeApplePay: 73d55b6586e0acf7c5897100bf3dc7924488cf2d
-  StripeCameraCore: d3a281318aae77233616ce0336572afe7000db7c
-  StripeCore: 06bafa6087c3fa240460d9feb6729543d1634961
-  StripeCryptoOnramp: 8953cc4ac938ffeedf524f3f9c6bc9d0ecaa9d79
-  StripeFinancialConnections: 648b3cba2b42198fce9c1f3e5f997543031a76f4
-  StripeIdentity: 0ea131379bb6d78c50dfa57861d1ff1d3472d74f
-  StripeIssuing: dfd966fd0c32dc2d38c5cea8f18d88969967eaaf
-  StripePayments: c20f9058b588fb4f677822d6d415d8d59ae21fc3
-  StripePaymentSheet: 87e00057a5867f6a594bd1285494b6efe43639a9
-  StripePaymentsUI: 8af6ccdeea136ef2c8b942b27e6a33c4ff84e877
-  StripeUICore: 500ec9fd1c7c733a33f28c6a4b75423b87496ee4
+  Stripe: 62f19d63a53ed29f6d068f840346a0026dbe23d9
+  stripe-react-native: 59b3adcee6bcb78b187ba840f434b1485bf9d712
+  StripeApplePay: 0226102f6b161d5c6159c4ff22f1c3d0c47d1d05
+  StripeCameraCore: c686801a2e257b47953272e56856da9ba18a1aa2
+  StripeCore: 87da160bc7e185cf17d4fe3b06f8c939ee220ded
+  StripeCryptoOnramp: 8694642ee5b7d28d00ad87c026ebab3730968afd
+  StripeFinancialConnections: 1b4a2c7c5657302d1ee5566773b877e2ec22f9a2
+  StripeFinancialConnectionsLite: 8a3bc78c5706950c1e2e0c629f7fd3fe7bb8495c
+  StripeIdentity: 99ab625e2f9ac00efc2fb729d920d0f440d44853
+  StripeIssuing: 7e3d1caa14f1c28b377dbc26c9f59163e1221f95
+  StripePayments: 83e5961152ca742a67eb7fe28b777a579892a231
+  StripePaymentSheet: a3e15549e052d8cfcd479e9054e0c79a60709813
+  StripePaymentsUI: 06e878345ca13e12662bec3839e54e1320b98a4e
+  StripeUICore: 28ec9064839fcf23e9e40bba3f4651ac9123eab3
   Yoga: 5934998fbeaef7845dbf698f698518695ab4cd1a
 
 PODFILE CHECKSUM: 605f3cad878b7c0eee93ebb4a78a8141d34cd328

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stripe/stripe-react-native",
-  "version": "0.74.0",
+  "version": "0.75.0",
   "author": "Stripe",
   "description": "Stripe SDK for React Native",
   "main": "lib/commonjs/index",

--- a/stripe-react-native.podspec
+++ b/stripe-react-native.podspec
@@ -2,7 +2,7 @@ require 'json'
 
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 # Keep stripe_version in sync with https://github.com/stripe/stripe-identity-react-native/blob/main/stripe-identity-react-native.podspec
-stripe_version = '26.6.0'
+stripe_version = '26.7.0'
 
 fabric_enabled = ENV['RCT_NEW_ARCH_ENABLED'] == '1'
 


### PR DESCRIPTION
- [x] Ensure the CHANGELOG is up to date with all relevant commits since the last release
- [x] Add the version number for this release & the date to the CHANGELOG, underneath "## Unreleased"
  - e.g. "## 1.2.3 - 2022-02-14"
- [x] Update stripe-ios to the latest GitHub release (26.7.0)
- [x] Update stripe-android to the latest GitHub release (23.16.0)
- [x] Update the README if necessary (this is only required when there are breaking changes in the release, such as dropping support for an iOS || Android version)
