### PR TITLE
[SPM] Add the Expo SPM opt-out

### DIFF
--- a/src/plugin/__tests__/withStripe-test.ts
+++ b/src/plugin/__tests__/withStripe-test.ts
@@ -5,6 +5,7 @@ import {
   setApplePayEntitlement,
   setGooglePayMetaData,
   setOnrampGradleProperty,
+  setPodfileDisableSPM,
 } from '../withStripe';
 
 jest.mock(
@@ -173,5 +174,52 @@ describe('setOnrampGradleProperty', () => {
       key: 'StripeSdk_includeOnramp',
       value: 'true',
     });
+  });
+});
+
+describe('setPodfileDisableSPM', () => {
+  // Mirrors the shape of the Podfile Expo generates: the flag must land
+  // after `prepare_react_native_project!` and before the target block.
+  const samplePodfile = [
+    `require File.join(File.dirname(\`node --print "require.resolve('expo/package.json')"\`), "scripts/autolinking")`,
+    '',
+    'prepare_react_native_project!',
+    '',
+    "target 'StripeExpoTest' do",
+    '  use_expo_modules!',
+    'end',
+    '',
+  ].join('\n');
+
+  it('inserts $StripeDisableSPM = true after prepare_react_native_project!', () => {
+    const result = setPodfileDisableSPM(samplePodfile, true);
+
+    expect(result).toContain('$StripeDisableSPM = true');
+    expect(result.indexOf('prepare_react_native_project!')).toBeLessThan(
+      result.indexOf('$StripeDisableSPM = true')
+    );
+    expect(result.indexOf('$StripeDisableSPM = true')).toBeLessThan(
+      result.indexOf("target 'StripeExpoTest'")
+    );
+  });
+
+  it('is idempotent when the flag is already present', () => {
+    const once = setPodfileDisableSPM(samplePodfile, true);
+    const twice = setPodfileDisableSPM(once, true);
+
+    expect(twice).toEqual(once);
+    expect(twice.match(/\$StripeDisableSPM = true/g)).toHaveLength(1);
+  });
+
+  it('removes a previously generated flag when disableSPM is false', () => {
+    const enabled = setPodfileDisableSPM(samplePodfile, true);
+    const disabled = setPodfileDisableSPM(enabled, false);
+
+    expect(disabled).not.toContain('$StripeDisableSPM');
+    expect(disabled).toEqual(samplePodfile);
+  });
+
+  it('leaves the Podfile untouched when disableSPM is false and no flag was generated', () => {
+    expect(setPodfileDisableSPM(samplePodfile, false)).toEqual(samplePodfile);
   });
 });

--- a/src/plugin/withStripe.ts
+++ b/src/plugin/withStripe.ts
@@ -8,6 +8,10 @@ import {
   withGradleProperties,
   withPodfile,
 } from '@expo/config-plugins';
+import {
+  mergeContents,
+  removeGeneratedContents,
+} from '@expo/config-plugins/build/utils/generateCode';
 import path from 'path';
 
 const {
@@ -32,6 +36,16 @@ type StripePluginProps = {
    * Defaults to false.
    */
   includeOnramp?: boolean;
+  /**
+   * iOS only. When true, sets `$StripeDisableSPM = true` in the generated
+   * Podfile, so the Stripe iOS SDK is resolved through the CocoaPods registry
+   * instead of Swift Package Manager (available while Stripe continues to
+   * publish pods). Use this to opt out of SPM resolution — for example to
+   * keep building with static frameworks, which SPM mode does not support.
+   * Defaults to false (SPM resolution on React Native >= 0.75, which requires
+   * `expo-build-properties` with `"useFrameworks": "dynamic"`).
+   */
+  disableSPM?: boolean;
 };
 
 const withStripe: ConfigPlugin<StripePluginProps> = (config, props) => {
@@ -43,7 +57,7 @@ const withStripe: ConfigPlugin<StripePluginProps> = (config, props) => {
 
 const withStripeIos: ConfigPlugin<StripePluginProps> = (
   expoConfig,
-  { merchantIdentifier, includeOnramp = false }
+  { merchantIdentifier, includeOnramp = false, disableSPM = false }
 ) => {
   let resultConfig = withEntitlementsPlist(expoConfig, (entitlementsConfig) => {
     entitlementsConfig.modResults = setApplePayEntitlement(
@@ -51,6 +65,18 @@ const withStripeIos: ConfigPlugin<StripePluginProps> = (
       entitlementsConfig.modResults
     );
     return entitlementsConfig;
+  });
+
+  // Always run the Podfile mod (not just when disableSPM is true): when the
+  // option is turned back off, the previously generated block must be removed
+  // again, because `expo prebuild` without --clean reuses the existing
+  // Podfile.
+  resultConfig = withPodfile(resultConfig, (config) => {
+    config.modResults.contents = setPodfileDisableSPM(
+      config.modResults.contents,
+      disableSPM
+    );
+    return config;
   });
 
   // Conditionally include Onramp pod for iOS.
@@ -86,6 +112,38 @@ const withStripeIos: ConfigPlugin<StripePluginProps> = (
 
   return resultConfig;
 };
+
+const DISABLE_SPM_TAG = '@stripe/stripe-react-native-disableSPM';
+
+/**
+ * Adds `$StripeDisableSPM = true` to the Podfile (inside a tagged
+ * `@generated` block) when `disableSPM` is true, and removes any previously
+ * generated block when it is false.
+ *
+ * The flag is read by stripe_spm.rb when CocoaPods evaluates the
+ * stripe-react-native podspec, so it must be defined before any `target`
+ * block. The Podfile Expo generates opens with
+ * `prepare_react_native_project!` at the top level, which makes it a stable
+ * anchor: inserting immediately after it guarantees the flag precedes the
+ * target block on every Expo SDK's template
+ */
+export function setPodfileDisableSPM(
+  contents: string,
+  disableSPM: boolean
+): string {
+  if (!disableSPM) {
+    return removeGeneratedContents(contents, DISABLE_SPM_TAG) ?? contents;
+  }
+
+  return mergeContents({
+    src: contents,
+    newSrc: '$StripeDisableSPM = true',
+    tag: DISABLE_SPM_TAG,
+    anchor: /prepare_react_native_project!/,
+    offset: 1,
+    comment: '#',
+  }).contents;
+}
 
 /**
  * Adds the following to the entitlements:

--- a/src/plugin/withStripe.ts
+++ b/src/plugin/withStripe.ts
@@ -39,11 +39,12 @@ type StripePluginProps = {
   /**
    * iOS only. When true, sets `$StripeDisableSPM = true` in the generated
    * Podfile, so the Stripe iOS SDK is resolved through the CocoaPods registry
-   * instead of Swift Package Manager (available while Stripe continues to
-   * publish pods). Use this to opt out of SPM resolution — for example to
-   * keep building with static frameworks, which SPM mode does not support.
+   * instead of Swift Package Manager.
    * Defaults to false (SPM resolution on React Native >= 0.75, which requires
    * `expo-build-properties` with `"useFrameworks": "dynamic"`).
+   * WARNING: CocoaPods support is deprecated and future Stripe SDK versions
+   * will not provide this option. Only use it as a last resort to temporarily
+   * support static linking, old React Native versions, or as a stopgap workaround.
    */
   disableSPM?: boolean;
 };


### PR DESCRIPTION
## Summary
- Expose an opt-out from SPM resolution for Expo users
- Add automated testing for this opt-out

## Motivation
The SPM resolution is complicated and prone to bugs. We need to give users an escape hatch while we ensure that it is watertight. Expo users don't have access to the flag that normally controls this, so we need to expose something specifically for them.

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [ ] I tested this manually
- [x] I added automated tests
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Documentation

Select one: 
- [x] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
