### PR TITLE
Enforce token-returning Financial Connections API in Connect bridge

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,9 +1,6 @@
 module.exports = {
   presets: ['module:@react-native/babel-preset'],
   plugins: [
-    ...(process.env.NODE_ENV === 'test'
-      ? ['@babel/plugin-transform-dynamic-import']
-      : []),
     function ModifyPackageJsonImportForTranspilation() {
       return {
         visitor: {

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,6 +1,9 @@
 module.exports = {
   presets: ['module:@react-native/babel-preset'],
   plugins: [
+    ...(process.env.NODE_ENV === 'test'
+      ? ['@babel/plugin-transform-dynamic-import']
+      : []),
     function ModifyPackageJsonImportForTranspilation() {
       return {
         visitor: {

--- a/src/connect/EmbeddedComponent.tsx
+++ b/src/connect/EmbeddedComponent.tsx
@@ -156,9 +156,19 @@ type EmbeddedFinancialConnectionsError = {
   type?: string;
 };
 
+type FinancialConnectionsTokenSuccess = Extract<
+  FinancialConnections.TokenResult,
+  { session: FinancialConnections.Session }
+>;
+
+type ValidFinancialConnectionsTokenSuccess =
+  FinancialConnectionsTokenSuccess & {
+    token: FinancialConnections.BankAccountToken & { id: string };
+  };
+
 type EmbeddedFinancialConnectionsResult =
   | {
-      session: FinancialConnections.Session;
+      session: FinancialConnectionsTokenSuccess['session'];
       token: ReturnType<typeof toStripeJsBankAccountToken>;
       error?: undefined;
     }
@@ -180,6 +190,18 @@ function collectBankAccountTokenForEmbeddedComponent(
   return NativeStripeSdk.collectBankAccountToken(clientSecret, {
     connectedAccountId,
   });
+}
+
+function isValidFinancialConnectionsTokenSuccess(
+  result: FinancialConnections.TokenResult
+): result is ValidFinancialConnectionsTokenSuccess {
+  return (
+    !result.error &&
+    result.session != null &&
+    result.token != null &&
+    typeof result.token.id === 'string' &&
+    result.token.id.length > 0
+  );
 }
 
 export function EmbeddedComponent(props: EmbeddedComponentProps) {
@@ -219,12 +241,7 @@ export function EmbeddedComponent(props: EmbeddedComponentProps) {
       const mod = await import('react-native-webview');
       setDynamicWebview({ WebView: mod.WebView });
     } catch (err) {
-      try {
-        const mod = require('react-native-webview');
-        setDynamicWebview({ WebView: mod.WebView });
-      } catch {
-        console.error('Failed to import react-native-webview:', err);
-      }
+      console.error('Failed to import react-native-webview:', err);
     }
   }, [dynamicWebview]);
 
@@ -657,6 +674,17 @@ export function EmbeddedComponent(props: EmbeddedComponentProps) {
                   message: result.error.message,
                   localizedMessage: result.error.localizedMessage,
                   type: result.error.type,
+                },
+              });
+              return;
+            }
+
+            if (!isValidFinancialConnectionsTokenSuccess(result)) {
+              handleFinancialConnectionsResult(id, {
+                error: {
+                  code: 'UnexpectedError',
+                  message:
+                    'Financial Connections completed without a session and bank-account token',
                 },
               });
               return;

--- a/src/connect/EmbeddedComponent.tsx
+++ b/src/connect/EmbeddedComponent.tsx
@@ -28,7 +28,7 @@ import type {
   LoaderStart,
   StripeConnectInitParams,
 } from './connectTypes';
-import type { FinancialConnections } from '../types';
+import type { FinancialConnections, StripeError } from '../types';
 import { FinancialConnectionsSheetError } from '../types/FinancialConnections';
 import { ComponentAnalyticsClient } from './analytics/ComponentAnalyticsClient';
 
@@ -149,60 +149,19 @@ type StripeConnectInitParamsInternal = StripeConnectInitParams & {
   overrides?: Record<string, string>;
 };
 
-type EmbeddedFinancialConnectionsError = {
-  code: string;
-  message: string;
-  localizedMessage?: string;
-  type?: string;
-};
-
-type FinancialConnectionsTokenSuccess = Extract<
-  FinancialConnections.TokenResult,
-  { session: FinancialConnections.Session }
->;
-
-type ValidFinancialConnectionsTokenSuccess =
-  FinancialConnectionsTokenSuccess & {
-    token: FinancialConnections.BankAccountToken & { id: string };
-  };
-
 type EmbeddedFinancialConnectionsResult =
   | {
-      session: FinancialConnectionsTokenSuccess['session'];
+      status: 'success';
+      session: FinancialConnections.Session;
       token: ReturnType<typeof toStripeJsBankAccountToken>;
-      error?: undefined;
     }
   | {
-      session?: undefined;
-      token?: undefined;
-      error: EmbeddedFinancialConnectionsError;
+      status: 'error';
+      error: StripeError<string>;
     }
   | {
-      session?: undefined;
-      token?: undefined;
-      error?: undefined;
+      status: 'canceled';
     };
-
-function collectBankAccountTokenForEmbeddedComponent(
-  clientSecret: string,
-  connectedAccountId: string
-): Promise<FinancialConnections.TokenResult> {
-  return NativeStripeSdk.collectBankAccountToken(clientSecret, {
-    connectedAccountId,
-  });
-}
-
-function isValidFinancialConnectionsTokenSuccess(
-  result: FinancialConnections.TokenResult
-): result is ValidFinancialConnectionsTokenSuccess {
-  return (
-    !result.error &&
-    result.session != null &&
-    result.token != null &&
-    typeof result.token.id === 'string' &&
-    result.token.id.length > 0
-  );
-}
 
 export function EmbeddedComponent(props: EmbeddedComponentProps) {
   const [dynamicWebview, setDynamicWebview] = useState<{
@@ -524,20 +483,41 @@ export function EmbeddedComponent(props: EmbeddedComponentProps) {
     id: string,
     result: EmbeddedFinancialConnectionsResult
   ) => {
+    let value;
+    switch (result.status) {
+      case 'success':
+        value = {
+          id,
+          financialConnectionsSession: {
+            accounts: result.session.accounts,
+          },
+          token: result.token,
+          error: null,
+        };
+        break;
+      case 'error':
+        value = {
+          id,
+          financialConnectionsSession: null,
+          token: null,
+          error: result.error,
+        };
+        break;
+      case 'canceled':
+        value = {
+          id,
+          financialConnectionsSession: null,
+          token: null,
+          error: null,
+        };
+        break;
+    }
+
     ref.current?.injectJavaScript(`
       (function() {
         window.callSetterWithSerializableValue(${JSON.stringify({
           setter: 'setCollectMobileFinancialConnectionsResult',
-          value: {
-            id: id,
-            financialConnectionsSession: result.session
-              ? {
-                  accounts: result.session.accounts,
-                }
-              : null,
-            token: result.token ?? null,
-            error: result.error ?? null,
-          },
+          value,
         })});
         true;
       })();
@@ -609,6 +589,7 @@ export function EmbeddedComponent(props: EmbeddedComponentProps) {
         // Validate client secret
         if (!clientSecret || typeof clientSecret !== 'string') {
           handleFinancialConnectionsResult(id, {
+            status: 'error',
             error: {
               code: 'InvalidClientSecret',
               message: 'Invalid or missing clientSecret parameter',
@@ -620,6 +601,7 @@ export function EmbeddedComponent(props: EmbeddedComponentProps) {
         // Prevent multiple simultaneous flows
         if (pendingFinancialConnectionsPromise.current) {
           handleFinancialConnectionsResult(id, {
+            status: 'error',
             error: {
               code: 'AlreadyInProgress',
               message: 'Financial Connections flow already in progress',
@@ -643,7 +625,10 @@ export function EmbeddedComponent(props: EmbeddedComponentProps) {
         }
 
         // Store cleanup function
+        let hasCleanedUp = false;
         const cleanup = () => {
+          if (hasCleanedUp) return;
+          hasCleanedUp = true;
           eventListener?.remove();
           pendingFinancialConnectionsPromise.current = null;
         };
@@ -653,34 +638,36 @@ export function EmbeddedComponent(props: EmbeddedComponentProps) {
           cleanup,
         };
 
-        collectBankAccountTokenForEmbeddedComponent(
-          clientSecret,
-          connectedAccountId
-        )
-          .then((result) => {
-            cleanup();
+        const resultPromise: Promise<FinancialConnections.TokenResult> =
+          NativeStripeSdk.collectBankAccountToken(clientSecret, {
+            connectedAccountId,
+          });
 
+        resultPromise
+          .then((result) => {
             if (result.error) {
               if (
                 result.error.code === FinancialConnectionsSheetError.Canceled
               ) {
-                handleFinancialConnectionsResult(id, {});
+                handleFinancialConnectionsResult(id, { status: 'canceled' });
                 return;
               }
 
               handleFinancialConnectionsResult(id, {
-                error: {
-                  code: result.error.code,
-                  message: result.error.message,
-                  localizedMessage: result.error.localizedMessage,
-                  type: result.error.type,
-                },
+                status: 'error',
+                error: result.error,
               });
               return;
             }
 
-            if (!isValidFinancialConnectionsTokenSuccess(result)) {
+            if (
+              !result.session ||
+              !result.token ||
+              typeof result.token.id !== 'string' ||
+              result.token.id.length === 0
+            ) {
               handleFinancialConnectionsResult(id, {
+                status: 'error',
                 error: {
                   code: 'UnexpectedError',
                   message:
@@ -691,14 +678,15 @@ export function EmbeddedComponent(props: EmbeddedComponentProps) {
             }
 
             handleFinancialConnectionsResult(id, {
+              status: 'success',
               session: result.session,
               token: toStripeJsBankAccountToken(result.token),
             });
           })
           .catch((unexpectedError) => {
-            cleanup();
             handleUnexpectedError(unexpectedError);
             handleFinancialConnectionsResult(id, {
+              status: 'error',
               error: {
                 code: 'UnexpectedError',
                 message:
@@ -707,7 +695,8 @@ export function EmbeddedComponent(props: EmbeddedComponentProps) {
                     : 'An unexpected error occurred during Financial Connections',
               },
             });
-          });
+          })
+          .finally(cleanup);
       } else if (message.type === 'closeWebView') {
         // message.data is empty
         callbacks?.onCloseWebView?.({});

--- a/src/connect/EmbeddedComponent.tsx
+++ b/src/connect/EmbeddedComponent.tsx
@@ -149,6 +149,39 @@ type StripeConnectInitParamsInternal = StripeConnectInitParams & {
   overrides?: Record<string, string>;
 };
 
+type EmbeddedFinancialConnectionsError = {
+  code: string;
+  message: string;
+  localizedMessage?: string;
+  type?: string;
+};
+
+type EmbeddedFinancialConnectionsResult =
+  | {
+      session: FinancialConnections.Session;
+      token: ReturnType<typeof toStripeJsBankAccountToken>;
+      error?: undefined;
+    }
+  | {
+      session?: undefined;
+      token?: undefined;
+      error: EmbeddedFinancialConnectionsError;
+    }
+  | {
+      session?: undefined;
+      token?: undefined;
+      error?: undefined;
+    };
+
+function collectBankAccountTokenForEmbeddedComponent(
+  clientSecret: string,
+  connectedAccountId: string
+): Promise<FinancialConnections.TokenResult> {
+  return NativeStripeSdk.collectBankAccountToken(clientSecret, {
+    connectedAccountId,
+  });
+}
+
 export function EmbeddedComponent(props: EmbeddedComponentProps) {
   const [dynamicWebview, setDynamicWebview] = useState<{
     WebView: typeof WebView | null;
@@ -186,7 +219,12 @@ export function EmbeddedComponent(props: EmbeddedComponentProps) {
       const mod = await import('react-native-webview');
       setDynamicWebview({ WebView: mod.WebView });
     } catch (err) {
-      console.error('Failed to import react-native-webview:', err);
+      try {
+        const mod = require('react-native-webview');
+        setDynamicWebview({ WebView: mod.WebView });
+      } catch {
+        console.error('Failed to import react-native-webview:', err);
+      }
     }
   }, [dynamicWebview]);
 
@@ -467,16 +505,7 @@ export function EmbeddedComponent(props: EmbeddedComponentProps) {
 
   const handleFinancialConnectionsResult = (
     id: string,
-    result: {
-      session?: FinancialConnections.Session;
-      token?: ReturnType<typeof toStripeJsBankAccountToken> | null;
-      error?: {
-        code: string;
-        message: string;
-        localizedMessage?: string;
-        type?: string;
-      };
-    }
+    result: EmbeddedFinancialConnectionsResult
   ) => {
     ref.current?.injectJavaScript(`
       (function() {
@@ -607,46 +636,36 @@ export function EmbeddedComponent(props: EmbeddedComponentProps) {
           cleanup,
         };
 
-        NativeStripeSdk.collectBankAccountToken(clientSecret, {
-          connectedAccountId,
-        })
-          .then(({ session, token, error }) => {
+        collectBankAccountTokenForEmbeddedComponent(
+          clientSecret,
+          connectedAccountId
+        )
+          .then((result) => {
             cleanup();
 
-            if (error) {
-              if (error.code === FinancialConnectionsSheetError.Canceled) {
-                handleFinancialConnectionsResult(id, {
-                  session: undefined,
-                  token: undefined,
-                  error: undefined,
-                });
+            if (result.error) {
+              if (
+                result.error.code === FinancialConnectionsSheetError.Canceled
+              ) {
+                handleFinancialConnectionsResult(id, {});
                 return;
               }
-              handleFinancialConnectionsResult(id, {
-                session: undefined,
-                token: undefined,
-                error: {
-                  code: error.code,
-                  message: error.message,
-                  localizedMessage: error.localizedMessage,
-                  type: error.type,
-                },
-              });
-            } else if (token || session) {
-              handleFinancialConnectionsResult(id, {
-                session,
-                token: token ? toStripeJsBankAccountToken(token) : null,
-                error: undefined,
-              });
-            } else {
+
               handleFinancialConnectionsResult(id, {
                 error: {
-                  code: 'UnexpectedError',
-                  message:
-                    'No session, token, or error returned from Financial Connections',
+                  code: result.error.code,
+                  message: result.error.message,
+                  localizedMessage: result.error.localizedMessage,
+                  type: result.error.type,
                 },
               });
+              return;
             }
+
+            handleFinancialConnectionsResult(id, {
+              session: result.session,
+              token: toStripeJsBankAccountToken(result.token),
+            });
           })
           .catch((unexpectedError) => {
             cleanup();

--- a/src/connect/EmbeddedComponent.tsx
+++ b/src/connect/EmbeddedComponent.tsx
@@ -151,16 +151,19 @@ type StripeConnectInitParamsInternal = StripeConnectInitParams & {
 
 type EmbeddedFinancialConnectionsResult =
   | {
-      status: 'success';
       session: FinancialConnections.Session;
-      token: ReturnType<typeof toStripeJsBankAccountToken>;
+      token: ReturnType<typeof toStripeJsBankAccountToken> | null;
+      error?: undefined;
     }
   | {
-      status: 'error';
+      session?: undefined;
+      token?: undefined;
       error: StripeError<string>;
     }
   | {
-      status: 'canceled';
+      session?: undefined;
+      token?: undefined;
+      error?: undefined;
     };
 
 export function EmbeddedComponent(props: EmbeddedComponentProps) {
@@ -484,33 +487,29 @@ export function EmbeddedComponent(props: EmbeddedComponentProps) {
     result: EmbeddedFinancialConnectionsResult
   ) => {
     let value;
-    switch (result.status) {
-      case 'success':
-        value = {
-          id,
-          financialConnectionsSession: {
-            accounts: result.session.accounts,
-          },
-          token: result.token,
-          error: null,
-        };
-        break;
-      case 'error':
-        value = {
-          id,
-          financialConnectionsSession: null,
-          token: null,
-          error: result.error,
-        };
-        break;
-      case 'canceled':
-        value = {
-          id,
-          financialConnectionsSession: null,
-          token: null,
-          error: null,
-        };
-        break;
+    if (result.error) {
+      value = {
+        id,
+        financialConnectionsSession: null,
+        token: null,
+        error: result.error,
+      };
+    } else if (result.session) {
+      value = {
+        id,
+        financialConnectionsSession: {
+          accounts: result.session.accounts,
+        },
+        token: result.token,
+        error: null,
+      };
+    } else {
+      value = {
+        id,
+        financialConnectionsSession: null,
+        token: null,
+        error: null,
+      };
     }
 
     ref.current?.injectJavaScript(`
@@ -589,7 +588,6 @@ export function EmbeddedComponent(props: EmbeddedComponentProps) {
         // Validate client secret
         if (!clientSecret || typeof clientSecret !== 'string') {
           handleFinancialConnectionsResult(id, {
-            status: 'error',
             error: {
               code: 'InvalidClientSecret',
               message: 'Invalid or missing clientSecret parameter',
@@ -601,7 +599,6 @@ export function EmbeddedComponent(props: EmbeddedComponentProps) {
         // Prevent multiple simultaneous flows
         if (pendingFinancialConnectionsPromise.current) {
           handleFinancialConnectionsResult(id, {
-            status: 'error',
             error: {
               code: 'AlreadyInProgress',
               message: 'Financial Connections flow already in progress',
@@ -649,44 +646,36 @@ export function EmbeddedComponent(props: EmbeddedComponentProps) {
               if (
                 result.error.code === FinancialConnectionsSheetError.Canceled
               ) {
-                handleFinancialConnectionsResult(id, { status: 'canceled' });
+                handleFinancialConnectionsResult(id, {});
                 return;
               }
 
               handleFinancialConnectionsResult(id, {
-                status: 'error',
                 error: result.error,
               });
               return;
             }
 
-            if (
-              !result.session ||
-              !result.token ||
-              typeof result.token.id !== 'string' ||
-              result.token.id.length === 0
-            ) {
+            if (!result.session) {
               handleFinancialConnectionsResult(id, {
-                status: 'error',
                 error: {
                   code: 'UnexpectedError',
-                  message:
-                    'Financial Connections completed without a session and bank-account token',
+                  message: 'Financial Connections completed without a session',
                 },
               });
               return;
             }
 
             handleFinancialConnectionsResult(id, {
-              status: 'success',
               session: result.session,
-              token: toStripeJsBankAccountToken(result.token),
+              token: result.token
+                ? toStripeJsBankAccountToken(result.token)
+                : null,
             });
           })
           .catch((unexpectedError) => {
             handleUnexpectedError(unexpectedError);
             handleFinancialConnectionsResult(id, {
-              status: 'error',
               error: {
                 code: 'UnexpectedError',
                 message:

--- a/src/connect/__tests__/EmbeddedComponent.test.tsx
+++ b/src/connect/__tests__/EmbeddedComponent.test.tsx
@@ -7,6 +7,7 @@ let webViewOnMessage: ((event: any) => void) | undefined;
 jest.mock('react-native-webview', () => {
   const React = require('react');
   return {
+    __esModule: true,
     WebView: React.forwardRef((props: any, ref: any) => {
       webViewOnMessage = props.onMessage;
       React.useImperativeHandle(ref, () => ({
@@ -58,6 +59,7 @@ describe('EmbeddedComponent', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    webViewOnMessage = undefined;
     connectInstance = loadConnectAndInitialize(mockInitParams);
   });
 
@@ -350,46 +352,35 @@ describe('EmbeddedComponent', () => {
   });
 
   describe('Financial Connections bridge', () => {
-    it('collects and forwards a bank-account token', async () => {
-      const mockCollectBankAccountToken =
-        NativeStripeSdk.collectBankAccountToken as jest.Mock;
-      const mockCollectFinancialConnectionsAccounts =
-        NativeStripeSdk.collectFinancialConnectionsAccounts as jest.Mock;
+    const mockSession = {
+      id: 'session',
+      clientSecret: 'client_secret',
+      livemode: false,
+      accounts: [],
+    };
+    const mockToken = {
+      id: 'btok_token',
+      livemode: false,
+      used: false,
+      type: 'BankAccount' as const,
+      created: 1000000,
+      bankAccount: {
+        id: 'bank_account',
+        bankName: 'Test Bank',
+        accountHolderName: null,
+        accountHolderType: null,
+        currency: 'usd',
+        country: 'US',
+        routingNumber: '110000000',
+        status: null,
+        fingerprint: null,
+        last4: '6789',
+      },
+    };
 
-      mockCollectBankAccountToken.mockResolvedValue({
-        session: {
-          id: 'session',
-          clientSecret: 'client_secret',
-          livemode: false,
-          accounts: [],
-        },
-        token: {
-          id: 'token',
-          livemode: false,
-          used: false,
-          type: 'BankAccount',
-          created: 1000000,
-          bankAccount: {
-            id: 'bank_account',
-            bankName: 'Test Bank',
-            accountHolderName: null,
-            accountHolderType: null,
-            currency: 'usd',
-            country: 'US',
-            routingNumber: '110000000',
-            status: null,
-            fingerprint: null,
-            last4: '6789',
-          },
-        },
-        error: undefined,
-      });
-
+    const openFinancialConnections = async () => {
       renderComponent({ component: 'account-onboarding' });
-
-      await waitFor(() => {
-        expect(webViewOnMessage).toBeDefined();
-      });
+      await waitFor(() => expect(webViewOnMessage).toBeDefined());
 
       await act(async () => {
         webViewOnMessage?.({
@@ -405,6 +396,36 @@ describe('EmbeddedComponent', () => {
           },
         });
       });
+    };
+
+    const getLastInjectedJavaScript = () =>
+      mockInjectJavaScript.mock.calls[
+        mockInjectJavaScript.mock.calls.length - 1
+      ]?.[0];
+
+    const expectUnexpectedError = () => {
+      const injectedJavaScript = getLastInjectedJavaScript();
+      expect(injectedJavaScript).toContain('UnexpectedError');
+      expect(injectedJavaScript).toContain(
+        '"financialConnectionsSession":null'
+      );
+      expect(injectedJavaScript).toContain('"token":null');
+      expect(injectedJavaScript).not.toContain('"id":"session"');
+      expect(injectedJavaScript).not.toContain('"id":"btok_token"');
+    };
+
+    it('collects and forwards a bank-account token', async () => {
+      const mockCollectBankAccountToken =
+        NativeStripeSdk.collectBankAccountToken as jest.Mock;
+      const mockCollectFinancialConnectionsAccounts =
+        NativeStripeSdk.collectFinancialConnectionsAccounts as jest.Mock;
+      mockCollectBankAccountToken.mockResolvedValue({
+        session: mockSession,
+        token: mockToken,
+        error: undefined,
+      });
+
+      await openFinancialConnections();
 
       expect(mockCollectBankAccountToken).toHaveBeenCalledWith(
         'client_secret',
@@ -412,11 +433,68 @@ describe('EmbeddedComponent', () => {
       );
       expect(mockCollectFinancialConnectionsAccounts).not.toHaveBeenCalled();
       expect(mockInjectJavaScript).toHaveBeenCalledWith(
-        expect.stringContaining('"id":"token"')
+        expect.stringContaining('"id":"btok_token"')
       );
       expect(mockInjectJavaScript).toHaveBeenCalledWith(
         expect.stringContaining('"bank_account"')
       );
+    });
+
+    it.each([
+      ['a session-only result', { session: mockSession, error: undefined }],
+      ['a result without a session', { token: mockToken, error: undefined }],
+      [
+        'a result without a token',
+        { session: mockSession, token: undefined, error: undefined },
+      ],
+      [
+        'a token with a null ID',
+        {
+          session: mockSession,
+          token: { ...mockToken, id: null },
+          error: undefined,
+        },
+      ],
+    ])('reports an unexpected error for %s', async (_description, result) => {
+      (NativeStripeSdk.collectBankAccountToken as jest.Mock).mockResolvedValue(
+        result
+      );
+
+      await openFinancialConnections();
+
+      expectUnexpectedError();
+    });
+
+    it('reports cancellation without an error', async () => {
+      (NativeStripeSdk.collectBankAccountToken as jest.Mock).mockResolvedValue({
+        error: { code: 'Canceled', message: 'Canceled' },
+      });
+
+      await openFinancialConnections();
+
+      const injectedJavaScript = getLastInjectedJavaScript();
+      expect(injectedJavaScript).toContain('"error":null');
+      expect(injectedJavaScript).not.toContain('UnexpectedError');
+    });
+
+    it('forwards native errors', async () => {
+      (NativeStripeSdk.collectBankAccountToken as jest.Mock).mockResolvedValue({
+        error: { code: 'Failed', message: 'Native error' },
+      });
+
+      await openFinancialConnections();
+
+      expect(getLastInjectedJavaScript()).toContain('"code":"Failed"');
+    });
+
+    it('reports rejected promises as unexpected errors', async () => {
+      (NativeStripeSdk.collectBankAccountToken as jest.Mock).mockRejectedValue(
+        new Error('Rejected')
+      );
+
+      await openFinancialConnections();
+
+      expectUnexpectedError();
     });
   });
 

--- a/src/connect/__tests__/EmbeddedComponent.test.tsx
+++ b/src/connect/__tests__/EmbeddedComponent.test.tsx
@@ -1,13 +1,16 @@
 // Mock dependencies BEFORE imports
 import { mockCreateNativeStripeSdkMock } from '../testUtils';
 
+const mockInjectJavaScript = jest.fn();
+let webViewOnMessage: ((event: any) => void) | undefined;
+
 jest.mock('react-native-webview', () => {
   const React = require('react');
   return {
-    WebView: React.forwardRef((_props: any, ref: any) => {
-      // Expose ref methods for testing
+    WebView: React.forwardRef((props: any, ref: any) => {
+      webViewOnMessage = props.onMessage;
       React.useImperativeHandle(ref, () => ({
-        injectJavaScript: jest.fn(),
+        injectJavaScript: mockInjectJavaScript,
       }));
       return null;
     }),
@@ -16,6 +19,8 @@ jest.mock('react-native-webview', () => {
 
 jest.mock('../../specs/NativeStripeSdkModule', () =>
   mockCreateNativeStripeSdkMock({
+    collectBankAccountToken: jest.fn(),
+    collectFinancialConnectionsAccounts: jest.fn(),
     openAuthenticatedWebView: jest.fn(),
   })
 );
@@ -23,6 +28,7 @@ jest.mock('../../specs/NativeStripeSdkModule', () =>
 import React from 'react';
 import { render, waitFor, act } from '@testing-library/react-native';
 import { Platform, AppState } from 'react-native';
+import NativeStripeSdk from '../../specs/NativeStripeSdkModule';
 import {
   EmbeddedComponent,
   isAllowedStripeHost,
@@ -340,6 +346,77 @@ describe('EmbeddedComponent', () => {
 
       // Custom font should be in context
       expect(contextValue.appearance.variables.fontFamily).toBe('CustomFont');
+    });
+  });
+
+  describe('Financial Connections bridge', () => {
+    it('collects and forwards a bank-account token', async () => {
+      const mockCollectBankAccountToken =
+        NativeStripeSdk.collectBankAccountToken as jest.Mock;
+      const mockCollectFinancialConnectionsAccounts =
+        NativeStripeSdk.collectFinancialConnectionsAccounts as jest.Mock;
+
+      mockCollectBankAccountToken.mockResolvedValue({
+        session: {
+          id: 'session',
+          clientSecret: 'client_secret',
+          livemode: false,
+          accounts: [],
+        },
+        token: {
+          id: 'token',
+          livemode: false,
+          used: false,
+          type: 'BankAccount',
+          created: 1000000,
+          bankAccount: {
+            id: 'bank_account',
+            bankName: 'Test Bank',
+            accountHolderName: null,
+            accountHolderType: null,
+            currency: 'usd',
+            country: 'US',
+            routingNumber: '110000000',
+            status: null,
+            fingerprint: null,
+            last4: '6789',
+          },
+        },
+        error: undefined,
+      });
+
+      renderComponent({ component: 'account-onboarding' });
+
+      await waitFor(() => {
+        expect(webViewOnMessage).toBeDefined();
+      });
+
+      await act(async () => {
+        webViewOnMessage?.({
+          nativeEvent: {
+            data: JSON.stringify({
+              type: 'openFinancialConnections',
+              data: {
+                id: 'request',
+                clientSecret: 'client_secret',
+                connectedAccountId: 'connected_account',
+              },
+            }),
+          },
+        });
+      });
+
+      expect(mockCollectBankAccountToken).toHaveBeenCalledWith(
+        'client_secret',
+        { connectedAccountId: 'connected_account' }
+      );
+      expect(mockCollectFinancialConnectionsAccounts).not.toHaveBeenCalled();
+      expect(mockInjectJavaScript).toHaveBeenCalledWith(
+        expect.stringContaining('"id":"token"')
+      );
+      expect(mockInjectJavaScript).toHaveBeenCalledWith(
+        expect.stringContaining('"bank_account"')
+      );
     });
   });
 

--- a/src/connect/__tests__/EmbeddedComponent.test.tsx
+++ b/src/connect/__tests__/EmbeddedComponent.test.tsx
@@ -3,18 +3,35 @@ import { mockCreateNativeStripeSdkMock } from '../testUtils';
 
 const mockInjectJavaScript = jest.fn();
 let webViewOnMessage: ((event: any) => void) | undefined;
+let mockLoadWebView = false;
+let mockWebViewComponent: any;
+
+jest.mock('react', () => {
+  const React = jest.requireActual('react');
+  return {
+    ...React,
+    useState: (initialState: any) => {
+      let resolvedInitialState = initialState;
+      if (mockLoadWebView && initialState === null) {
+        mockLoadWebView = false;
+        resolvedInitialState = { WebView: mockWebViewComponent };
+      }
+      return React.useState(resolvedInitialState);
+    },
+  };
+});
 
 jest.mock('react-native-webview', () => {
   const React = require('react');
+  mockWebViewComponent = React.forwardRef((props: any, ref: any) => {
+    webViewOnMessage = props.onMessage;
+    React.useImperativeHandle(ref, () => ({
+      injectJavaScript: mockInjectJavaScript,
+    }));
+    return null;
+  });
   return {
-    __esModule: true,
-    WebView: React.forwardRef((props: any, ref: any) => {
-      webViewOnMessage = props.onMessage;
-      React.useImperativeHandle(ref, () => ({
-        injectJavaScript: mockInjectJavaScript,
-      }));
-      return null;
-    }),
+    WebView: mockWebViewComponent,
   };
 });
 
@@ -29,6 +46,7 @@ jest.mock('../../specs/NativeStripeSdkModule', () =>
 import React from 'react';
 import { render, waitFor, act } from '@testing-library/react-native';
 import { Platform, AppState } from 'react-native';
+import 'react-native-webview';
 import NativeStripeSdk from '../../specs/NativeStripeSdkModule';
 import {
   EmbeddedComponent,
@@ -60,6 +78,7 @@ describe('EmbeddedComponent', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     webViewOnMessage = undefined;
+    mockLoadWebView = false;
     connectInstance = loadConnectAndInitialize(mockInitParams);
   });
 
@@ -379,6 +398,7 @@ describe('EmbeddedComponent', () => {
     };
 
     const openFinancialConnections = async () => {
+      mockLoadWebView = true;
       renderComponent({ component: 'account-onboarding' });
       await waitFor(() => expect(webViewOnMessage).toBeDefined());
 
@@ -403,15 +423,53 @@ describe('EmbeddedComponent', () => {
         mockInjectJavaScript.mock.calls.length - 1
       ]?.[0];
 
-    const expectUnexpectedError = () => {
+    const getLastFinancialConnectionsResult = () => {
       const injectedJavaScript = getLastInjectedJavaScript();
-      expect(injectedJavaScript).toContain('UnexpectedError');
-      expect(injectedJavaScript).toContain(
-        '"financialConnectionsSession":null'
-      );
-      expect(injectedJavaScript).toContain('"token":null');
-      expect(injectedJavaScript).not.toContain('"id":"session"');
-      expect(injectedJavaScript).not.toContain('"id":"btok_token"');
+      const serializedPayload = injectedJavaScript?.match(
+        /window\.callSetterWithSerializableValue\((.*)\);/
+      )?.[1];
+
+      if (!serializedPayload) {
+        throw new Error(
+          'No Financial Connections result found in the injected JavaScript'
+        );
+      }
+
+      return JSON.parse(serializedPayload).value;
+    };
+
+    const expectUnexpectedError = (message: string) => {
+      expect(getLastFinancialConnectionsResult()).toEqual({
+        id: 'request',
+        financialConnectionsSession: null,
+        token: null,
+        error: {
+          code: 'UnexpectedError',
+          message,
+        },
+      });
+    };
+
+    const expectedToken = {
+      id: 'btok_token',
+      object: 'token',
+      type: 'bank_account',
+      used: false,
+      livemode: false,
+      created: 1000000,
+      bank_account: {
+        id: 'bank_account',
+        object: 'bank_account',
+        account_holder_name: null,
+        account_holder_type: null,
+        bank_name: 'Test Bank',
+        country: 'US',
+        currency: 'usd',
+        fingerprint: null,
+        last4: '6789',
+        routing_number: '110000000',
+        status: null,
+      },
     };
 
     it('collects and forwards a bank-account token', async () => {
@@ -422,7 +480,6 @@ describe('EmbeddedComponent', () => {
       mockCollectBankAccountToken.mockResolvedValue({
         session: mockSession,
         token: mockToken,
-        error: undefined,
       });
 
       await openFinancialConnections();
@@ -432,27 +489,34 @@ describe('EmbeddedComponent', () => {
         { connectedAccountId: 'connected_account' }
       );
       expect(mockCollectFinancialConnectionsAccounts).not.toHaveBeenCalled();
-      expect(mockInjectJavaScript).toHaveBeenCalledWith(
-        expect.stringContaining('"id":"btok_token"')
-      );
-      expect(mockInjectJavaScript).toHaveBeenCalledWith(
-        expect.stringContaining('"bank_account"')
+      expect(getLastFinancialConnectionsResult()).toEqual({
+        id: 'request',
+        financialConnectionsSession: { accounts: [] },
+        token: expectedToken,
+        error: null,
+      });
+    });
+
+    it('rejects the incident session-only result', async () => {
+      (NativeStripeSdk.collectBankAccountToken as jest.Mock).mockResolvedValue({
+        session: mockSession,
+      });
+
+      await openFinancialConnections();
+
+      expectUnexpectedError(
+        'Financial Connections completed without a session and bank-account token'
       );
     });
 
     it.each([
-      ['a session-only result', { session: mockSession, error: undefined }],
-      ['a result without a session', { token: mockToken, error: undefined }],
-      [
-        'a result without a token',
-        { session: mockSession, token: undefined, error: undefined },
-      ],
+      ['a result without a session', { token: mockToken }],
+      ['a result without a token', { session: mockSession, token: undefined }],
       [
         'a token with a null ID',
         {
           session: mockSession,
           token: { ...mockToken, id: null },
-          error: undefined,
         },
       ],
     ])('reports an unexpected error for %s', async (_description, result) => {
@@ -462,7 +526,9 @@ describe('EmbeddedComponent', () => {
 
       await openFinancialConnections();
 
-      expectUnexpectedError();
+      expectUnexpectedError(
+        'Financial Connections completed without a session and bank-account token'
+      );
     });
 
     it('reports cancellation without an error', async () => {
@@ -472,9 +538,12 @@ describe('EmbeddedComponent', () => {
 
       await openFinancialConnections();
 
-      const injectedJavaScript = getLastInjectedJavaScript();
-      expect(injectedJavaScript).toContain('"error":null');
-      expect(injectedJavaScript).not.toContain('UnexpectedError');
+      expect(getLastFinancialConnectionsResult()).toEqual({
+        id: 'request',
+        financialConnectionsSession: null,
+        token: null,
+        error: null,
+      });
     });
 
     it('forwards native errors', async () => {
@@ -484,7 +553,12 @@ describe('EmbeddedComponent', () => {
 
       await openFinancialConnections();
 
-      expect(getLastInjectedJavaScript()).toContain('"code":"Failed"');
+      expect(getLastFinancialConnectionsResult()).toEqual({
+        id: 'request',
+        financialConnectionsSession: null,
+        token: null,
+        error: { code: 'Failed', message: 'Native error' },
+      });
     });
 
     it('reports rejected promises as unexpected errors', async () => {
@@ -494,7 +568,7 @@ describe('EmbeddedComponent', () => {
 
       await openFinancialConnections();
 
-      expectUnexpectedError();
+      expectUnexpectedError('Rejected');
     });
   });
 

--- a/src/connect/__tests__/EmbeddedComponent.test.tsx
+++ b/src/connect/__tests__/EmbeddedComponent.test.tsx
@@ -497,28 +497,24 @@ describe('EmbeddedComponent', () => {
       });
     });
 
-    it('rejects the incident session-only result', async () => {
+    it('forwards a session-only result with a null token', async () => {
       (NativeStripeSdk.collectBankAccountToken as jest.Mock).mockResolvedValue({
         session: mockSession,
       });
 
       await openFinancialConnections();
 
-      expectUnexpectedError(
-        'Financial Connections completed without a session and bank-account token'
-      );
+      expect(getLastFinancialConnectionsResult()).toEqual({
+        id: 'request',
+        financialConnectionsSession: { accounts: [] },
+        token: null,
+        error: null,
+      });
     });
 
     it.each([
-      ['a result without a session', { token: mockToken }],
-      ['a result without a token', { session: mockSession, token: undefined }],
-      [
-        'a token with a null ID',
-        {
-          session: mockSession,
-          token: { ...mockToken, id: null },
-        },
-      ],
+      ['a token without a session', { token: mockToken }],
+      ['neither a session, token, nor error', {}],
     ])('reports an unexpected error for %s', async (_description, result) => {
       (NativeStripeSdk.collectBankAccountToken as jest.Mock).mockResolvedValue(
         result
@@ -527,7 +523,7 @@ describe('EmbeddedComponent', () => {
       await openFinancialConnections();
 
       expectUnexpectedError(
-        'Financial Connections completed without a session and bank-account token'
+        'Financial Connections completed without a session'
       );
     });
 


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

- Explicitly require the Connect Financial Connections native call to return `FinancialConnections.TokenResult`.
- Make accidentally substituting the session-only `collectFinancialConnectionsAccounts` API a TypeScript compilation error.
- Preserve support for session-only runtime responses for compatibility with the existing mobile Connect protocol.
- Reject malformed responses that contain a token without a session or contain no result.
- Add bridge tests covering token success, session-only success, cancellation, native errors, and malformed responses.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a link to the relevant issue, a code snippet, or an example project that demonstrates the bug. -->
Connect manual bank-account entry requires the bank-account token returned by `collectBankAccountToken`. Previously, the bridge’s permissive result shape allowed the session-only API to be selected without a TypeScript error.

This change preserves the distinction between `TokenResult` and `SessionResult` at the native call site so the wrong API cannot be substituted without failing type-checking.

## Testing
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
- [x] I tested this manually
- [x] I added automated tests
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

Regression tested this on Android:

https://github.com/user-attachments/assets/1ddce115-d350-4095-b287-6f385cc48940

And iOS (forgot to record the initial flow but this is the edit flow):

https://github.com/user-attachments/assets/7c9be0fe-c47f-4cb0-b522-9d777b148b1f



## Documentation

Select one: 
- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.