### PR TITLE
StripeCryptoOnramp: OnrampPresenter Activity Recreation Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## Unreleased
+
+**Fixes**
+
+* [Fixed] Android: Fixed Crypto Onramp presentation failures after Activity recreation by recreating the presenter for the current Activity.
+
 ## 0.76.0 - 2026-09-01
 **Features**
 * [Added] Added `deleteWalletAddress` to Crypto Onramp for deleting a registered wallet from the current Link account.

--- a/android/src/onramp/java/com/reactnativestripesdk/OnrampSdkModule.kt
+++ b/android/src/onramp/java/com/reactnativestripesdk/OnrampSdkModule.kt
@@ -85,6 +85,7 @@ class OnrampSdkModule(
   private var stripeAccountId: String? = null
 
   private var onrampCoordinator: OnrampCoordinator? = null
+  private var onrampCallbacks: OnrampCallbacks? = null
   private var onrampPresenter: OnrampCoordinator.Presenter? = null
 
   private var presenterActivity: ComponentActivity? = null
@@ -213,6 +214,8 @@ class OnrampSdkModule(
           checkoutClientSecretDeferred!!.await()
         }
 
+    this.onrampCallbacks = onrampCallbacks
+
     val coordinator =
       onrampCoordinator ?: OnrampCoordinator
         .Builder()
@@ -271,6 +274,12 @@ class OnrampSdkModule(
 
     clearOnrampPresenter()
     return try {
+      // Finishing the previous host removes the SDK callback registration. Building
+      // again restores it while retaining the SDK's existing coordinator and session.
+      // This is a temporary fix until the native SDK handles this better.
+      onrampCallbacks?.let { callbacks ->
+        OnrampCoordinator.Builder().build(activity.application, SavedStateHandle(), callbacks)
+      }
       coordinator.createPresenter(activity).also {
         onrampPresenter = it
         presenterActivity = activity

--- a/android/src/onramp/java/com/reactnativestripesdk/OnrampSdkModule.kt
+++ b/android/src/onramp/java/com/reactnativestripesdk/OnrampSdkModule.kt
@@ -6,14 +6,19 @@ import android.annotation.SuppressLint
 import android.app.Application
 import androidx.activity.ComponentActivity
 import androidx.fragment.app.FragmentActivity
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.SavedStateHandle
 import com.stripe.android.core.model.CountryCode
 import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.LifecycleEventListener
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactMethod
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.bridge.UiThreadUtil
 import com.facebook.react.bridge.WritableNativeMap
 import com.facebook.react.module.annotations.ReactModule
 import com.reactnativestripesdk.utils.ErrorType
@@ -73,7 +78,7 @@ import kotlinx.coroutines.withTimeoutOrNull
 @ReactModule(name = NativeOnrampSdkModuleSpec.NAME)
 class OnrampSdkModule(
   reactContext: ReactApplicationContext,
-) : NativeOnrampSdkModuleSpec(reactContext) {
+) : NativeOnrampSdkModuleSpec(reactContext), LifecycleEventListener {
   private val eventEmitterCompat = EventEmitterCompat(reactContext)
   private var reactNativeSdkVersion: String? = null
   private lateinit var publishableKey: String
@@ -81,6 +86,17 @@ class OnrampSdkModule(
 
   private var onrampCoordinator: OnrampCoordinator? = null
   private var onrampPresenter: OnrampCoordinator.Presenter? = null
+
+  private var presenterActivity: ComponentActivity? = null
+  private var isOnrampConfigured = false
+  private val presenterLifecycleObserver =
+    object : DefaultLifecycleObserver {
+      override fun onDestroy(owner: LifecycleOwner) {
+        if (presenterActivity === owner) {
+          clearOnrampPresenter()
+        }
+      }
+    }
 
   private var authenticateUserPromise: Promise? = null
   private var identityVerificationPromise: Promise? = null
@@ -111,21 +127,37 @@ class OnrampSdkModule(
     promise.resolve(null)
   }
 
-  override fun invalidate() {
-    super.invalidate()
-    rnScope.cancel()
+  init {
+    reactContext.addLifecycleEventListener(this)
   }
 
-  /**
-   * Safely get and cast the current activity as an AppCompatActivity. If that fails, the promise
-   * provided will be resolved with an error message instructing the user to retry the method.
-   */
-  private fun getCurrentActivityOrResolveWithError(promise: Promise?): FragmentActivity? {
-    (reactApplicationContext.currentActivity as? FragmentActivity)?.let {
-      return it
+  override fun invalidate() {
+    super.invalidate()
+    reactApplicationContext.removeLifecycleEventListener(this)
+    rnScope.cancel()
+    UiThreadUtil.runOnUiThread {
+      clearOnrampPresenter()
+      isOnrampConfigured = false
     }
-    promise?.resolve(createMissingActivityError())
-    return null
+  }
+
+  override fun onHostResume() {
+    rnScope.launch {
+      // Re-register result handlers even if JS does not make another presentation call.
+      if (isOnrampConfigured) getOnrampPresenter(null)
+    }
+  }
+
+  override fun onHostPause() = Unit
+
+  // The presenter's actual Activity owns cleanup. RN host callbacks may refer to a
+  // different Activity, and pausing the host is normal while Link is on screen.
+  override fun onHostDestroy() = Unit
+
+  private fun clearOnrampPresenter() {
+    presenterActivity?.lifecycle?.removeObserver(presenterLifecycleObserver)
+    presenterActivity = null
+    onrampPresenter = null
   }
 
   @ReactMethod
@@ -191,7 +223,7 @@ class OnrampSdkModule(
       val configuration = mapConfig(config, publishableKey, onrampAdditionalSdkVersions())
       val configureResult = coordinator.configure(configuration)
 
-      CoroutineScope(Dispatchers.Main).launch {
+      rnScope.launch {
         when (configureResult) {
           is OnrampConfigurationResult.Completed -> {
             createOnrampPresenter(promise)
@@ -215,27 +247,52 @@ class OnrampSdkModule(
     }
   }
 
-  @ReactMethod
   private fun createOnrampPresenter(promise: Promise) {
-    val activity = getCurrentActivityOrResolveWithError(promise) as? ComponentActivity
-    if (activity == null) {
-      promise.resolve(createMissingActivityError())
-      return
-    }
-    if (onrampCoordinator == null) {
-      promise.resolve(createMissingInitError())
-      return
-    }
-    if (onrampPresenter != null) {
-      promise.resolveVoid()
-      return
-    }
+    isOnrampConfigured = true
+    if (getOnrampPresenter(promise) != null) promise.resolveVoid()
+  }
 
-    try {
-      onrampPresenter = onrampCoordinator!!.createPresenter(activity)
-      promise.resolveVoid()
-    } catch (e: Exception) {
-      promise.resolve(createOnrampFailedError(e))
+  // Called only on Main, so the host cannot be destroyed between validation and launch.
+  @Suppress("TooGenericExceptionCaught") // Convert SDK construction failures to bridge errors.
+  private fun getOnrampPresenter(promise: Promise?): OnrampCoordinator.Presenter? {
+    val coordinator = onrampCoordinator
+    if (!isOnrampConfigured || coordinator == null) {
+      promise?.resolve(createOnrampNotConfiguredError())
+      return null
+    }
+    val activity = reactApplicationContext.currentActivity as? FragmentActivity
+    if (activity == null || activity.isFinishing || activity.isDestroyed ||
+      !activity.lifecycle.currentState.isAtLeast(Lifecycle.State.CREATED)
+    ) {
+      promise?.resolve(createMissingActivityError())
+      return null
+    }
+    if (presenterActivity === activity) return onrampPresenter
+
+    clearOnrampPresenter()
+    return try {
+      coordinator.createPresenter(activity).also {
+        onrampPresenter = it
+        presenterActivity = activity
+        activity.lifecycle.addObserver(presenterLifecycleObserver)
+      }
+    } catch (error: Exception) {
+      promise?.resolve(createOnrampFailedError(error))
+      null
+    }
+  }
+
+  private fun withOnrampPresenter(
+    promise: Promise,
+    present: (OnrampCoordinator.Presenter) -> Unit,
+  ) {
+    rnScope.launch {
+      val presenter = getOnrampPresenter(promise) ?: return@launch
+      if (presenterActivity?.lifecycle?.currentState?.isAtLeast(Lifecycle.State.RESUMED) != true) {
+        promise.resolve(createMissingActivityError())
+        return@launch
+      }
+      present(presenter)
     }
   }
 
@@ -526,14 +583,10 @@ class OnrampSdkModule(
 
   @ReactMethod
   override fun presentUserAttestation(promise: Promise) {
-    val presenter =
-      onrampPresenter ?: run {
-        promise.resolve(createOnrampNotConfiguredError())
-        return
-      }
-
-    userAttestationPromise = promise
-    presenter.presentUserAttestation()
+    withOnrampPresenter(promise) { presenter ->
+      userAttestationPromise = promise
+      presenter.presentUserAttestation()
+    }
   }
 
   @ReactMethod
@@ -560,15 +613,11 @@ class OnrampSdkModule(
 
   @ReactMethod
   override fun verifyIdentity(promise: Promise) {
-    val presenter =
-      onrampPresenter ?: run {
-        promise.resolve(createOnrampNotConfiguredError())
-        return
-      }
+    withOnrampPresenter(promise) { presenter ->
+      identityVerificationPromise = promise
 
-    identityVerificationPromise = promise
-
-    presenter.verifyIdentity()
+      presenter.verifyIdentity()
+    }
   }
 
   @ReactMethod
@@ -576,16 +625,12 @@ class OnrampSdkModule(
     updatedAddress: ReadableMap?,
     promise: Promise,
   ) {
-    val presenter =
-      onrampPresenter ?: run {
-        promise.resolve(createOnrampNotConfiguredError())
-        return
-      }
+    withOnrampPresenter(promise) { presenter ->
+      val address = mapToPaymentSheetAddress(updatedAddress)
 
-    val address = mapToPaymentSheetAddress(updatedAddress)
-
-    verifyKycPromise = promise
-    presenter.verifyKycInfo(address)
+      verifyKycPromise = promise
+      presenter.verifyKycInfo(address)
+    }
   }
 
   @ReactMethod
@@ -594,23 +639,19 @@ class OnrampSdkModule(
     platformPayParams: ReadableMap,
     promise: Promise,
   ) {
-    val presenter =
-      onrampPresenter ?: run {
-        promise.resolve(createOnrampNotConfiguredError())
-        return
-      }
+    withOnrampPresenter(promise) { presenter ->
+      val method =
+        try {
+          mapOnrampPaymentMethodSelection(paymentMethod, platformPayParams)
+        } catch (error: IllegalArgumentException) {
+          promise.resolve(createOnrampFailedError(error))
+          return@withOnrampPresenter
+        }
 
-    val method =
-      try {
-        mapOnrampPaymentMethodSelection(paymentMethod, platformPayParams)
-      } catch (error: IllegalArgumentException) {
-        promise.resolve(createOnrampFailedError(error))
-        return
-      }
+      collectPaymentPromise = promise
 
-    collectPaymentPromise = promise
-
-    presenter.collectPaymentMethod(method)
+      presenter.collectPaymentMethod(method)
+    }
   }
 
   @ReactMethod
@@ -634,15 +675,11 @@ class OnrampSdkModule(
     onrampSessionId: String,
     promise: Promise,
   ) {
-    val presenter =
-      onrampPresenter ?: run {
-        promise.resolve(createOnrampNotConfiguredError())
-        return
-      }
+    withOnrampPresenter(promise) { presenter ->
+      checkoutPromise = promise
 
-    checkoutPromise = promise
-
-    presenter.performCheckout(onrampSessionId)
+      presenter.performCheckout(onrampSessionId)
+    }
   }
 
   @ReactMethod
@@ -662,15 +699,11 @@ class OnrampSdkModule(
     linkAuthIntentId: String,
     promise: Promise,
   ) {
-    val presenter =
-      onrampPresenter ?: run {
-        promise.resolve(createOnrampNotConfiguredError())
-        return
-      }
+    withOnrampPresenter(promise) { presenter ->
+      authorizePromise = promise
 
-    authorizePromise = promise
-
-    presenter.authorize(linkAuthIntentId)
+      presenter.authorize(linkAuthIntentId)
+    }
   }
 
   @ReactMethod


### PR DESCRIPTION
## Summary

Recreates the Onramp presenter when its host Activity changes and runs presentation calls on the main thread.
While this was focused on fixing this for Authentication (where the bug was reported), it could theoretically affect anywhere the presenter was being used.

## Motivation

The RN module can survive Activity recreation while retaining a presenter tied to the destroyed Activity. Calling authorize then attempts to use its unregistered NativeLinkActivityContract launcher.

Tracks the presenter's owning Activity, clears it on destruction, and recreates it for the current host while preserving the existing coordinator.

## Testing

- [x] I tested this manually
- [ ] I added automated tests

Tested on a Pixel 7a by recreating the Activity after configuring Onramp, then calling authorize. Confirmed the module survived while the Activity changed. Reproduced the unregistered-launcher exception on master and verified authorization works with this fix.

## Documentation

- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.