### PR TITLE
fix: resolve promise in PaymentSheet intent/confirmation token creation callbacks

### DIFF
--- a/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
+++ b/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
@@ -341,6 +341,7 @@ class StripeSdkModule(
     }
 
     paymentSheetManager?.paymentSheetIntentCreationCallback?.complete(params)
+    promise.resolve(null)
   }
 
   @ReactMethod

--- a/ios/StripeSdkImpl.swift
+++ b/ios/StripeSdkImpl.swift
@@ -241,10 +241,12 @@ public class StripeSdkImpl: NSObject, UIAdaptivePresentationControllerDelegate {
         }
         if let clientSecret = result["clientSecret"] as? String {
             paymentSheetConfirmationTokenIntentCreationCallback(.success(clientSecret))
+            resolve(nil)
         } else {
             let errorParams = result["error"] as? NSDictionary
             let error = ConfirmationError.init(errorMessage: errorParams?["localizedMessage"] as? String ?? "An unknown error occurred.")
             paymentSheetConfirmationTokenIntentCreationCallback(.failure(error))
+            resolve(nil)
         }
     }
 


### PR DESCRIPTION
## Summary
`intentCreationCallback` and `confirmationTokenCreationCallback` never resolve on the success path, on either platform. This adds the missing `promise.resolve(null)` / `resolve(nil)` call after the result is handed off to the PaymentSheet continuation.

## Motivation
In the Flutter SDK that copies the react-native native implementations, the fact that these resolutions never happen prevents Future's in the flutter SDK to never complete when these methods are called.

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [ ] I added automated tests
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
