### PR TITLE
[SPM] Define SPM integration workflows

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -137,14 +137,10 @@ workflows:
   # via e2e-build-ios-old-arch / e2e-tests-ios-old-arch.
   #
   # Unlike unit-test-ios, this job embeds a prebuilt JS bundle
-  # (_build_js_bundle, as the e2e jobs do). CI has no Metro server, and with
-  # neither Metro nor an embedded bundle the Debug test app's old-arch launch
-  # path never becomes ready for XCTest — the run fails with "test runner
-  # hung before establishing connection" after the app's failed
-  # http://localhost:8081/status probe. react-native-test-app prefers Metro
-  # in Debug but falls back to the embedded main.ios.jsbundle once that probe
-  # fails, so the bundle unblocks launch. The new-arch (bridgeless) launch
-  # path happens to tolerate having no bundle at all, which is why
+  # (_build_js_bundle, as the e2e jobs do). CI has no Metro server, and
+  # without that react-native-test-app in Debug falls back to the embedded
+  # main.ios.jsbundle, so the bundle unblocks launch. The new-arch (bridgeless)
+  # launch path happens to tolerate having no bundle at all, which is why
   # unit-test-ios gets away without this step.
   unit-test-ios-old-arch:
     envs:
@@ -269,11 +265,8 @@ workflows:
 
   # Build-only coverage for the CocoaPods fallback path (STRIPE_DISABLE_SPM /
   # $StripeDisableSPM): Stripe resolved from the pod registry with React
-  # Native's default static libraries. All other iOS jobs run SPM mode, so
-  # without this job the fallback — what RN < 0.75 apps and opted-out apps use
-  # while Stripe still publishes pods — would have no CI coverage. New arch +
-  # static + pods is the closest match to today's real-world default app
-  # configuration. Build-only: no e2e-tests consumer pulls its artifact.
+  # Native's default static libraries. New arch + static + pods is most
+  # similar to an expected real-world default app configuration, so we use it.
   build-ios-fallback:
     envs:
       - NEW_ARCH_ENABLED: true

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -120,6 +120,64 @@ workflows:
           inputs:
             - notify_user_groups: none
 
+  # Old-architecture variant of unit-test-ios: the same native unit tests
+  # against an old-arch pod install (still SPM mode — dynamic frameworks with
+  # a source-built React core; see example/ios/Podfile). The iOS formatting
+  # check isn't repeated here: it is architecture-independent and already
+  # runs in unit-test-ios.
+  #
+  # Runs in the test-projects pipeline rather than per-PR. The marginal
+  # coverage is narrow — most of the unit suite is architecture-independent
+  # Swift, so old arch uniquely adds only the RCT_NEW_ARCH_ENABLED=0 compile
+  # of the OldArch compat layer and the tests' old-arch-conditional
+  # assertions (e.g. ReactNativeAnalyticsTests) — while the build is among
+  # the most expensive: old-arch SPM mode can't use the prebuilt React core
+  # (see example/ios/Podfile), so it source-builds React with dynamic
+  # frameworks. Old-arch build and runtime coverage still runs on every PR
+  # via e2e-build-ios-old-arch / e2e-tests-ios-old-arch.
+  #
+  # Unlike unit-test-ios, this job embeds a prebuilt JS bundle
+  # (_build_js_bundle, as the e2e jobs do). CI has no Metro server, and with
+  # neither Metro nor an embedded bundle the Debug test app's old-arch launch
+  # path never becomes ready for XCTest — the run fails with "test runner
+  # hung before establishing connection" after the app's failed
+  # http://localhost:8081/status probe. react-native-test-app prefers Metro
+  # in Debug but falls back to the embedded main.ios.jsbundle once that probe
+  # fails, so the bundle unblocks launch. The new-arch (bridgeless) launch
+  # path happens to tolerate having no bundle at all, which is why
+  # unit-test-ios gets away without this step.
+  unit-test-ios-old-arch:
+    envs:
+      - NEW_ARCH_ENABLED: false
+      - RCT_NEW_ARCH_ENABLED: 0
+    before_run:
+      - _prepare_ios
+      - _build_js_bundle
+      - _install_pods
+    steps:
+      - xcode-test@4:
+          title: Xcode Test for iOS
+          inputs:
+            - project_path: example/ios/example.xcworkspace
+            - destination: platform=iOS Simulator,name=iPhone 16 Pro Max
+            # The SDK's native unit tests are compiled into the test app's
+            # ReactTestAppTests target by example/ios/Podfile (post_integrate);
+            # the podspec deliberately ships no test spec, because one isn't
+            # usable under SPM resolution.
+            - scheme: ReactTestApp
+            - xcodebuild_options: -only-testing:ReactTestAppTests
+            - log_formatter: xcbeautify
+      - save-cache@1:
+          title: Save Pods Cache
+          is_always_run: true
+          inputs:
+            - key: pods-{{ .Arch }}-{{ getenv "NEW_ARCH_ENABLED" }}-{{ checksum "example/ios/Podfile.lock" }}
+            - paths: |
+                example/ios/Pods
+      - deploy-to-bitrise-io@2:
+          inputs:
+            - notify_user_groups: none
+
   unit-test-android:
     before_run:
       - _prepare_android
@@ -208,6 +266,54 @@ workflows:
       - RCT_NEW_ARCH_ENABLED: 1
     before_run:
       - _e2e_build_ios
+
+  # Build-only coverage for the CocoaPods fallback path (STRIPE_DISABLE_SPM /
+  # $StripeDisableSPM): Stripe resolved from the pod registry with React
+  # Native's default static libraries. All other iOS jobs run SPM mode, so
+  # without this job the fallback — what RN < 0.75 apps and opted-out apps use
+  # while Stripe still publishes pods — would have no CI coverage. New arch +
+  # static + pods is the closest match to today's real-world default app
+  # configuration. Build-only: no e2e-tests consumer pulls its artifact.
+  build-ios-fallback:
+    envs:
+      - NEW_ARCH_ENABLED: true
+      - RCT_NEW_ARCH_ENABLED: 1
+      - STRIPE_DISABLE_SPM: '1'
+    before_run:
+      - _e2e_build_ios
+
+  # Validates the Expo Continuous Native Generation path on every PR.
+  # Protects this behavior: a fresh `expo prebuild --clean`
+  # project gets exactly ONE `pod install`, so every SPM artifact (package
+  # reference, embed phase) must land in that single pass. The other iOS jobs
+  # all build the committed react-native-test-app project, which never
+  # exercises a from-scratch app project or the Expo config plugin.
+  #
+  # Two passes: SPM mode (expo-build-properties dynamic frameworks, asserts
+  # the SPM integration, then a full Release simulator build to catch
+  # compile/link regressions under Expo), and the CocoaPods fallback via the
+  # plugin's disableSPM option (prebuild + assertions only — fallback
+  # *builds* are covered by build-ios-fallback, and Expo's static default
+  # matches that configuration).
+  expo-prebuild-ios:
+    envs:
+      - EXPO_SDK_VERSION: '54'
+    before_run:
+      - _prepare_js
+    steps:
+      - script@1:
+          title: Expo prebuild + build (SPM mode)
+          timeout: 2700
+          inputs:
+            - content: ./scripts/test-expo-project --sdk-version "$EXPO_SDK_VERSION" --platforms ios
+      - script@1:
+          title: Expo prebuild, CocoaPods fallback (plugin disableSPM)
+          timeout: 1200
+          inputs:
+            - content: ./scripts/test-expo-project --sdk-version "$EXPO_SDK_VERSION" --platforms ios --disable-spm --skip-build
+      - deploy-to-bitrise-io@2:
+          inputs:
+            - notify_user_groups: none
 
   e2e-tests-ios-old-arch:
     envs:
@@ -531,11 +637,16 @@ workflows:
 
                 DERIVED_DATA_PATH="$BITRISE_SOURCE_DIR/DerivedData"
                 build_ios() {
+                  # ARCHS/ONLY_ACTIVE_ARCH: build only the arm64 simulator
+                  # slice (CI runners and the SPM-built Stripe package don't
+                  # need Intel), roughly halving Release build time.
                   xcodebuild -workspace example.xcworkspace \
                     -scheme example \
                     -configuration Release \
                     -sdk iphonesimulator \
                     -derivedDataPath "$DERIVED_DATA_PATH" \
+                    ARCHS=arm64 \
+                    ONLY_ACTIVE_ARCH=YES \
                     build | xcbeautify
                 }
                 build_ios || (echo "iOS build failed, retrying in 30s..." && sleep 30 && build_ios)


### PR DESCRIPTION
## Summary
1. add an old arch variant to the unit tests job that only runs in the test-project pipeline
2. add a build-only job for the CocoaPods fallback
3. add test for fresh Expo projects
4. limit E2E build to arm64 architecture only

## Motivation
Referencing the numbered items above:
1. This scenario now has different behavior with SPM resolution, and so we should add coverage of it, but not on every PR since it is expensive.
2. Ensure the health of the CocoaPods fallback
3. This was a scenario that had bugs during development, so we should guard against them
4. This is the only architecture actually needed for tests, and limiting CI to this reduces CI times. I manually verified that CI still runs find without this change (it's just much faster with it)

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [ ] I tested this manually
- [ ] I added automated tests
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
