### PR TITLE
chore: bump stripe-android 23.17.0

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -3,4 +3,4 @@ StripeSdk_compileSdkVersion=36
 StripeSdk_targetSdkVersion=36
 StripeSdk_minSdkVersion=23
 # Keep StripeSdk_stripeVersion in sync with https://github.com/stripe/stripe-identity-react-native/blob/main/android/gradle.properties
-StripeSdk_stripeVersion=23.16.0
+StripeSdk_stripeVersion=23.17.0


### PR DESCRIPTION
- `android/gradle.properties`: `StripeSdk_stripeVersion` → `23.17.0` ([release notes](https://github.com/stripe/stripe-android/releases/tag/v23.17.0))

_Automated by [`bump-native-sdks`](.github/workflows/bump-native-sdks.yml)_