### PR TITLE
[SPM] Run native tests from ReactTestApp

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -102,7 +102,11 @@ workflows:
           inputs:
             - project_path: example/ios/example.xcworkspace
             - destination: platform=iOS Simulator,name=iPhone 16 Pro Max
-            - scheme: stripe-react-native-Unit-Tests
+            # The SDK's native unit tests are compiled into the test app's
+            # ReactTestAppTests target by example/ios/Podfile (post_integrate),
+            # which also prepares the target for SPM-resolved dependencies.
+            - scheme: ReactTestApp
+            - xcodebuild_options: -only-testing:ReactTestAppTests
             - log_formatter: xcbeautify
       - save-cache@1:
           title: Save Pods Cache

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -80,7 +80,60 @@ options = {
   end,
 }
 
-use_test_app! options do |target|
-  pod 'stripe-react-native', path: '../node_modules/@stripe/stripe-react-native', testspecs: ['Tests']
+use_test_app! options do |_target|
+  pod 'stripe-react-native', path: '../node_modules/@stripe/stripe-react-native'
   pod 'stripe-react-native/Onramp', path: '../node_modules/@stripe/stripe-react-native'
+
+  # Declares the ReactTestAppTests target so CocoaPods integrates it (search
+  # paths etc.); its test sources are added in post_integrate below. The
+  # SDK's podspec test_spec isn't used here because test specs build inside
+  # the Pods project, where the SPM-resolved Stripe modules aren't visible to
+  # a separate test target the way they are to an app-level one.
+  _target.tests
+end
+
+# post_integrate runs after CocoaPods has written its projects and hooked
+# them into the workspace. react-native-test-app regenerates
+# ReactTestApp.xcodeproj under node_modules/.generated on every pod install,
+# so every adjustment here must be (re)applied on each run.
+post_integrate do |_installer|
+  project_path = "#{ws_dir}/node_modules/.generated/ios/ReactTestApp.xcodeproj"
+  project = Xcodeproj::Project.open(project_path)
+  test_target = project.targets.find { |target| target.name == 'ReactTestAppTests' }
+  app_target = project.targets.find { |target| target.name == 'ReactTestApp' }
+
+  # The SDK's public headers import React headers non-modularly; when the
+  # workspace builds with dynamic frameworks those imports land inside
+  # framework modules and Xcode rejects them without this setting.
+  [app_target, test_target].compact.each do |target|
+    target.build_configurations.each do |config|
+      config.build_settings['CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES'] = 'YES'
+    end
+  end
+
+  # The SDK's native unit tests live in the repo (ios/Tests), not in the
+  # generated test app; add them to the ReactTestAppTests target by reference
+  # so `xcodebuild test -scheme ReactTestApp` runs them.
+  tests_group = project.main_group.find_subpath('StripeReactNativeTests', true)
+  tests_group.path = '../../../../ios/Tests'
+  tests_group.source_tree = 'SOURCE_ROOT'
+
+  Dir.glob("#{ws_dir.parent}/ios/Tests/*.{m,swift}").sort.each do |path|
+    name = File.basename(path)
+    file_ref = tests_group.files.find { |file| file.path == name } || tests_group.new_file(name)
+    next if test_target.source_build_phase.files_references.include?(file_ref)
+
+    test_target.add_file_references([file_ref])
+  end
+
+  test_target.build_configurations.each do |config|
+    flags = Array(config.build_settings['OTHER_SWIFT_FLAGS'] || '$(inherited)')
+    flags = flags.flat_map { |flag| flag.to_s.split(' ') }
+    flags << '$(inherited)' unless flags.include?('$(inherited)')
+    # The tests conditionally compile new-architecture code paths.
+    flags << '-DRCT_NEW_ARCH_ENABLED' if new_arch_enabled && !flags.include?('-DRCT_NEW_ARCH_ENABLED')
+    config.build_settings['OTHER_SWIFT_FLAGS'] = flags
+  end
+
+  project.save
 end

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "run-example-android:release": "cd example && yarn build:android && yarn android --mode=release --no-packager",
     "test:e2e:ios": "bash ./scripts/run-maestro-tests ios",
     "test:e2e:android": "bash ./scripts/run-maestro-tests android",
-    "test:unit:ios": "xcodebuild test -workspace example/ios/example.xcworkspace -destination 'platform=iOS Simulator,name=iPhone 16 Pro Max' -scheme stripe-react-native-Unit-Tests",
+    "test:unit:ios": "xcodebuild test -workspace example/ios/example.xcworkspace -destination 'platform=iOS Simulator,name=iPhone 16 Pro Max' -scheme ReactTestApp -only-testing:ReactTestAppTests",
     "test:unit:android": "cd example/android && ./gradlew :stripe_stripe-react-native:testDebugUnitTest",
     "test-ios": "maestro test -e APP_ID=com.stripe.react.native",
     "test-android": "maestro test -e APP_ID=com.stripe.react.native",


### PR DESCRIPTION
## Summary
- declare the ReactTestAppTests target
- set CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES (this is removed in a future PR with a fix for the issue)
- add the tests to the ReactTestAppTests target

## Motivation
We used to declare tests via the `test_spec` in the podspec, but this doesn't work with the new SPM resolution, so we manually have them to a `ReactTestAppTests` target

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [ ] I tested this manually
- [ ] I added automated tests
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
