### PR TITLE
test: deflake PaymentSheet CPM flow

### DIFF
--- a/e2e-tests/paymentsheet-cpm.yml
+++ b/e2e-tests/paymentsheet-cpm.yml
@@ -2,32 +2,47 @@ appId: ${APP_ID}
 ---
 - launchApp:
     clearState: true
+- assertVisible:
+    text: "Accept a payment"
+    optional: true
+- runFlow:
+    when:
+      notVisible: "Accept a payment"
+    commands:
+      - launchApp
+      - extendedWaitUntil:
+          visible: "Accept a payment"
+          timeout: 30000
 - tapOn: "Accept a payment"
 - tapOn: "Prebuilt UI (single-step)"
 - tapOn: "Checkout"
 - extendedWaitUntil:
-    visible: "Card"
-    timeout: 30000
+    visible: "TEST"
+    timeout: 150000
 - scrollUntilVisible:
     element:
       text: "BufoPay (test)"
     timeout: 150000
 - tapOn:
     text: "BufoPay (test)"
-- scrollUntilVisible:
-    element:
-      id: "primary_button" # Android
-    optional: true
-- scrollUntilVisible:
-    element:
-      text: "purchase!" # iOS
-    optional: true
-- tapOn:
-    id: "primary_button" # Android
-    optional: true
-- tapOn:
-    text: "purchase!" # iOS
-    optional: true
+- runFlow:
+    when:
+      platform: android
+    commands:
+      - scrollUntilVisible:
+          element:
+            id: "primary_button"
+      - tapOn:
+          id: "primary_button"
+- runFlow:
+    when:
+      platform: ios
+    commands:
+      - scrollUntilVisible:
+          element:
+            text: "purchase!"
+      - tapOn:
+          text: "purchase!"
 - extendedWaitUntil:
     visible: "Custom Payment Method"
     timeout: 30000

--- a/example/src/screens/PaymentsUICompleteScreen.tsx
+++ b/example/src/screens/PaymentsUICompleteScreen.tsx
@@ -88,6 +88,9 @@ export default function PaymentsUICompleteScreen() {
     const { error } = await presentPaymentSheet();
 
     if (!error) {
+      // PaymentSheet can finish while its custom payment method dialog is still
+      // dismissing. Wait for that transition so this alert is not dropped.
+      await new Promise<void>((resolve) => setTimeout(resolve, 1000));
       Alert.alert('Success', 'The payment was confirmed successfully');
     } else {
       switch (error.code) {


### PR DESCRIPTION
## Summary
Stabilize the PaymentSheet custom payment method E2E flow by waiting for the result dialog transition, using stable and platform-specific selectors, and recovering from a transient initial app launch failure.

## Motivation
Repeated execution reproduced dropped success alerts, a selector failure when PaymentSheet displayed a saved card, and a transient app launch crash. These races made `paymentsheet-cpm.yml` fail intermittently even though the custom payment method flow was working.

## Testing
- [ ] I tested this manually
- [ ] I added automated tests

- `paymentsheet-cpm.yml`: 20 consecutive Android passes with Maestro 2.10.0
- `yarn eslint example/src/screens/PaymentsUICompleteScreen.tsx`
- `yarn prettier --check example/src/screens/PaymentsUICompleteScreen.tsx`
- Pre-commit TypeScript and ESLint checks passed
- `cd example && yarn typescript` still reports unrelated pre-existing generated-library mismatches; it reports no diagnostics in the changed screen

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
