### PR TITLE
Bump stripe-ios to 26.10.0 and stripe-android to 23.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## Unreleased
+**Changes**
+* Updated Stripe iOS SDK from 26.9.0 to 26.10.0.
+* Updated Stripe Android SDK from 23.17.1 to 23.18.0.
+
 ## 0.76.0 - 2026-09-01
 **Features**
 * [Added] Added `deleteWalletAddress` to Crypto Onramp for deleting a registered wallet from the current Link account.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -176,7 +176,7 @@ dependencies {
   implementation "androidx.browser:browser:1.8.0"
 
   // play-services-wallet is already included in stripe-android
-  compileOnly "com.google.android.gms:play-services-wallet:19.3.0"
+  compileOnly "com.google.android.gms:play-services-wallet:20.0.0"
 
   // Users need to declare this dependency on their own, otherwise all methods are a no-op
   compileOnly "com.stripe:stripe-android-issuing-push-provisioning:1.3.0"
@@ -197,4 +197,3 @@ if (lintRulesJar.exists()) {
     lintChecks files(lintRulesJar)
   }
 }
-

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -3,4 +3,4 @@ StripeSdk_compileSdkVersion=36
 StripeSdk_targetSdkVersion=36
 StripeSdk_minSdkVersion=23
 # Keep StripeSdk_stripeVersion in sync with https://github.com/stripe/stripe-identity-react-native/blob/main/android/gradle.properties
-StripeSdk_stripeVersion=23.17.1
+StripeSdk_stripeVersion=23.18.0

--- a/android/src/main/java/com/reactnativestripesdk/GooglePayRequestHelper.kt
+++ b/android/src/main/java/com/reactnativestripesdk/GooglePayRequestHelper.kt
@@ -1,17 +1,18 @@
 package com.reactnativestripesdk
 
-import android.app.Activity
-import android.content.Intent
+import androidx.activity.result.ActivityResultLauncher
 import androidx.fragment.app.FragmentActivity
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReadableMap
+import com.google.android.gms.common.api.CommonStatusCodes
 import com.google.android.gms.tasks.Task
-import com.google.android.gms.wallet.AutoResolveHelper
 import com.google.android.gms.wallet.PaymentData
 import com.google.android.gms.wallet.PaymentDataRequest
 import com.google.android.gms.wallet.Wallet
 import com.google.android.gms.wallet.WalletConstants
+import com.google.android.gms.wallet.contract.ApiTaskResult
+import com.google.android.gms.wallet.contract.TaskResultContracts
 import com.reactnativestripesdk.utils.ErrorType
 import com.reactnativestripesdk.utils.createError
 import com.reactnativestripesdk.utils.getBooleanOr
@@ -27,11 +28,10 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import org.json.JSONObject
 import java.util.Locale
+import java.util.UUID
 
 class GooglePayRequestHelper {
   companion object {
-    internal const val LOAD_PAYMENT_DATA_REQUEST_CODE = 414243
-
     internal fun createPaymentRequest(
       activity: FragmentActivity,
       factory: GooglePayJsonFactory,
@@ -124,39 +124,51 @@ class GooglePayRequestHelper {
     internal fun createPaymentMethod(
       request: Task<PaymentData>,
       activity: FragmentActivity,
-    ) {
-      @Suppress("DEPRECATION")
-      AutoResolveHelper.resolveTask(request, activity, LOAD_PAYMENT_DATA_REQUEST_CODE)
-    }
-
-    internal fun handleGooglePaymentMethodResult(
-      resultCode: Int,
-      data: Intent?,
       stripe: Stripe,
       forToken: Boolean,
       promise: Promise,
     ) {
-      when (resultCode) {
-        Activity.RESULT_OK -> {
-          data?.let { intent ->
-            PaymentData.getFromIntent(intent)?.let {
-              if (forToken) {
-                resolveWithToken(it, promise)
-              } else {
-                resolveWithPaymentMethod(it, stripe, promise)
-              }
-            }
+      activity.runOnUiThread {
+        lateinit var launcher: ActivityResultLauncher<Task<PaymentData>>
+        launcher =
+          activity.activityResultRegistry.register(
+            "stripe-react-native-google-pay-${UUID.randomUUID()}",
+            TaskResultContracts.GetPaymentDataResult(),
+          ) { result ->
+            launcher.unregister()
+            handleGooglePaymentMethodResult(result, stripe, forToken, promise)
           }
+        launcher.launch(request)
+      }
+    }
+
+    private fun handleGooglePaymentMethodResult(
+      result: ApiTaskResult<PaymentData>,
+      stripe: Stripe,
+      forToken: Boolean,
+      promise: Promise,
+    ) {
+      when {
+        result.status.isSuccess -> {
+          result.result?.let {
+            if (forToken) {
+              resolveWithToken(it, promise)
+            } else {
+              resolveWithPaymentMethod(it, stripe, promise)
+            }
+          } ?: promise.resolve(
+            createError(ErrorType.Failed.toString(), "Google Pay did not return payment data"),
+          )
         }
-        Activity.RESULT_CANCELED -> {
+        result.status.statusCode == CommonStatusCodes.CANCELED -> {
           promise.resolve(
             createError(ErrorType.Canceled.toString(), "The payment has been canceled"),
           )
         }
-        AutoResolveHelper.RESULT_ERROR -> {
-          AutoResolveHelper.getStatusFromIntent(data)?.let {
-            promise.resolve(createError(ErrorType.Failed.toString(), it.statusMessage))
-          }
+        else -> {
+          promise.resolve(
+            createError(ErrorType.Failed.toString(), result.status.statusMessage),
+          )
         }
       }
     }

--- a/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
+++ b/android/src/main/java/com/reactnativestripesdk/StripeSdkModule.kt
@@ -13,7 +13,6 @@ import androidx.core.net.toUri
 import androidx.fragment.app.FragmentActivity
 import com.facebook.react.ReactActivity
 import com.facebook.react.bridge.Arguments
-import com.facebook.react.bridge.BaseActivityEventListener
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactMethod
@@ -97,9 +96,6 @@ class StripeSdkModule(
   private var stripeAccountId: String? = null
   private var urlScheme: String? = null
 
-  private var createPlatformPayPaymentMethodPromise: Promise? = null
-  private var platformPayUsesDeprecatedTokenFlow = false
-
   private val stripeUIManagers = mutableListOf<StripeUIManager>()
   private var paymentSheetManager: PaymentSheetManager? = null
   private var paymentLauncherManager: PaymentLauncherManager? = null
@@ -123,37 +119,6 @@ class StripeSdkModule(
   private val pendingUrlsLock = Any()
 
   val eventEmitter: EventEmitterCompat by lazy { EventEmitterCompat(reactApplicationContext) }
-
-  private val mActivityEventListener =
-    object : BaseActivityEventListener() {
-      override fun onActivityResult(
-        activity: Activity,
-        requestCode: Int,
-        resultCode: Int,
-        data: Intent?,
-      ) {
-        if (::stripe.isInitialized) {
-          when (requestCode) {
-            GooglePayRequestHelper.LOAD_PAYMENT_DATA_REQUEST_CODE -> {
-              createPlatformPayPaymentMethodPromise?.let {
-                GooglePayRequestHelper.handleGooglePaymentMethodResult(
-                  resultCode,
-                  data,
-                  stripe,
-                  platformPayUsesDeprecatedTokenFlow,
-                  it,
-                )
-                createPlatformPayPaymentMethodPromise = null
-              }
-            }
-          }
-        }
-      }
-    }
-
-  init {
-    reactContext.addActivityEventListener(mActivityEventListener)
-  }
 
   override fun invalidate() {
     super.invalidate()
@@ -917,8 +882,6 @@ class StripeSdkModule(
         )
         return
       }
-    platformPayUsesDeprecatedTokenFlow = usesDeprecatedTokenFlow
-    createPlatformPayPaymentMethodPromise = promise
     getCurrentActivityOrResolveWithError(promise)?.let {
       val request =
         GooglePayRequestHelper.createPaymentRequest(
@@ -926,7 +889,13 @@ class StripeSdkModule(
           GooglePayJsonFactory(reactApplicationContext),
           googlePayParams,
         )
-      GooglePayRequestHelper.createPaymentMethod(request, it)
+      GooglePayRequestHelper.createPaymentMethod(
+        request,
+        it,
+        stripe,
+        usesDeprecatedTokenFlow,
+        promise,
+      )
     }
   }
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1820,13 +1820,13 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - Stripe (26.9.0):
-    - StripeApplePay (= 26.9.0)
-    - StripeCore (= 26.9.0)
-    - StripeIssuing (= 26.9.0)
-    - StripePayments (= 26.9.0)
-    - StripePaymentsUI (= 26.9.0)
-    - StripeUICore (= 26.9.0)
+  - Stripe (26.10.0):
+    - StripeApplePay (= 26.10.0)
+    - StripeCore (= 26.10.0)
+    - StripeIssuing (= 26.10.0)
+    - StripePayments (= 26.10.0)
+    - StripePaymentsUI (= 26.10.0)
+    - StripeUICore (= 26.10.0)
   - stripe-react-native (0.76.0):
     - hermes-engine
     - RCTRequired
@@ -1872,12 +1872,12 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-    - Stripe (= 26.9.0)
-    - StripeApplePay (= 26.9.0)
-    - StripeFinancialConnections (= 26.9.0)
-    - StripePayments (= 26.9.0)
-    - StripePaymentSheet (= 26.9.0)
-    - StripePaymentsUI (= 26.9.0)
+    - Stripe (= 26.10.0)
+    - StripeApplePay (= 26.10.0)
+    - StripeFinancialConnections (= 26.10.0)
+    - StripePayments (= 26.10.0)
+    - StripePaymentSheet (= 26.10.0)
+    - StripePaymentsUI (= 26.10.0)
     - Yoga
   - stripe-react-native/NewArch (0.76.0):
     - hermes-engine
@@ -1923,7 +1923,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - stripe-react-native/Core
-    - StripeCryptoOnramp (= 26.9.0)
+    - StripeCryptoOnramp (= 26.10.0)
     - Yoga
   - stripe-react-native/Tests (0.76.0):
     - hermes-engine
@@ -1947,49 +1947,49 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - StripeApplePay (26.9.0):
-    - StripeCore (= 26.9.0)
-  - StripeCameraCore (26.9.0):
-    - StripeCore (= 26.9.0)
-  - StripeCore (26.9.0)
-  - StripeCryptoOnramp (26.9.0):
-    - StripeApplePay (= 26.9.0)
-    - StripeCore (= 26.9.0)
-    - StripeIdentity (= 26.9.0)
-    - StripePayments (= 26.9.0)
-    - StripePaymentSheet (= 26.9.0)
-    - StripePaymentsUI (= 26.9.0)
-    - StripeUICore (= 26.9.0)
-  - StripeFinancialConnections (26.9.0):
-    - StripeCore (= 26.9.0)
-    - StripeUICore (= 26.9.0)
-  - StripeFinancialConnectionsLite (26.9.0):
-    - StripeCore (= 26.9.0)
-  - StripeIdentity (26.9.0):
-    - StripeCameraCore (= 26.9.0)
-    - StripeCore (= 26.9.0)
-    - StripeUICore (= 26.9.0)
-  - StripeIssuing (26.9.0):
-    - StripeCore (= 26.9.0)
-    - StripePayments (= 26.9.0)
-    - StripePaymentsUI (= 26.9.0)
-  - StripePayments (26.9.0):
-    - StripeCore (= 26.9.0)
-    - StripePayments/Stripe3DS2 (= 26.9.0)
-  - StripePayments/Stripe3DS2 (26.9.0):
-    - StripeCore (= 26.9.0)
-  - StripePaymentSheet (26.9.0):
-    - StripeApplePay (= 26.9.0)
-    - StripeCore (= 26.9.0)
-    - StripeFinancialConnectionsLite (= 26.9.0)
-    - StripePayments (= 26.9.0)
-    - StripePaymentsUI (= 26.9.0)
-  - StripePaymentsUI (26.9.0):
-    - StripeCore (= 26.9.0)
-    - StripePayments (= 26.9.0)
-    - StripeUICore (= 26.9.0)
-  - StripeUICore (26.9.0):
-    - StripeCore (= 26.9.0)
+  - StripeApplePay (26.10.0):
+    - StripeCore (= 26.10.0)
+  - StripeCameraCore (26.10.0):
+    - StripeCore (= 26.10.0)
+  - StripeCore (26.10.0)
+  - StripeCryptoOnramp (26.10.0):
+    - StripeApplePay (= 26.10.0)
+    - StripeCore (= 26.10.0)
+    - StripeIdentity (= 26.10.0)
+    - StripePayments (= 26.10.0)
+    - StripePaymentSheet (= 26.10.0)
+    - StripePaymentsUI (= 26.10.0)
+    - StripeUICore (= 26.10.0)
+  - StripeFinancialConnections (26.10.0):
+    - StripeCore (= 26.10.0)
+    - StripeUICore (= 26.10.0)
+  - StripeFinancialConnectionsLite (26.10.0):
+    - StripeCore (= 26.10.0)
+  - StripeIdentity (26.10.0):
+    - StripeCameraCore (= 26.10.0)
+    - StripeCore (= 26.10.0)
+    - StripeUICore (= 26.10.0)
+  - StripeIssuing (26.10.0):
+    - StripeCore (= 26.10.0)
+    - StripePayments (= 26.10.0)
+    - StripePaymentsUI (= 26.10.0)
+  - StripePayments (26.10.0):
+    - StripeCore (= 26.10.0)
+    - StripePayments/Stripe3DS2 (= 26.10.0)
+  - StripePayments/Stripe3DS2 (26.10.0):
+    - StripeCore (= 26.10.0)
+  - StripePaymentSheet (26.10.0):
+    - StripeApplePay (= 26.10.0)
+    - StripeCore (= 26.10.0)
+    - StripeFinancialConnectionsLite (= 26.10.0)
+    - StripePayments (= 26.10.0)
+    - StripePaymentsUI (= 26.10.0)
+  - StripePaymentsUI (26.10.0):
+    - StripeCore (= 26.10.0)
+    - StripePayments (= 26.10.0)
+    - StripeUICore (= 26.10.0)
+  - StripeUICore (26.10.0):
+    - StripeCore (= 26.10.0)
   - Yoga (0.0.0)
 
 DEPENDENCIES:
@@ -2249,86 +2249,86 @@ SPEC CHECKSUMS:
   RCTTypeSafety: 16a4144ca3f959583ab019b57d5633df10b5e97c
   React: 914f8695f9bf38e6418228c2ffb70021e559f92f
   React-callinvoker: 1c0808402aee0c6d4a0d8e7220ce6547af9fba71
-  React-Core: 4ae98f9e8135b8ddbd7c98730afb6fdae883db90
+  React-Core: c61410ef0ca6055e204a963992e363227e0fd1c5
   React-Core-prebuilt: 02f0ad625ddd47463c009c2d0c5dd35c0d982599
-  React-CoreModules: e878a90bb19b8f3851818af997dbae3b3b0a27ac
-  React-cxxreact: 28af9844f6dc87be1385ab521fbfb3746f19563c
+  React-CoreModules: 1f6d1744b5f9f2ec684a4bb5ced25370f87e5382
+  React-cxxreact: 3af79478e8187b63ffc22b794cd42d3fc1f1f2da
   React-debug: 6328c2228e268846161f10082e80dc69eac2e90a
-  React-defaultsnativemodule: afc9d809ec75780f39464a6949c07987fbea488c
-  React-domnativemodule: 91a233260411d41f27f67aa1358b7f9f0bfd101d
-  React-Fabric: 21f349b5e93f305a3c38c885902683a9c79cf983
-  React-FabricComponents: 47ac634cc9ecc64b30a9997192f510eebe4177e4
-  React-FabricImage: 21873acd6d4a51a0b97c133141051c7acb11cc86
-  React-featureflags: 653f469f0c3c9dc271d610373e3b6e66a9fd847d
-  React-featureflagsnativemodule: c91a8a3880e0f4838286402241ead47db43aed28
-  React-graphics: b4bdb0f635b8048c652a5d2b73eb8b1ddd950f24
-  React-hermes: fcfad3b917400f49026f3232561e039c9d1c34bf
-  React-idlecallbacksnativemodule: 8cb83207e39f8179ac1d344b6177c6ab3ccebcdc
-  React-ImageManager: 396128004783fc510e629124dce682d38d1088e7
-  React-jserrorhandler: b58b788d788cdbf8bda7db74a88ebfcffc8a0795
-  React-jsi: d2c3f8555175371c02da6dfe7ed1b64b55a9d6c0
-  React-jsiexecutor: ba537434eb45ee018b590ed7d29ee233fddb8669
-  React-jsinspector: f21b6654baf96cb9f71748844a32468a5f73ad51
-  React-jsinspectorcdp: 3f8be4830694c3c1c39442e50f8db877966d43f0
-  React-jsinspectornetwork: 70e41469565712ad60e11d9c8b8f999b9f7f61eb
-  React-jsinspectortracing: eccf9bfa4ec7f130d514f215cfb2222dc3c0e270
-  React-jsitooling: b376a695f5a507627f7934748533b24eed1751ca
-  React-jsitracing: 5c8c3273dda2d95191cc0612fb5e71c4d9018d2a
-  React-logger: c3e2f8a2e284341205f61eef3d4677ab5a309dfd
-  React-Mapbuffer: 603c18db65844bb81dbe62fee8fcc976eaeb7108
-  React-microtasksnativemodule: d77e0c426fce34c23227394c96ca1033b30c813c
-  react-native-safe-area-context: 53f796cb6c814661bbe99fbdfd0585d07b996cdd
-  React-NativeModulesApple: 1664340b8750d64e0ef3907c5e53d9481f74bcbd
+  React-defaultsnativemodule: d635ef36d755321e5d6fc065bd166b2c5a0e9833
+  React-domnativemodule: dd28f6d96cd21236e020be2eff6fe0b7d4ec3b66
+  React-Fabric: 2e32c3fdbb1fbcf5fde54607e3abe453c6652ce2
+  React-FabricComponents: 5ed0cdb81f6b91656cb4d3be432feaa28a58071a
+  React-FabricImage: 2bc714f818cb24e454f5d3961864373271b2faf8
+  React-featureflags: 847642f41fa71ad4eec5e0351badebcad4fe6171
+  React-featureflagsnativemodule: c868a544b2c626fa337bcbd364b1befe749f0d3f
+  React-graphics: 192ec701def5b3f2a07db2814dfba5a44986cff6
+  React-hermes: e875778b496c86d07ab2ccaa36a9505d248a254b
+  React-idlecallbacksnativemodule: 4d57965cdf82c14ee3b337189836cd8491632b76
+  React-ImageManager: bd0b99e370b13de82c9cd15f0f08144ff3de079e
+  React-jserrorhandler: a2fdef4cbcfdcdf3fa9f5d1f7190f7fd4535248d
+  React-jsi: 89d43d1e7d4d0663f8ba67e0b39eb4e4672c27de
+  React-jsiexecutor: abe4874aaab90dfee5dec480680220b2f8af07e3
+  React-jsinspector: a0b3e051aef842b0b2be2353790ae2b2a5a65a8f
+  React-jsinspectorcdp: 6346013b2247c6263fbf5199adf4a8751e53bd89
+  React-jsinspectornetwork: 26281aa50d49fc1ec93abf981d934698fa95714f
+  React-jsinspectortracing: 55eedf6d57540507570259a778663b90060bbd6e
+  React-jsitooling: 0e001113fa56d8498aa8ac28437ac0d36348e51a
+  React-jsitracing: b713793eb8a5bbc4d86a84e9d9e5023c0f58cbaf
+  React-logger: 50fdb9a8236da90c0b1072da5c32ee03aeb5bf28
+  React-Mapbuffer: 9050ee10c19f4f7fca8963d0211b2854d624973e
+  React-microtasksnativemodule: f775db9e991c6f3b8ccbc02bfcde22770f96e23b
+  react-native-safe-area-context: 37e680fc4cace3c0030ee46e8987d24f5d3bdab2
+  React-NativeModulesApple: 8969913947d5b576de4ed371a939455a8daf28aa
   React-oscompat: ce47230ed20185e91de62d8c6d139ae61763d09c
-  React-perflogger: b1af3cfb3f095f819b2814910000392a8e17ba9f
-  React-performancetimeline: f9ec65b77bcadbc7bd8b47a6f4b4b697da7b1490
+  React-perflogger: 02b010e665772c7dcb859d85d44c1bfc5ac7c0e4
+  React-performancetimeline: 130db956b5a83aa4fb41ddf5ae68da89f3fb1526
   React-RCTActionSheet: 0b14875b3963e9124a5a29a45bd1b22df8803916
-  React-RCTAnimation: 60f6eca214a62b9673f64db6df3830cee902b5af
-  React-RCTAppDelegate: 37734b39bac108af30a0fd9d3e1149ec68b82c28
-  React-RCTBlob: 83fbcbd57755caf021787324aac2fe9b028cc264
-  React-RCTFabric: a05cb1df484008db3753c8b4a71e4c6d9f1e43a6
-  React-RCTFBReactNativeSpec: d58d7ae9447020bbbac651e3b0674422aba18266
-  React-RCTImage: 47aba3be7c6c64f956b7918ab933769602406aac
-  React-RCTLinking: 2dbaa4df2e4523f68baa07936bd8efdfa34d5f31
-  React-RCTNetwork: 1fca7455f9dedf7de2b95bec438da06680f3b000
-  React-RCTRuntime: 17819dd1dfc8613efaf4cbb9d8686baae4a83e5b
-  React-RCTSettings: 01bf91c856862354d3d2f642ccb82f3697a4284a
-  React-RCTText: cb576a3797dcb64933613c522296a07eaafc0461
-  React-RCTVibration: 560af8c086741f3525b8456a482cdbe27f9d098e
+  React-RCTAnimation: a7b90fd2af7bb9c084428867445a1481a8cb112e
+  React-RCTAppDelegate: 3262bedd01263f140ec62b7989f4355f57cec016
+  React-RCTBlob: c17531368702f1ebed5d0ada75a7cf5915072a53
+  React-RCTFabric: 6409edd8cfdc3133b6cc75636d3b858fdb1d11ea
+  React-RCTFBReactNativeSpec: c004b27b4fa3bd85878ad2cf53de3bbec85da797
+  React-RCTImage: c68078a120d0123f4f07a5ac77bea3bb10242f32
+  React-RCTLinking: cf8f9391fe7fe471f96da3a5f0435235eca18c5b
+  React-RCTNetwork: ca31f7c879355760c2d9832a06ee35f517938a20
+  React-RCTRuntime: a6cf4a1e42754fc87f493e538f2ac6b820e45418
+  React-RCTSettings: e0e140b2ff4bf86d34e9637f6316848fc00be035
+  React-RCTText: 75915bace6f7877c03a840cc7b6c622fb62bfa6b
+  React-RCTVibration: 25f26b85e5e432bb3c256f8b384f9269e9529f25
   React-rendererconsistency: 2dac03f448ff337235fd5820b10f81633328870d
-  React-renderercss: c5c6b7a15948dd28facca39a18ac269073718490
-  React-rendererdebug: 3c9d5e1634273f5a24d84cc5669f290ce0bdc812
-  React-RuntimeApple: 887637d1e12ea8262df7d32bc100467df2302613
-  React-RuntimeCore: 91f779835dc4f8f84777fe5dd24f1a22f96454e4
-  React-runtimeexecutor: 8bb6b738f37b0ada4a6269e6f8ab1133dea0285c
-  React-RuntimeHermes: 4cb93de9fa8b1cc753d200dbe61a01b9ec5f5562
-  React-runtimescheduler: 83dc28f530bfbd2fce84ed13aa7feebdc24e5af7
-  React-timing: 03c7217455d2bff459b27a3811be25796b600f47
-  React-utils: 6d46795ae0444ec8a5d9a5f201157b286bf5250a
-  ReactAppDependencyProvider: c277c5b231881ad4f00cd59e3aa0671b99d7ebee
-  ReactCodegen: 4c44b74b77fc41ae25b9e2c7e9bd6e2bc772c23f
-  ReactCommon: e6e232202a447d353e5531f2be82f50f47cbaa9a
+  React-renderercss: 477da167bb96b5ac86d30c5d295412fb853f5453
+  React-rendererdebug: 2a1798c6f3ef5f22d466df24c33653edbabb5b89
+  React-RuntimeApple: 28cf4d8eb18432f6a21abbed7d801ab7f6b6f0b4
+  React-RuntimeCore: 41bf0fd56a00de5660f222415af49879fa49c4f0
+  React-runtimeexecutor: 1afb774dde3011348e8334be69d2f57a359ea43e
+  React-RuntimeHermes: f3b158ea40e8212b1a723a68b4315e7a495c5fc6
+  React-runtimescheduler: 3e1e2bec7300bae512533107d8e54c6e5c63fe0f
+  React-timing: 6fa9883de2e41791e5dc4ec404e5e37f3f50e801
+  React-utils: 6e2035b53d087927768649a11a26c4e092448e34
+  ReactAppDependencyProvider: 1bcd3527ac0390a1c898c114f81ff954be35ed79
+  ReactCodegen: 7d4593f7591f002d137fe40cef3f6c11f13c88cc
+  ReactCommon: 08810150b1206cc44aecf5f6ae19af32f29151a8
   ReactNativeDependencies: 71ce9c28beb282aa720ea7b46980fff9669f428a
-  ReactNativeHost: 321d403ccbfc19067e6ac1a43d7ffcd8e1b24b53
-  ReactTestApp-DevSupport: 467513802464ac48223177b7aa5e0b1b58d3ac20
+  ReactNativeHost: 3c46b8bdf9111ae806d950fa2bd7ba6a5432a5b6
+  ReactTestApp-DevSupport: 963986104f003af978562535682fec417b4aadfa
   ReactTestApp-Resources: 49fb7249af8203b9c74fd85de8c6f5bbb77a41df
-  RNCAsyncStorage: e85a99325df9eb0191a6ee2b2a842644c7eb29f4
-  RNCPicker: e0149590451d5eae242cf686014a6f6d808f93c7
-  RNScreens: 448161bce0b7d670222bf4ac967b0c3449cdcefa
-  Stripe: a232266e1c9709b56cfdeffaa731370407b0e3e2
-  stripe-react-native: e20afdf0ad65bb66aaece5cb4e696ea1947c0b8d
-  StripeApplePay: 83587609b80bc165a941fbe7c6ba7db8822bcc36
-  StripeCameraCore: 644b64d3c9daa836de18e6a5f2e1dcc16a403580
-  StripeCore: 0d4533f5ca61b8abd60004464e0125ee98df91b7
-  StripeCryptoOnramp: cb70f1bd7b64c85ffa99e7595bf99f418d93559c
-  StripeFinancialConnections: e61972f157473f6bdced8d25075ddfad48d36ca9
-  StripeFinancialConnectionsLite: 0b51780316bb63a94fd5ef11a4480fb9a0951661
-  StripeIdentity: d83c7916194a42d47df577153ab2d383a793702e
-  StripeIssuing: 4a0c35bebc94b586c4c3b73fe432280330f75739
-  StripePayments: 57614a765aa5dce6d5e5c4d669afda2b80c64e5e
-  StripePaymentSheet: 6ecef03b5032a1acff02a47e0bbfc17fb730bb3d
-  StripePaymentsUI: bcb256b2cb9cb0926842ca92cd19e9705c3339f8
-  StripeUICore: cd7242a0449cea4e4b38b61d11584dfabb8e28ce
+  RNCAsyncStorage: 3a4f5e2777dae1688b781a487923a08569e27fe4
+  RNCPicker: c8a3584b74133464ee926224463fcc54dfdaebca
+  RNScreens: 61c18865ab074f4d995ac8d7cf5060522a649d05
+  Stripe: 6bfba727bd2ae9faf6b88abe20ab626a9e0ae39f
+  stripe-react-native: 3b98e3c284f6a2140ebefafec5b8af3d1b1ca204
+  StripeApplePay: 62ef5ff84e32c513568df284ff52cc47532e0ad6
+  StripeCameraCore: 9e3670df26334473f21cf199ed8ce5c2f677388d
+  StripeCore: 5dd8ed3eb8e96c4092f90ea5c4c8028aa4432954
+  StripeCryptoOnramp: 738ef64373c582e39ad81b66f4741bf3a82e649f
+  StripeFinancialConnections: e19ea00b157e2fa290371d8702ebd93e3c4f4c93
+  StripeFinancialConnectionsLite: a83ef9e75cbe69ff0bb9d51fd74739ac80a005be
+  StripeIdentity: 9cd0c6a150bc4f640317948551ab0bf72f045eb5
+  StripeIssuing: 5d33345f07123f435298f69fb2802b106f226aec
+  StripePayments: 7e3e5d5a193526545a527a4fee82606da0b4b717
+  StripePaymentSheet: 492a322e29348de075f52ce04ce75e495b9a3d56
+  StripePaymentsUI: f33ca975e23485ae1e1fa80ea8ea3133723b959e
+  StripeUICore: 02b100aade8f774afe409bcefa7456764be9344b
   Yoga: 5934998fbeaef7845dbf698f698518695ab4cd1a
 
 PODFILE CHECKSUM: 605f3cad878b7c0eee93ebb4a78a8141d34cd328

--- a/stripe-react-native.podspec
+++ b/stripe-react-native.podspec
@@ -2,7 +2,7 @@ require 'json'
 
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 # Keep stripe_version in sync with https://github.com/stripe/stripe-identity-react-native/blob/main/stripe-identity-react-native.podspec
-stripe_version = '26.9.0'
+stripe_version = '26.10.0'
 
 fabric_enabled = ENV['RCT_NEW_ARCH_ENABLED'] == '1'
 


### PR DESCRIPTION
## Summary

Updates stripe-ios to 26.10.0 and stripe-android to 23.18.0 for the latest payment method support. Google Wallet 20.0 removed `AutoResolveHelper`, so Android Google Pay payment method creation now uses `TaskResultContracts` while keeping the existing success, cancellation, and error handling.

## Motivation

Native SDK updates

## Testing

- Android release builds with old and new React Native architectures; Android native unit tests
- iOS example app build; iOS native unit tests (295 tests)

## Documentation

- [x] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
