### PR TITLE
Add internal auth challenge props to the AccountOnboarding EC

### DIFF
--- a/etc/stripe-react-native.api.md
+++ b/etc/stripe-react-native.api.md
@@ -4687,9 +4687,9 @@ interface WeChatPayParams_2 {
 // Warnings were encountered during analysis:
 //
 // src/components/CustomerSheet.tsx:374:27 - (ae-forgotten-export) The symbol "Component" needs to be exported by the entry point index.d.ts
-// src/connect/Components.tsx:75:3 - (ae-forgotten-export) The symbol "StepChange" needs to be exported by the entry point index.d.ts
-// src/connect/Components.tsx:79:3 - (ae-forgotten-export) The symbol "CollectionOptions" needs to be exported by the entry point index.d.ts
-// src/connect/Components.tsx:253:3 - (ae-forgotten-export) The symbol "PaymentsListDefaultFilters" needs to be exported by the entry point index.d.ts
+// src/connect/Components.tsx:88:3 - (ae-forgotten-export) The symbol "StepChange" needs to be exported by the entry point index.d.ts
+// src/connect/Components.tsx:92:3 - (ae-forgotten-export) The symbol "CollectionOptions" needs to be exported by the entry point index.d.ts
+// src/connect/Components.tsx:273:3 - (ae-forgotten-export) The symbol "PaymentsListDefaultFilters" needs to be exported by the entry point index.d.ts
 // src/connect/connectTypes.ts:208:3 - (ae-forgotten-export) The symbol "AppearanceOptions" needs to be exported by the entry point index.d.ts
 // src/connect/connectTypes.ts:218:3 - (ae-forgotten-export) The symbol "CssFontSource" needs to be exported by the entry point index.d.ts
 // src/connect/connectTypes.ts:218:3 - (ae-forgotten-export) The symbol "CustomFontSource" needs to be exported by the entry point index.d.ts

--- a/src/connect/Components.tsx
+++ b/src/connect/Components.tsx
@@ -24,6 +24,19 @@ import { useConnectComponents } from './ConnectComponentsProvider';
 export { NavigationBar } from './NavigationBar';
 export type { NavigationBarProps } from './NavigationBar';
 
+type AuthChallengeRequiredEvent = {
+  action: string;
+  requestId: number;
+};
+
+type AuthChallengeResponse = {
+  requestId: number | null;
+  completion: {
+    secret: string;
+    metadata?: Record<string, string>;
+  } | null;
+};
+
 /**
  * A full-screen modal component for Connect account onboarding.
  * Guides connected accounts through the process of providing required information.
@@ -78,13 +91,17 @@ export function ConnectAccountOnboarding({
   privacyPolicyUrl?: string;
   collectionOptions?: CollectionOptions;
 } & Omit<CommonComponentProps, 'style'>) {
-  // kycRecipientAccountId is intentionally omitted from the public prop types to
+  // The following props are intentionally omitted from the public prop types to
   // discourage use by external integrators. This is API hygiene only — it is not
   // a security boundary. Real authorization is enforced server-side.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const kycRecipientAccountId = (rest as any).kycRecipientAccountId as
-    | string
-    | undefined;
+  const { kycRecipientAccountId, authChallenge, onAuthChallengeRequired } =
+    rest as {
+      kycRecipientAccountId?: string;
+      authChallenge?: AuthChallengeResponse;
+      onAuthChallengeRequired?: (event: AuthChallengeRequiredEvent) => void;
+    };
+
   const [visible, setVisible] = useState(true);
   const [loading, setLoading] = useState(true);
   const { appearance } = useConnectComponents();
@@ -105,6 +122,7 @@ export function ConnectAccountOnboarding({
       setPrivacyPolicyUrl: privacyPolicyUrl,
       setCollectionOptions: collectionOptions,
       setKycRecipientAccountId: kycRecipientAccountId,
+      setAuthChallenge: authChallenge,
     };
   }, [
     fullTermsOfServiceUrl,
@@ -112,6 +130,7 @@ export function ConnectAccountOnboarding({
     privacyPolicyUrl,
     collectionOptions,
     kycRecipientAccountId,
+    authChallenge,
   ]);
 
   const onExitCallback = useCallback(() => {
@@ -127,8 +146,9 @@ export function ConnectAccountOnboarding({
       onExit: onExitCallback,
       onStepChange,
       onCloseWebView: onExitCallback,
+      onAuthChallengeRequired,
     };
-  }, [onExitCallback, onStepChange]);
+  }, [onExitCallback, onStepChange, onAuthChallengeRequired]);
 
   const onLoaderStartCallback = useCallback(
     (event: LoaderStart) => {

--- a/src/connect/__tests__/Components.test.tsx
+++ b/src/connect/__tests__/Components.test.tsx
@@ -33,6 +33,18 @@ jest.mock('../../specs/NativeConnectAccountOnboardingView', () => {
   };
 });
 
+// Lets us inspect exactly what componentProps/callbacks ConnectAccountOnboarding
+// forwards down, including the internal-only props (kycRecipientAccountId,
+// authChallenge, onAuthChallengeRequired) that aren't in its public prop types.
+jest.mock('../EmbeddedComponent', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return {
+    EmbeddedComponent: (props: any) =>
+      React.createElement(View, { testID: 'embedded-component', ...props }),
+  };
+});
+
 import React from 'react';
 import { render, waitFor } from '@testing-library/react-native';
 import { Platform } from 'react-native';
@@ -219,6 +231,32 @@ describe('ConnectAccountOnboarding', () => {
       await waitFor(() => {
         expect(onExit).toHaveBeenCalled();
       });
+    });
+
+    it('forwards internal-only props (kycRecipientAccountId, authChallenge, onAuthChallengeRequired) to EmbeddedComponent', () => {
+      const onAuthChallengeRequired = jest.fn();
+      const authChallenge = {
+        requestId: 42,
+        completion: { secret: 'as_secret_123' },
+      };
+
+      const { getByTestId } = renderComponent({
+        kycRecipientAccountId: 'acct_123',
+        authChallenge,
+        onAuthChallengeRequired,
+      });
+
+      const embedded = getByTestId('embedded-component');
+      expect(embedded.props.componentProps.setKycRecipientAccountId).toBe(
+        'acct_123'
+      );
+      expect(embedded.props.componentProps.setAuthChallenge).toBe(
+        authChallenge
+      );
+
+      const event = { action: 'verify_identity', requestId: 42 };
+      embedded.props.callbacks.onAuthChallengeRequired(event);
+      expect(onAuthChallengeRequired).toHaveBeenCalledWith(event);
     });
 
     it('renders with default appearance when not specified', () => {


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

The [AccountOnboarding](https://docs.stripe.com/connect/supported-embedded-components/account-onboarding?platform=react-native) component when used internally to onboard recipients sometimes asks for an auth challenge. This PR adds the internal-only props pass-through to the embedded-component to be able to perform the handoff to the mobile app to perform the 2FA and pass back the new challenge.

Onboarding recipients is a Stripe-only feature, these props are intentionally not exposed on the public interface of the component.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a link to the relevant issue, a code snippet, or an example project that demonstrates the bug. -->

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [ ] I tested this manually
- [ ] I added automated tests
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
