### PR TITLE
[SPM] Remove stale SPM embed phases

### DIFF
--- a/stripe_spm.rb
+++ b/stripe_spm.rb
@@ -131,8 +131,8 @@ module StripeSPM
   ONRAMP_PRODUCT = 'StripeCryptoOnramp'.freeze
   ONRAMP_SUBSPEC = "#{POD_NAME}/Onramp".freeze
 
-  # Shown in Xcode's build-phases UI; also the key used to find/replace
-  # the phase on later installs.
+  # Shown in Xcode's build-phases UI; also the key used to find/replace/remove
+  # the phase on later installs (if the user moves off of SPM resolution).
   EMBED_PHASE_NAME = '[stripe-react-native] Embed SPM Frameworks'.freeze
 
   # Embeds SPM-built dynamic frameworks into the app bundle.
@@ -246,9 +246,15 @@ module StripeSPM
     def apply_user_project(installer)
       pod_target = installer.pod_targets.find { |target| target.pod_name == POD_NAME }
       return if pod_target.nil?
-      return unless active?
 
-      add_embed_phase(installer)
+      if active?
+        add_embed_phase(installer)
+      else
+        # SPM mode is off, but a previous install may have left the embed
+        # phase in the user's project (which, unlike Pods.xcodeproj, is not
+        # regenerated on each install). Clean it up so opting out is complete.
+        remove_embed_phase(installer)
+      end
     end
 
     private
@@ -362,6 +368,19 @@ module StripeSPM
         # phase under build-phase fingerprinting. Guarded because older
         # Xcodeproj gems don't model the attribute.
         phase.always_out_of_date = '1' if phase.respond_to?(:always_out_of_date=)
+        true
+      end
+    end
+
+    # Inverse of add_embed_phase, used when SPM mode is off. Needed so that
+    # if the user opts out of SPM resolution they aren't left with a harmless
+    # but confusing dead build phase in their project.
+    def remove_embed_phase(installer)
+      each_user_app_target(installer) do |user_target|
+        phase = user_target.shell_script_build_phases.find { |p| p.name == EMBED_PHASE_NAME }
+        next false if phase.nil?
+
+        phase.remove_from_project
         true
       end
     end

--- a/stripe_spm.rb
+++ b/stripe_spm.rb
@@ -251,7 +251,10 @@ module StripeSPM
       @version = version
     end
 
-    # True when the podspec declared the Swift package this install.
+    # True when the podspec declared the Swift package this install. When
+    # false (RN < 0.75 or $StripeDisableSPM), the installer hooks skip the
+    # Pods-project stage entirely and only perform cleanup in the
+    # user-project stage (see apply_user_project).
     def active?
       !@version.nil?
     end

--- a/stripe_spm.rb
+++ b/stripe_spm.rb
@@ -251,10 +251,7 @@ module StripeSPM
       @version = version
     end
 
-    # True when the podspec declared the Swift package this install. When
-    # false (RN < 0.75 or $StripeDisableSPM), the installer hooks skip the
-    # Pods-project stage entirely and only perform cleanup in the
-    # user-project stage (see apply_user_project).
+    # True when the podspec declared the Swift package this install.
     def active?
       !@version.nil?
     end


### PR DESCRIPTION
## Summary
Remove the build script we added to the user's project when they disable SPM resolution.

## Motivation
If a user uses SPM resolution (on by default) but then disables it, a zombie build phase will be left in there project. This is harmless but could be confusing and leaves a mess.

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [x] I added automated tests
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Documentation

Select one: 
- [x] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
