### PR TITLE
Fix PaymentSheet result activity race

### DIFF
--- a/android/src/main/java/com/reactnativestripesdk/PaymentSheetManager.kt
+++ b/android/src/main/java/com/reactnativestripesdk/PaymentSheetManager.kt
@@ -15,6 +15,7 @@ import android.util.Log
 import androidx.core.graphics.createBitmap
 import androidx.core.graphics.drawable.DrawableCompat
 import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.LifecycleEventListener
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReadableMap
@@ -61,6 +62,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withTimeoutOrNull
 import java.io.ByteArrayOutputStream
+import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.coroutines.resume
 
 @OptIn(
@@ -526,10 +528,12 @@ class PaymentSheetManager(
   }
 
   private fun resolvePaymentResult(map: WritableMap) {
-    confirmPromise?.let {
-      it.resolve(map)
-      confirmPromise = null
-    } ?: run { resolvePresentPromise(map) }
+    runWhenActivityAvailable(context) {
+      confirmPromise?.let {
+        it.resolve(map)
+        confirmPromise = null
+      } ?: run { resolvePresentPromise(map) }
+    }
   }
 
   override fun onConfirmCustomPaymentMethod(
@@ -615,6 +619,48 @@ class PaymentSheetManager(
 
     private const val CUSTOM_PAYMENT_METHOD_INIT_DELAY_MS = 100L
   }
+}
+
+internal fun runWhenActivityAvailable(
+  context: ReactApplicationContext,
+  action: () -> Unit,
+) {
+  if (context.currentActivity != null) {
+    action()
+    return
+  }
+
+  val didFinish = AtomicBoolean(false)
+  lateinit var listener: LifecycleEventListener
+
+  fun runIfActivityAvailable() {
+    if (context.currentActivity != null && didFinish.compareAndSet(false, true)) {
+      context.removeLifecycleEventListener(listener)
+      action()
+    }
+  }
+
+  listener =
+    object : LifecycleEventListener {
+      override fun onHostResume() {
+        runIfActivityAvailable()
+      }
+
+      override fun onHostPause() {
+        // No-op. Wait for the React activity to resume before resolving the promise.
+      }
+
+      override fun onHostDestroy() {
+        if (didFinish.compareAndSet(false, true)) {
+          context.removeLifecycleEventListener(this)
+        }
+      }
+    }
+
+  context.addLifecycleEventListener(listener)
+
+  // The activity can resume between the initial check and listener registration.
+  runIfActivityAvailable()
 }
 
 suspend fun waitForDrawableToLoad(

--- a/android/src/test/java/com/reactnativestripesdk/PaymentSheetManagerTest.kt
+++ b/android/src/test/java/com/reactnativestripesdk/PaymentSheetManagerTest.kt
@@ -1,24 +1,91 @@
 package com.reactnativestripesdk
 
+import android.app.Activity
+import com.facebook.react.bridge.LifecycleEventListener
 import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.WritableMap
 import com.reactnativestripesdk.utils.readableArrayOf
 import com.reactnativestripesdk.utils.readableMapOf
 import com.stripe.android.paymentelement.PaymentMethodOptionsSetupFutureUsagePreview
 import com.stripe.android.paymentsheet.PaymentSheet
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentCaptor
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.doAnswer
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
 import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
 @OptIn(PaymentMethodOptionsSetupFutureUsagePreview::class)
 class PaymentSheetManagerTest {
+  @Test
+  fun runWhenActivityAvailable_RunsImmediatelyWhenActivityIsAttached() {
+    val context = mock(ReactApplicationContext::class.java)
+    `when`(context.currentActivity).thenReturn(mock(Activity::class.java))
+    var didRun = false
+
+    runWhenActivityAvailable(context) {
+      didRun = true
+    }
+
+    assertTrue(didRun)
+  }
+
+  @Test
+  fun runWhenActivityAvailable_WaitsForHostResumeWhenActivityIsDetached() {
+    val context = mock(ReactApplicationContext::class.java)
+    var activity: Activity? = null
+    `when`(context.currentActivity).thenAnswer { activity }
+    var didRun = false
+
+    runWhenActivityAvailable(context) {
+      didRun = true
+    }
+
+    assertFalse(didRun)
+    val listener = captureLifecycleEventListener(context)
+    activity = mock(Activity::class.java)
+    listener.onHostResume()
+
+    assertTrue(didRun)
+    verify(context).removeLifecycleEventListener(listener)
+  }
+
+  @Test
+  fun runWhenActivityAvailable_HandlesActivityResumingDuringRegistration() {
+    val context = mock(ReactApplicationContext::class.java)
+    var activity: Activity? = null
+    `when`(context.currentActivity).thenAnswer { activity }
+    doAnswer {
+      activity = mock(Activity::class.java)
+      null
+    }.`when`(context).addLifecycleEventListener(any())
+    var didRun = false
+
+    runWhenActivityAvailable(context) {
+      didRun = true
+    }
+
+    assertTrue(didRun)
+    verify(context).removeLifecycleEventListener(any())
+  }
+
+  private fun captureLifecycleEventListener(
+    context: ReactApplicationContext,
+  ): LifecycleEventListener {
+    val captor = ArgumentCaptor.forClass(LifecycleEventListener::class.java)
+    verify(context).addLifecycleEventListener(captor.capture())
+    return captor.value
+  }
+
   // ============================================
   // mapToCollectionMode Tests
   // ============================================


### PR DESCRIPTION
## Summary
Delay PaymentSheet result promise resolution until the React host activity is available again.

## Motivation
The custom payment method E2E flow intermittently resolved `presentPaymentSheet` while Android was still transitioning away from PaymentSheet. An immediate React Native alert was then dropped with `Tried to show an alert while not attached to an Activity`, causing `paymentsheet-cpm.yml` to fail.

## Testing
- [ ] I tested this manually
- [x] I added automated tests

- `./gradlew :stripe_stripe-react-native:testDebugUnitTest --tests com.reactnativestripesdk.PaymentSheetManagerTest`
- `yarn format:android:check`
- `./gradlew :stripe_stripe-react-native:clean :app:assembleRelease --no-build-cache`
- `paymentsheet-cpm.yml` on Android: reproduced once in 6 clean iterations before the fix, then passed 20 consecutive iterations after the fix

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
