### PR TITLE
Add test deflaking skill

### DIFF
--- a/.claude/skills/deflake-test/SKILL.md
+++ b/.claude/skills/deflake-test/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: deflake-test
+description: Reproduce, diagnose, fix, and stress-verify a suspected flaky unit, integration, or Maestro E2E test. Use when asked to repeat one focused test until it fails or establish a consecutive-pass threshold, not for ordinary one-off failures or broad suite validation.
+---
+
+# Deflake a test
+
+Use the iteration count requested by the user. Otherwise default to **20**. When using the bundled runner, override the count with `--iterations`/`-n` or `DEFLAKE_ITERATIONS`.
+
+## Workflow
+
+1. Find the narrowest command that runs exactly the requested test. Read repository instructions and test documentation first. Prepare required devices, apps, services, fixtures, and dependencies without broadening into a repository-wide suite.
+2. Run the test sequentially up to the configured count, stopping at the first genuine test failure. Preserve separate output and debug artifacts for every iteration. Use [`scripts/repeat-until-failure.sh`](scripts/repeat-until-failure.sh) for ordinary commands.
+3. Count only valid executions of the intended test. Parser or runner incompatibilities, missing builds or services, disconnected devices, exhausted emulator storage, stale system overlays, and another process replacing the app are harness failures. Repair or isolate the environment, then restart the initial count. Do not change product code or weaken the test to accommodate a broken harness.
+4. If the first clean run reaches the configured count without failure, stop immediately. Make no code changes and report that the issue could not be reproduced.
+5. When a failure occurs, inspect the most specific evidence available: failed-step timing, screenshots, view hierarchy, application and native logs, process lifecycle, network/backend state, and differences between iterations. Identify the first causal event rather than only the final missing element.
+6. Apply the smallest root-cause fix. Prefer lifecycle or state synchronization and stable readiness conditions over sleeps, retries, or relaxed assertions. A fixed delay is a last resort and must be justified by a bounded external transition.
+7. Run focused unit, compilation, and static checks required by the affected code and repository instructions. Then start a fresh run and require the configured number of consecutive passes. Any genuine failure resets the consecutive-pass count and requires further investigation.
+8. Report the failing iteration, root cause, fix, focused validation, and final consecutive-pass result. Follow the repository's existing commit and pull-request workflow; this skill grants no additional permission to mutate external systems.
+
+## Maestro E2E guidance for this repository
+
+- Build and install the example app first, then run one flow with `maestro test -e APP_ID=com.stripe.react.native <flow>` and an explicit device ID when multiple devices are connected.
+- Confirm the installed Maestro version supports the flow syntax. Treat a parse error as a runner mismatch, not a test reproduction.
+- Before counting Android iterations, verify emulator storage, network access to the configured demo backend, and that the expected APK remains installed. Concurrent worktrees use the same application ID and can replace each other's builds.
+- Give each iteration its own `--debug-output` directory. On failure, inspect its screenshot, hierarchy, Maestro log, device logcat, and application process exit reason.
+- Use platform-conditional flows for platform-specific selectors rather than mutually exclusive optional actions.
+- Wait for a stable screen identity or readiness signal, not content that can vary with saved payment methods, account state, or layout.
+- Do not hide startup crashes with an in-flow relaunch unless evidence shows the launch failure is unrelated infrastructure and existing suite-level retries are insufficient.
+- If a native flow returns control to JavaScript, check whether work that immediately presents UI ran before the React host activity reattached. Waiting for a later assertion cannot recover an alert or event that was already dropped.
+- Keep test hardening separate from product fixes when they address independent failure modes; remove redundant workarounds after the underlying race is fixed.

--- a/.claude/skills/deflake-test/scripts/repeat-until-failure.sh
+++ b/.claude/skills/deflake-test/scripts/repeat-until-failure.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+
+set -uo pipefail
+
+iterations="${DEFLAKE_ITERATIONS:-20}"
+output_dir="${DEFLAKE_OUTPUT_DIR:-/tmp/deflake-test-$(date +%Y%m%d-%H%M%S)}"
+
+usage() {
+  cat <<'USAGE'
+Usage: repeat-until-failure.sh [-n COUNT] [-o OUTPUT_DIR] -- COMMAND [ARG ...]
+
+Runs COMMAND sequentially, stopping at its first non-zero exit. COUNT defaults
+to DEFLAKE_ITERATIONS or 20. Each iteration is logged separately.
+USAGE
+}
+
+while (($#)); do
+  case "$1" in
+    -n | --iterations)
+      [[ $# -ge 2 ]] || { usage >&2; exit 2; }
+      iterations="$2"
+      shift 2
+      ;;
+    -o | --output-dir)
+      [[ $# -ge 2 ]] || { usage >&2; exit 2; }
+      output_dir="$2"
+      shift 2
+      ;;
+    --)
+      shift
+      break
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+[[ "$iterations" =~ ^[1-9][0-9]*$ ]] || {
+  echo "Iteration count must be a positive integer: $iterations" >&2
+  exit 2
+}
+
+(($#)) || {
+  echo "A command is required after --" >&2
+  usage >&2
+  exit 2
+}
+
+mkdir -p "$output_dir"
+echo "OUTPUT_DIR=$output_dir"
+
+for ((iteration = 1; iteration <= iterations; iteration++)); do
+  log_file="$output_dir/iteration-$iteration.log"
+  echo "===== iteration $iteration/$iterations ====="
+  "$@" 2>&1 | tee "$log_file"
+  statuses=("${PIPESTATUS[@]}")
+  command_status="${statuses[0]}"
+  tee_status="${statuses[1]}"
+
+  if ((tee_status != 0)); then
+    echo "Unable to write iteration log: $log_file" >&2
+    exit "$tee_status"
+  fi
+
+  if ((command_status != 0)); then
+    echo "FAILED_ITERATION=$iteration STATUS=$command_status"
+    exit "$command_status"
+  fi
+done
+
+echo "ALL_ITERATIONS_PASSED=$iterations"


### PR DESCRIPTION
## Summary
Add a repository skill for reproducing, diagnosing, fixing, and stress-verifying flaky tests, plus a configurable repeat-until-failure runner.

## Motivation
The PaymentSheet CPM investigation surfaced reusable guidance for separating harness failures from genuine flakes, preserving per-iteration evidence, preferring root-cause synchronization over delays, and requiring a fresh consecutive-pass run after a fix. Keeping this workflow in the repository makes it available to other contributors and agents.

The iteration count defaults to 20 and can be overridden with `--iterations`/`-n` or `DEFLAKE_ITERATIONS`.

## Testing
- [ ] I tested this manually
- [ ] I added automated tests

- Bundled skill validator: `Skill is valid!`
- `bash -n` for the runner
- Verified the default 20-pass path
- Verified `-n` and `DEFLAKE_ITERATIONS` overrides
- Verified stop-on-first-failure and exit-code propagation

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [X] This PR does not result in any developer-facing changes.
