### PR TITLE
Fix PaymentSheet startActivity crash after checkout re-open (Android)

### DIFF
--- a/android/src/main/java/com/reactnativestripesdk/PaymentSheetManager.kt
+++ b/android/src/main/java/com/reactnativestripesdk/PaymentSheetManager.kt
@@ -87,6 +87,10 @@ class PaymentSheetManager(
   private var keepJsAwake: KeepJsAwakeTask? = null
   private var lastConfigureWasCustomFlow: Boolean? = null
 
+  // Activity `paymentSheet`/`flowController` registered their launchers on; if the current
+  // Activity is ever a different instance, those launchers are stale and must be rebuilt.
+  private var builtWithActivity: Activity? = null
+
   @SuppressLint("RestrictedApi")
   override fun onCreate() {
     configure(arguments, initPromise)
@@ -96,6 +100,7 @@ class PaymentSheetManager(
     super.onDestroy()
     flowController = null
     paymentSheet = null
+    builtWithActivity = null
   }
 
   fun configure(
@@ -211,9 +216,13 @@ class PaymentSheetManager(
     args: ReadableMap,
     promise: Promise,
   ) {
+    val currentActivity = context.currentActivity
+    val activityChanged = currentActivity != null && currentActivity !== builtWithActivity
+
     if (args.getBooleanOr("customFlow", false)) {
       lastConfigureWasCustomFlow = true
-      if (flowController == null) {
+      if (flowController == null || activityChanged) {
+        flowController = null
         initFlowController(args, promise)
       }
       configureFlowController(promise)
@@ -221,7 +230,8 @@ class PaymentSheetManager(
     }
 
     lastConfigureWasCustomFlow = false
-    if (paymentSheet == null) {
+    if (paymentSheet == null || activityChanged) {
+      paymentSheet = null
       initPaymentSheet(args, promise)
     }
     promise.resolve(Arguments.createMap())
@@ -253,6 +263,7 @@ class PaymentSheetManager(
           .confirmCustomPaymentMethodCallback(this)
           .build(activity, signal)
       }
+    builtWithActivity = activity
   }
 
   private fun initFlowController(
@@ -286,6 +297,7 @@ class PaymentSheetManager(
           ).confirmCustomPaymentMethodCallback(this)
           .build(activity)
       }
+    builtWithActivity = activity
   }
 
   private fun buildCreateConfirmationTokenCallback(): CreateIntentWithConfirmationTokenCallback {


### PR DESCRIPTION
## Summary
Fixes #2563 — PaymentSheet gets stuck erroring on Android after close/reopen of checkout, with the log:
```
startActivity called from non-Activity context; forcing Intent.FLAG_ACTIVITY_NEW_TASK
```

`PaymentSheetManager` caches `paymentSheet`/`flowController` for its whole lifetime and only rebuilds when the field is `null`. Both are built via `.build(activity, signal)`, which registers `ActivityResultLauncher`s on that specific `Activity` instance. If the underlying `Activity` is recreated while the manager stays alive across a close/reopen of the checkout screen, the cached instance keeps pointing at launchers registered on a dead `Activity`, and presenting falls back to `startActivity` on a non-`Activity` context — matching the reporter's log exactly.

This PR tracks which `Activity` the sheet/controller was built against (`builtWithActivity`). In `configureMode`, if the current `Activity` differs from that, the cached instance is nulled out and rebuilt against the fresh `Activity` before presenting.

## Verification
- Compiles cleanly against the Android SDK (`android-36`) with no new imports.
- Full existing Android unit test suite passes: `./gradlew :stripe_stripe-react-native:testDebugUnitTest` — 346/346 tests, 0 failures.
- **Not yet covered by a dedicated regression test** — the existing `PaymentSheetManagerTest.kt` only exercises pure mapper functions and `handleFlowControllerConfigured`, nothing in the activity-rebuild path itself.
- **Not reproduced against a physical device** — I don't have the reporter's repro environment (Samsung Galaxy F15, Android 16). This is my best hypothesis from tracing `initPaymentSheet`/`initFlowController`/`onDestroy`/`presentWithTimeout`, not a confirmed root cause from a live repro.

Happy to add a Robolectric-based regression test for the activity-swap path, or adjust the approach, if a maintainer can confirm this matches the internal ticket's diagnosis.

## Test plan
- [ ] Maintainer/reporter confirms this resolves the repro in #2563
- [ ] Add regression test for activity-rebuild path (open to guidance on best approach here)